### PR TITLE
Configを言語に応じて動的に定義可能にする

### DIFF
--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -48,17 +48,9 @@ class AppConfig
     const LINE_OPEN_URL = 'https://openchat.line.me/jp/cover/';
     const LINE_OPEN_URL_SUFFIX = '?utm_source=line-openchat-seo&utm_medium=category&utm_campaign=default';
 
-    const SITEMAP_DIR = __DIR__ . '/../../public/sitemap.xml';
-
-    const DAILY_CRON_UPDATED_AT_DATE =  __DIR__ . '/../../storage/static_data_top/daily_updated_at.dat';
-    const HOURLY_CRON_UPDATED_AT_DATETIME =     __DIR__ . '/../../storage/static_data_top/hourly_updated_at.dat';
-    const HOURLY_REAL_UPDATED_AT_DATETIME =      __DIR__ . '/../../storage/static_data_top/real_updated_at.dat';
-    const COMMENT_UPDATED_AT_MICROTIME =      __DIR__ . '/../../storage/static_data_top/comment_updated_at.dat';
-    const TAG_UPDATED_AT_DATETIME =      __DIR__ . '/../../storage/static_data_top/tag_updated_at.dat';
-
     const ROOT_PATH = __DIR__ . '/../../';
 
-    const OPEN_CHAT_CATEGORY = [
+    public static $OPEN_CHAT_CATEGORY = [
         'ゲーム' => 17,
         'スポーツ' => 16,
         '芸能人・有名人' => 26,
@@ -104,15 +96,23 @@ class AppConfig
 
     const ADD_OPEN_CHAT_DEFAULT_OPENCHAT_IMG_URL_HASH = '2AtTNcODU67';
 
+    const SITEMAP_DIR = __DIR__ . '/../../public/sitemap.xml';
+
+    public static $DAILY_CRON_UPDATED_AT_DATE =  __DIR__ . '/../../storage/static_data_top/daily_updated_at.dat';
+    public static $HOURLY_CRON_UPDATED_AT_DATETIME = __DIR__ . '/../../storage/static_data_top/hourly_updated_at.dat';
+    public static $HOURLY_REAL_UPDATED_AT_DATETIME =  __DIR__ . '/../../storage/static_data_top/real_updated_at.dat';
+
+    const COMMENT_UPDATED_AT_MICROTIME = __DIR__ . '/../../storage/static_data_top/comment_updated_at.dat';
+    const TAG_UPDATED_AT_DATETIME = __DIR__ . '/../../storage/static_data_top/tag_updated_at.dat';
+
     const OPEN_CHAT_SUB_CATEGORIES_FILE_PATH = __DIR__ . '/../../storage/open_chat_sub_categories/subcategories.json';
     const OPEN_CHAT_SUB_CATEGORIES_TAG_FILE_PATH = __DIR__ . '/../../storage/open_chat_sub_categories/subcategories_tag.json';
 
-    const OPEN_CHAT_RANKING_POSITION_DIR = __DIR__ . '/../../storage/ranking_position/ranking';
-    const OPEN_CHAT_RISING_POSITION_DIR = __DIR__ . '/../../storage/ranking_position/rising';
-    const OPEN_CHAT_HOUR_FILTER_ID_DIR = __DIR__ . '/../../storage/ranking_position/filter.dat';
+    public static $OPEN_CHAT_RANKING_POSITION_DIR = __DIR__ . '/../../storage/ranking_position/ranking';
+    public static $OPEN_CHAT_RISING_POSITION_DIR = __DIR__ . '/../../storage/ranking_position/rising';
+    public static $OPEN_CHAT_HOUR_FILTER_ID_DIR = __DIR__ . '/../../storage/ranking_position/filter.dat';
 
     const OPEN_CHAT_ID_DATA_FILE_PATH = __DIR__ . '/../../storage/OpenChatBackupData';
     const COMMENT_DATA_FILE_PATH = __DIR__ . '/../../storage/CommentBackupData';
-
     const ACCREDITATION_DATA_FILE_PATH = __DIR__ . '/../../storage/AccreditationBackupData';
 }

--- a/app/Config/AppDynamicConfig.php
+++ b/app/Config/AppDynamicConfig.php
@@ -1,0 +1,5 @@
+<?php
+
+use App\Config\AppConfig;
+
+// AppConfig::$DAILY_CRON_UPDATED_AT_DATE = __DIR__ . '/../../storage/static_data_top/daily_updated_at.dat';

--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -39,7 +39,7 @@ Route::middlewareGroup(RedirectLineWebBrowser::class)
     ->matchNum('category', min: 1)
     ->match(function (int $category) {
         handleRequestWithETagAndCache("ranking/{$category}");
-        return isset(array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category]);
+        return isset(array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category]);
     })
 
     ->path('ranking', [ReactRankingPageController::class, 'ranking'])
@@ -52,7 +52,7 @@ Route::middlewareGroup(RedirectLineWebBrowser::class)
     ->matchNum('category', min: 1)
     ->match(function (int $category) {
         handleRequestWithETagAndCache("official-ranking/{$category}");
-        return isset(array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category]);
+        return isset(array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category]);
     })
 
     ->path('official-ranking', [ReactRankingPageController::class, 'ranking'])

--- a/app/Controllers/Api/MyListApiController.php
+++ b/app/Controllers/Api/MyListApiController.php
@@ -35,7 +35,7 @@ class MyListApiController
                 $myListIdArray
             );
 
-        $hourlyUpdatedAt = new \DateTime(file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME));
+        $hourlyUpdatedAt = new \DateTime(file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME));
 
         return view('components/myList', compact('myList', 'hourlyUpdatedAt'));
     }

--- a/app/Controllers/Api/OpenChatRankingPageApiController.php
+++ b/app/Controllers/Api/OpenChatRankingPageApiController.php
@@ -28,7 +28,7 @@ class OpenChatRankingPageApiController
 
         $this->args->page = Valid::num(Recp::input('page', 0), min: 0, e: $error);
         $this->args->limit = Valid::num(Recp::input('limit'), min: 1, e: $error);
-        $this->args->category = (int)Valid::str(Recp::input('category', '0'), regex: AppConfig::OPEN_CHAT_CATEGORY, e: $error);
+        $this->args->category = (int)Valid::str(Recp::input('category', '0'), regex: AppConfig::$OPEN_CHAT_CATEGORY, e: $error);
 
         $this->args->list = Valid::str(Recp::input('list', 'daily'), regex: ['hourly', 'daily', 'weekly', 'all', 'ranking', 'rising'], e: $error);
         $this->args->order = Valid::str(Recp::input('order', 'asc'), regex: ['asc', 'desc'], e: $error);

--- a/app/Controllers/Api/RankingPositionApiController.php
+++ b/app/Controllers/Api/RankingPositionApiController.php
@@ -26,7 +26,7 @@ class RankingPositionApiController
         string $start_date,
         string $end_date
     ) {
-        if (strtotime($start_date) > strtotime(file_get_contents(AppConfig::DAILY_CRON_UPDATED_AT_DATE))) {
+        if (strtotime($start_date) > strtotime(file_get_contents(AppConfig::$DAILY_CRON_UPDATED_AT_DATE))) {
             return response(new RankingPositionChartDto);
         }
 

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -107,7 +107,7 @@ class OpenChatPageController
             return $this->deletedResponse($recommendGenarator, $open_chat_id, $topPageDto);
 
         $tag = $oc['tag1'];
-        $categoryValue = $oc['category'] ? array_search($oc['category'], AppConfig::OPEN_CHAT_CATEGORY) : null;
+        $categoryValue = $oc['category'] ? array_search($oc['category'], AppConfig::$OPEN_CHAT_CATEGORY) : null;
         $category = $categoryValue ?? 'その他';
         $recommend = $recommendGenarator->getRecommend($tag, $oc['tag2'], $oc['tag3'], $oc['category']);
 

--- a/app/Controllers/Pages/RankingBanLabsPageController.php
+++ b/app/Controllers/Pages/RankingBanLabsPageController.php
@@ -36,8 +36,8 @@ class RankingBanLabsPageController
 
         $_css = ['room_list', 'site_header', 'site_footer'];
 
-        $_updatedAt = new \DateTime(file_get_contents(AppConfig::HOURLY_REAL_UPDATED_AT_DATETIME));
-        $_now = file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME);
+        $_updatedAt = new \DateTime(file_get_contents(AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME));
+        $_now = file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME);
 
         $limit = 50;
 

--- a/app/Controllers/Pages/ReactRankingPageController.php
+++ b/app/Controllers/Pages/ReactRankingPageController.php
@@ -29,7 +29,7 @@ class ReactRankingPageController
         $title1 = '';
         switch (!!$category) {
             case true:
-                $title1 = array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category] . '｜';
+                $title1 = array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category] . '｜';
                 break;
             default:
                 $title1 = $title0 ? '' : '【最新】';
@@ -92,7 +92,7 @@ class ReactRankingPageController
         $_breadcrumbsShema = $breadcrumbsShema->generateSchema(
             'ランキング',
             'ranking',
-            $category ? array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category] : '',
+            $category ? array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category] : '',
             $category ? (string)$category : ''
         );
 

--- a/app/Controllers/Pages/TagLabsPageController.php
+++ b/app/Controllers/Pages/TagLabsPageController.php
@@ -35,8 +35,8 @@ class TagLabsPageController
             }, $tagsGroup);
         })($staticDataGeneration->getTagList());
 
-        $categories = array_flip(AppConfig::OPEN_CHAT_CATEGORY);
-        $_updatedAt = new \DateTime(file_get_contents(AppConfig::HOURLY_REAL_UPDATED_AT_DATETIME));
+        $categories = array_flip(AppConfig::$OPEN_CHAT_CATEGORY);
+        $_updatedAt = new \DateTime(file_get_contents(AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME));
 
         if (isset($isAdminPage) && adminMode()) {
             /** @var AdsRepository $adsRepo */

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -166,7 +166,7 @@ function handleRequestWithETagAndCache(string $content, int $maxAge = 0, int $sM
 {
     // ETagを生成（ここではコンテンツのMD5ハッシュを使用）
     if ($hourly) {
-        $etag = '"' . md5($content . filemtime(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME)) . '"';
+        $etag = '"' . md5($content . filemtime(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME)) . '"';
     } else {
         $etag = '"' . md5($content) . '"';
     }
@@ -238,12 +238,12 @@ function purgeCacheCloudFlare(
 
 function getHouryUpdateTime()
 {
-    return file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME);
+    return file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME);
 }
 
 function getDailyUpdateTime()
 {
-    return file_get_contents(AppConfig::DAILY_CRON_UPDATED_AT_DATE);
+    return file_get_contents(AppConfig::$DAILY_CRON_UPDATED_AT_DATE);
 }
 
 /* function imgUrl(int $id, string $img_url): string
@@ -305,7 +305,7 @@ function filePathNumById(int $id): string
 
 function getCategoryName(int $category): string
 {
-    return array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category] ?? '';
+    return array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category] ?? '';
 }
 
 function addCronLog(string|array $log)

--- a/app/Services/Cron/ParallelDownloadOpenChat.php
+++ b/app/Services/Cron/ParallelDownloadOpenChat.php
@@ -41,7 +41,7 @@ class ParallelDownloadOpenChat
 
     private function download(RankingType $type, int $category)
     {
-        $categoryStr = array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category];
+        $categoryStr = array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category];
         $typeStr = $type->value;
 
         addCronLog("download start: {$typeStr} {$categoryStr}");
@@ -56,7 +56,7 @@ class ParallelDownloadOpenChat
     {
         foreach ($args as $api) {
             $type = $api['type'];
-            $category = array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$api['category']] ?? 'UNDIFINED';
+            $category = array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$api['category']] ?? 'UNDIFINED';
             addCronLog("ParallelDownloadOpenChat {$type} {$category}: " . $e->getMessage());
         }
     }
@@ -66,7 +66,7 @@ class ParallelDownloadOpenChat
         // 全てのダウンロードプロセスを強制終了する
         OpenChatApiDbMergerWithParallelDownloader::setKillFlagTrue();
 
-        $categoryStr = $category !== null ? (array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category] ?? $category) : 'null';
+        $categoryStr = $category !== null ? (array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category] ?? $category) : 'null';
         $typeStr = $type ?? 'null';
         $error = "ParallelDownloadOpenChat {$typeStr} {$categoryStr}: " . $e->__toString();
 

--- a/app/Services/OpenChat/Crawler/AbstractOpenChatApiRankingDownloaderProcess.php
+++ b/app/Services/OpenChat/Crawler/AbstractOpenChatApiRankingDownloaderProcess.php
@@ -11,12 +11,12 @@ use Shadow\Kernel\Validator;
 abstract class AbstractOpenChatApiRankingDownloaderProcess
 {
     /**
-     * @var string $callableGenerateUrl `$callableGenerateUrl(string $category, string $ct)`
+     * @var \Closure $callableGenerateUrl `$callableGenerateUrl(string $category, string $ct)`
      */
-    protected string $callableGenerateUrl;
+    protected \Closure $callableGenerateUrl;
 
     function __construct(
-        private CrawlerFactory $crawlerFactory
+        protected CrawlerFactory $crawlerFactory
     ) {
     }
 

--- a/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloader.php
+++ b/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloader.php
@@ -25,7 +25,7 @@ class OpenChatApiRankingDownloader
     function fetchOpenChatApiRankingAll(\Closure $callback, ?\Closure $callbackByCategoryBefore, ?\Closure $callbackByCategoryAfter): array
     {
         $result = [];
-        foreach (AppConfig::OPEN_CHAT_CATEGORY as $key => $category) {
+        foreach (AppConfig::$OPEN_CHAT_CATEGORY as $key => $category) {
             if ($callbackByCategoryBefore && $callbackByCategoryBefore((string)$category)) {
                 continue;
             }

--- a/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloaderProcess.php
+++ b/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloaderProcess.php
@@ -2,9 +2,16 @@
 
 declare(strict_types=1);
 
-namespace App\Services\OpenChat\Crawler;;
+namespace App\Services\OpenChat\Crawler;
+
+use App\Config\OpenChatCrawlerConfig;
+use App\Services\Crawler\CrawlerFactory;;
 
 class OpenChatApiRankingDownloaderProcess extends AbstractOpenChatApiRankingDownloaderProcess
 {
-    protected string $callableGenerateUrl = '\App\Config\OpenChatCrawlerConfig::generateOpenChatApiRankigDataUrl';
+    function __construct(
+        protected CrawlerFactory $crawlerFactory
+    ) {
+        $this->callableGenerateUrl = OpenChatCrawlerConfig::generateOpenChatApiRankigDataUrl(...);
+    }
 }

--- a/app/Services/OpenChat/Crawler/OpenChatApiRisingDownloaderProcess.php
+++ b/app/Services/OpenChat/Crawler/OpenChatApiRisingDownloaderProcess.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace App\Services\OpenChat\Crawler;
 
+use App\Config\OpenChatCrawlerConfig;
+use App\Services\Crawler\CrawlerFactory;
+
 class OpenChatApiRisingDownloaderProcess extends AbstractOpenChatApiRankingDownloaderProcess
 {
-    protected string $callableGenerateUrl = '\App\Config\OpenChatCrawlerConfig::generateOpenChatApiRisingDataUrl';
+    function __construct(
+        protected CrawlerFactory $crawlerFactory
+    ) {
+        $this->callableGenerateUrl = OpenChatCrawlerConfig::generateOpenChatApiRisingDataUrl(...);
+    }
 }

--- a/app/Services/OpenChat/Crawler/OpenChatApiSubCategoryDownloader.php
+++ b/app/Services/OpenChat/Crawler/OpenChatApiSubCategoryDownloader.php
@@ -56,7 +56,7 @@ class OpenChatApiSubCategoryDownloader
     function fetchOpenChatApiSubCategoriesAll(\Closure $callback): array
     {
         $result = [];
-        foreach (AppConfig::OPEN_CHAT_CATEGORY as $name => $category) {
+        foreach (AppConfig::$OPEN_CHAT_CATEGORY as $name => $category) {
             if ($category === 0) {
                 continue;
             }

--- a/app/Services/OpenChat/OpenChatApiDbMergerWithParallelDownloader.php
+++ b/app/Services/OpenChat/OpenChatApiDbMergerWithParallelDownloader.php
@@ -101,7 +101,7 @@ class OpenChatApiDbMergerWithParallelDownloader
             RankingType::Ranking => $this->rankingStore->getStorageData((string)$category)[1],
         };
 
-        $log = $type->value . " " . array_flip(AppConfig::OPEN_CHAT_CATEGORY)[$category];
+        $log = $type->value . " " . array_flip(AppConfig::$OPEN_CHAT_CATEGORY)[$category];
         addCronLog("merge start: {$log}");
 
         foreach ($dtos as $dto)

--- a/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php
+++ b/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php
@@ -43,7 +43,7 @@ class RankingPositionHourPersistence
         $this->openChatDataWithCache->cacheOpenChatData(true);
 
         $fileTime = '';
-        foreach (AppConfig::OPEN_CHAT_CATEGORY as $key => $category) {
+        foreach (AppConfig::$OPEN_CHAT_CATEGORY as $key => $category) {
             [$risingFileTime, $risingOcDtoArray] = $this->risingPositionStore->getStorageData((string)$category);
             $risingInsertDtoArray = $this->createInsertDtoArray($risingOcDtoArray);
             unset($risingOcDtoArray);

--- a/app/Services/RankingPosition/RankingPositionHourChartArrayService.php
+++ b/app/Services/RankingPosition/RankingPositionHourChartArrayService.php
@@ -21,7 +21,7 @@ class RankingPositionHourChartArrayService
 
     function getPositionHourChartArray(RankingType $type, int $open_chat_id, int $category): RankingPositionHourChartDto
     {
-        $updatedAt = file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME);
+        $updatedAt = file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME);
         
         $repoDto = $this->rankingPositionHourPageRepository->getHourPosition(
             $type,

--- a/app/Services/RankingPosition/Store/RankingPositionStore.php
+++ b/app/Services/RankingPosition/Store/RankingPositionStore.php
@@ -8,5 +8,8 @@ use App\Config\AppConfig;
 
 class RankingPositionStore extends AbstractRankingPositionStore
 {
-    protected string $filePath = AppConfig::OPEN_CHAT_RANKING_POSITION_DIR;
+    function __construct()
+    {
+        $this->filePath = AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR;
+    }
 }

--- a/app/Services/RankingPosition/Store/RisingPositionStore.php
+++ b/app/Services/RankingPosition/Store/RisingPositionStore.php
@@ -8,5 +8,8 @@ use App\Config\AppConfig;
 
 class RisingPositionStore extends AbstractRankingPositionStore
 {
-    protected string $filePath = AppConfig::OPEN_CHAT_RISING_POSITION_DIR;
+    function __construct()
+    {
+        $this->filePath = AppConfig::$OPEN_CHAT_RISING_POSITION_DIR;
+    }
 }

--- a/app/Services/Recommend/RecommendRankingBuilder.php
+++ b/app/Services/Recommend/RecommendRankingBuilder.php
@@ -60,7 +60,7 @@ class RecommendRankingBuilder
             $ranking2,
             $ranking3,
             $ranking4,
-            file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME)
+            file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME)
         );
 
         return $dto->maxMemberCount ? $dto : false;

--- a/app/Services/Recommend/StaticData/RecommendStaticDataFile.php
+++ b/app/Services/Recommend/StaticData/RecommendStaticDataFile.php
@@ -11,7 +11,7 @@ class RecommendStaticDataFile
 {
     private function checkUpdatedAt(RecommendListDto|false $data)
     {
-        if (!$data || !$data->hourlyUpdatedAt === file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME))
+        if (!$data || !$data->hourlyUpdatedAt === file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME))
             noStore();
     }
 

--- a/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
+++ b/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
@@ -81,7 +81,7 @@ class RecommendStaticDataGenerator
 
     private function updateCategoryStaticData()
     {
-        foreach (AppConfig::OPEN_CHAT_CATEGORY as $category) {
+        foreach (AppConfig::$OPEN_CHAT_CATEGORY as $category) {
             saveSerializedFile(
                 "static_data_recommend/category/{$category}.dat",
                 $this->getCategoryRanking($category)

--- a/app/Services/SitemapGenerator.php
+++ b/app/Services/SitemapGenerator.php
@@ -51,8 +51,8 @@ class SitemapGenerator
 
     private function generateSitemap1(): string
     {
-        $date = file_get_contents(AppConfig::DAILY_CRON_UPDATED_AT_DATE);
-        $datetime = file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME);
+        $date = file_get_contents(AppConfig::$DAILY_CRON_UPDATED_AT_DATE);
+        $datetime = file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME);
 
         $sitemap = new Sitemap();
         $sitemap->addItem(rtrim(self::SITE_URL, "/"), changeFreq: ChangeFreq::DAILY, lastmod: new \DateTime);
@@ -76,7 +76,7 @@ class SitemapGenerator
                 lastmod: '@' . filemtime(PUBLIC_DIR . "/" . $accreditationJs)
             );
 
-        foreach (AppConfig::OPEN_CHAT_CATEGORY as $category) {
+        foreach (AppConfig::$OPEN_CHAT_CATEGORY as $category) {
             $category && $sitemap->addItem(self::SITE_URL . 'ranking/' . $category, lastmod: $datetime);
         }
 

--- a/app/Services/StaticData/StaticDataGenerator.php
+++ b/app/Services/StaticData/StaticDataGenerator.php
@@ -32,9 +32,9 @@ class StaticDataGenerator
         $dto->recentCommentList = [];
         $dto->recommendList = $this->topPageRecommendList->getList(30);
 
-        $dto->hourlyUpdatedAt = new \DateTime(file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME));
-        $dto->dailyUpdatedAt = new \DateTime(file_get_contents(AppConfig::DAILY_CRON_UPDATED_AT_DATE));
-        $dto->rankingUpdatedAt = new \DateTime(file_get_contents(AppConfig::HOURLY_REAL_UPDATED_AT_DATETIME));
+        $dto->hourlyUpdatedAt = new \DateTime(file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME));
+        $dto->dailyUpdatedAt = new \DateTime(file_get_contents(AppConfig::$DAILY_CRON_UPDATED_AT_DATE));
+        $dto->rankingUpdatedAt = new \DateTime(file_get_contents(AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME));
 
         $tagList = getUnserializedFile('static_data_top/tag_list.dat');
         if (!$tagList)
@@ -48,9 +48,9 @@ class StaticDataGenerator
     function getRankingArgDto(): RankingArgDto
     {
         $_argDto = new RankingArgDto;
-        $_argDto->rankingUpdatedAt = convertDatetime(file_get_contents(AppConfig::HOURLY_REAL_UPDATED_AT_DATETIME), true);
-        $_argDto->hourlyUpdatedAt = file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME);
-        $_argDto->modifiedUpdatedAtDate = file_get_contents(AppConfig::DAILY_CRON_UPDATED_AT_DATE);;
+        $_argDto->rankingUpdatedAt = convertDatetime(file_get_contents(AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME), true);
+        $_argDto->hourlyUpdatedAt = file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME);
+        $_argDto->modifiedUpdatedAtDate = file_get_contents(AppConfig::$DAILY_CRON_UPDATED_AT_DATE);;
         $_argDto->subCategories = json_decode(file_get_contents(AppConfig::OPEN_CHAT_SUB_CATEGORIES_FILE_PATH), true);
 
         if (isset($_argDto->subCategories[6])) {
@@ -77,7 +77,7 @@ class StaticDataGenerator
             $tagList = $this->getTagList();
 
         $dto = new StaticRecommendPageDto;
-        $dto->hourlyUpdatedAt = file_get_contents(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME);
+        $dto->hourlyUpdatedAt = file_get_contents(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME);
         $dto->tagCount = array_sum(array_map(fn ($el) => count($el), $tagList));
 
         $dto->tagRecordCounts = [];
@@ -96,7 +96,7 @@ class StaticDataGenerator
 
     function updateStaticData()
     {
-        safeFileRewrite(AppConfig::HOURLY_REAL_UPDATED_AT_DATETIME, (new \DateTime)->format('Y-m-d H:i:s'));
+        safeFileRewrite(AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME, (new \DateTime)->format('Y-m-d H:i:s'));
         saveSerializedFile('static_data_top/tag_list.dat', $this->getTagList());
         saveSerializedFile('static_data_top/ranking_list.dat', $this->getTopPageDataFromDB());
         saveSerializedFile('static_data_top/ranking_arg_dto.dat', $this->getRankingArgDto());

--- a/app/Services/UpdateDailyRankingService.php
+++ b/app/Services/UpdateDailyRankingService.php
@@ -30,7 +30,7 @@ class UpdateDailyRankingService
 
     private function updateStaticData(string $date)
     {
-        safeFileRewrite(AppConfig::DAILY_CRON_UPDATED_AT_DATE, $date);
+        safeFileRewrite(AppConfig::$DAILY_CRON_UPDATED_AT_DATE, $date);
         $this->staticDataGenerator->updateStaticData();
     }
 }

--- a/app/Services/UpdateHourlyMemberRankingService.php
+++ b/app/Services/UpdateHourlyMemberRankingService.php
@@ -38,7 +38,7 @@ class UpdateHourlyMemberRankingService
 
     private function getCachedFilters(string $time)
     {
-        $filters = getUnserializedFile(AppConfig::OPEN_CHAT_HOUR_FILTER_ID_DIR, true);
+        $filters = getUnserializedFile(AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR, true);
         return $filters
             ? $filters
             : $this->statisticsRepository->getHourMemberChangeWithinLastWeekArray((new \DateTime($time))->format('Y-m-d'));
@@ -47,7 +47,7 @@ class UpdateHourlyMemberRankingService
     private function saveNextFiltersCache(string $time)
     {
         saveSerializedFile(
-            AppConfig::OPEN_CHAT_HOUR_FILTER_ID_DIR,
+            AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR,
             $this->statisticsRepository->getHourMemberChangeWithinLastWeekArray((new \DateTime($time))->format('Y-m-d')),
             true
         );
@@ -55,7 +55,7 @@ class UpdateHourlyMemberRankingService
 
     private function updateStaticData(string $time)
     {
-        safeFileRewrite(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME, $time);
+        safeFileRewrite(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME, $time);
         $this->staticDataGenerator->updateStaticData();
         $this->recommendStaticDataGenerator->updateStaticData();
     }

--- a/app/Views/components/recommend_list2.php
+++ b/app/Views/components/recommend_list2.php
@@ -35,7 +35,7 @@ if ($recommend->type === RecommendListType::Category) {
     <?php endif ?>
 
     <?php if ($recommend->type === RecommendListType::Category) : ?>
-        <a class="top-ranking-readMore unset ranking-url white-btn" href="<?php echo url('ranking/' . AppConfig::OPEN_CHAT_CATEGORY[$recommend->listName] . '?list=daily') ?>">
+        <a class="top-ranking-readMore unset ranking-url white-btn" href="<?php echo url('ranking/' . AppConfig::$OPEN_CHAT_CATEGORY[$recommend->listName] . '?list=daily') ?>">
             <span class="ranking-readMore">「<?php echo $recommend->listName ?>」カテゴリーをもっと見る</span>
         </a>
     <?php elseif ($recommend->type === RecommendListType::Official) : ?>

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
             "shared/MimimalCMS_Enums.php",
             "shared/MimimalCMS_ExceptionHandler.php",
             "shared/MimimalCMS_HelperFunctions.php",
-            "app/Helpers/functions.php"
+            "app/Helpers/functions.php",
+            "app/Config/AppDynamicConfig.php"
         ]
     }
 }

--- a/genetop_exec.php
+++ b/genetop_exec.php
@@ -24,7 +24,7 @@ try {
     $recommendStaticDataGenerator->updateStaticData();
     AdminTool::sendLineNofity('recommendStaticDataGenerator done');
     
-    touch(AppConfig::HOURLY_CRON_UPDATED_AT_DATETIME);
+    touch(AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME);
 } catch (\Throwable $e) {
     addCronLog($e->__toString());
     AdminTool::sendLineNofity($e->__toString());

--- a/tests/cron_test/SyncOpenChatTest.php
+++ b/tests/cron_test/SyncOpenChatTest.php
@@ -13,7 +13,7 @@ class SyncOpenChatTest extends TestCase
          * @var SyncOpenChat $syncOpenChat
          */
         $syncOpenChat = app(SyncOpenChat::class);
-        $syncOpenChat->handle(true);
+        $syncOpenChat->handle();
 
         addCronLog('End');
         $this->assertTrue(true);

--- a/tests/oc_tests/DBTest.php
+++ b/tests/oc_tests/DBTest.php
@@ -23,7 +23,7 @@ class DBTest extends TestCase
         $dateTime = new \DateTime('now');
 
         saveSerializedFile(
-            AppConfig::OPEN_CHAT_HOUR_FILTER_ID_DIR,
+            AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR,
             $this->statisticsRepository->getHourMemberChangeWithinLastWeekArray($dateTime->format('Y-m-d')),
             true
         );

--- a/tests/oc_tests/SqliteRankingPositionHourRepositoryTest.php
+++ b/tests/oc_tests/SqliteRankingPositionHourRepositoryTest.php
@@ -19,7 +19,7 @@ class SqliteRankingPositionHourRepositoryTest extends TestCase
          */
         $repo = app(SqliteRankingPositionHourRepository::class);
 
-        foreach (AppConfig::OPEN_CHAT_CATEGORY as $category) {
+        foreach (AppConfig::$OPEN_CHAT_CATEGORY as $category) {
             $result = $repo->insertRisingHourFromDtoArray(...$test->getStorageData((string)$category));
             debug($result);
         }


### PR DESCRIPTION
Cronサービスで読み込むConfig定数の一部（更新日時やカテゴリなどの参照先）を、実行時のコンテキスト（言語）に応じて動的に定義可能にした。

- 新たに `AppDynamicConfig.php` をComposerから読み込むようにした。
    - AppConfigのクラス定数を一部static変数に変更し、オートロードで最初に読み込まれる `AppDynamicConfig.php` の処理により、動的にAppConfigのStatic変数を定義するようにした。
- `AppConfig::DAILY_CRON_UPDATED_AT_DATE` などの最終更新時間を記録するデータ保存先を言語に応じて変更するため、Static変数に変更した。
- オプチャ公式サイトのAPIから取得したJSONを保存するディレクトリを定義する `AppConfig::OPEN_CHAT_RANKING_POSITION_DIR` などもStatic変数化した。
- Static変数化した定数をもともと利用している処理も必要な変更を加えた。

MySQL, SQLiteを除き、Cron処理で最低限必要な言語切り替えを可能にした。

後続の作業（今すぐやりたい作業）
- 定数URL_ROOTに基づいてDBを自動的に選択するDBクラスを使ってDBの切り替えを可能にする。
-  `AppDynamicConfig.php` に定数URL_ROOTに基づいてAppConfigのStatic変数を定義する処理(暫定版)を実装する？
    - 定数URL_ROOTを定義するための最も簡単な暫定的実装は、Cronの実行ファイルを言語毎に作り、オートローダーのrequireより先にURL_ROOTを定義すればいい
- 取得先URLを言語に応じて切り替え可能にして、単体テストする。 