### PR TITLE
DBクラスの接続情報を動的に変更可能にする

### DIFF
--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -98,7 +98,7 @@ class AppConfig
 
     const SITEMAP_DIR = __DIR__ . '/../../public/sitemap.xml';
 
-    public static string $DAILY_CRON_UPDATED_AT_DATE =  '';
+    public static string $DAILY_CRON_UPDATED_AT_DATE = '';
     public static string $HOURLY_CRON_UPDATED_AT_DATETIME = '';
     public static string $HOURLY_REAL_UPDATED_AT_DATETIME =  '';
 
@@ -115,4 +115,7 @@ class AppConfig
     const OPEN_CHAT_ID_DATA_FILE_PATH = __DIR__ . '/../../storage/OpenChatBackupData';
     const COMMENT_DATA_FILE_PATH = __DIR__ . '/../../storage/CommentBackupData';
     const ACCREDITATION_DATA_FILE_PATH = __DIR__ . '/../../storage/AccreditationBackupData';
+
+    public static string $databaseConfigClass = '';
+    public static string $rankingPositionDBConfigClass = '';
 }

--- a/app/Config/AppDynamicConfig.php
+++ b/app/Config/AppDynamicConfig.php
@@ -1,26 +1,44 @@
 <?php
 
 use App\Config\AppConfig;
+use App\Config\RankingPositionDBConfig;
+use App\Config\Shadow\DatabaseConfig;
+use App\Config\DatabaseConfigTw;
+use App\Config\DatabaseConfigTh;
+use App\Config\RankingPositionDBConfigTw;
+use App\Config\RankingPositionDBConfigTh;
 
 if (URL_ROOT === '/tw') {
     AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/tw/static_data_top/daily_updated_at.dat';
     AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/tw/static_data_top/hourly_updated_at.dat';
     AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/tw/static_data_top/real_updated_at.dat';
+
     AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR =    __DIR__ . '/../../storage/tw/ranking_position/ranking';
     AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/tw/ranking_position/rising';
     AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/tw/ranking_position/filter.dat';
+
+    AppConfig::$databaseConfigClass =               DatabaseConfigTw::class;
+    AppConfig::$rankingPositionDBConfigClass =      RankingPositionDBConfigTw::class;
 } elseif (URL_ROOT === '/th') {
     AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/th/static_data_top/daily_updated_at.dat';
     AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/th/static_data_top/hourly_updated_at.dat';
     AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/th/static_data_top/real_updated_at.dat';
+
     AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR =    __DIR__ . '/../../storage/th/ranking_position/ranking';
     AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/th/ranking_position/rising';
     AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/th/ranking_position/filter.dat';
+
+    AppConfig::$databaseConfigClass =               DatabaseConfigTh::class;
+    AppConfig::$rankingPositionDBConfigClass =      RankingPositionDBConfigTh::class;
 } else {
     AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/static_data_top/daily_updated_at.dat';
     AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/static_data_top/hourly_updated_at.dat';
     AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/static_data_top/real_updated_at.dat';
+
     AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR =    __DIR__ . '/../../storage/ranking_position/ranking';
     AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/ranking_position/rising';
     AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/ranking_position/filter.dat';
+
+    AppConfig::$databaseConfigClass =               DatabaseConfig::class;
+    AppConfig::$rankingPositionDBConfigClass =      RankingPositionDBConfig::class;
 }

--- a/app/Config/DatabaseConfigTh.php
+++ b/app/Config/DatabaseConfigTh.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Config;
+
+use App\Config\Shadow\DatabaseConfig;
+
+class DatabaseConfigTh extends DatabaseConfig
+{
+    const DB_NAME = 'cf782105_ocreview_th';
+}

--- a/app/Config/DatabaseConfigTw.php
+++ b/app/Config/DatabaseConfigTw.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Config;
+
+use App\Config\Shadow\DatabaseConfig;
+
+class DatabaseConfigTw extends DatabaseConfig
+{
+    const DB_NAME = 'cf782105_ocreview_tw';
+}

--- a/app/Config/RankingPositionDBConfigTh.php
+++ b/app/Config/RankingPositionDBConfigTh.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Config;
+
+class RankingPositionDBConfigTh extends RankingPositionDBConfig
+{
+    const DB_NAME = 'cf782105_ranking_th';
+}

--- a/app/Config/RankingPositionDBConfigTw.php
+++ b/app/Config/RankingPositionDBConfigTw.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Config;
+
+class RankingPositionDBConfigTw extends RankingPositionDBConfig
+{
+    const DB_NAME = 'cf782105_ranking_tw';
+}

--- a/app/Controllers/Pages/AdminPageController.php
+++ b/app/Controllers/Pages/AdminPageController.php
@@ -10,7 +10,7 @@ use App\Models\Accreditation\AccreditationUserModel;
 use App\Models\Repositories\DeleteOpenChatRepositoryInterface;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Admin\AdminAuthService;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use App\Services\Admin\AdminTool;
 use App\Services\OpenChat\OpenChatApiDbMerger;
 use App\Models\SQLite\SQLiteStatistics;

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -21,7 +21,7 @@ use App\Views\Meta\OcPageMeta;
 use App\Views\Schema\OcPageSchema;
 use App\Views\Schema\PageBreadcrumbsListSchema;
 use App\Views\StatisticsViewUtility;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatPageController
 {

--- a/app/Models/AdsRepositories/AdsRepository.php
+++ b/app/Models/AdsRepositories/AdsRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\AdsRepositories;
 
 use App\Views\Dto\AdsDto;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class AdsRepository
 {

--- a/app/Models/ApiRepositories/OpenChatOfficialRankingApiRepository.php
+++ b/app/Models/ApiRepositories/OpenChatOfficialRankingApiRepository.php
@@ -6,7 +6,7 @@ namespace App\Models\ApiRepositories;
 
 use App\Models\RankingPositionDB\RankingPositionDB;
 use App\Services\OpenChat\Enum\RankingType;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatOfficialRankingApiRepository
 {

--- a/app/Models/ApiRepositories/OpenChatStatsRankingApiRepository.php
+++ b/app/Models/ApiRepositories/OpenChatStatsRankingApiRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\ApiRepositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatStatsRankingApiRepository
 {

--- a/app/Models/CommentRepositories/RecentCommentListRepository.php
+++ b/app/Models/CommentRepositories/RecentCommentListRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\CommentRepositories;
 
 use App\Models\CommentRepositories\CommentDB;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class RecentCommentListRepository implements RecentCommentListRepositoryInterface
 {

--- a/app/Models/ExecuteSqlFile.php
+++ b/app/Models/ExecuteSqlFile.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use Shadow\DBInterface;
 
 class ExecuteSqlFile

--- a/app/Models/RankingBanRepositories/RankingBanPageRepository.php
+++ b/app/Models/RankingBanRepositories/RankingBanPageRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\RankingBanRepositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class RankingBanPageRepository
 {

--- a/app/Models/RankingPositionDB/Repositories/HourMemberRankingUpdaterRepository.php
+++ b/app/Models/RankingPositionDB/Repositories/HourMemberRankingUpdaterRepository.php
@@ -7,7 +7,7 @@ namespace App\Models\RankingPositionDB\Repositories;
 use App\Models\Importer\SqlInsert;
 use App\Models\RankingPositionDB\RankingPositionDB;
 use App\Models\Repositories\RankingPosition\HourMemberRankingUpdaterRepositoryInterface;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class HourMemberRankingUpdaterRepository implements HourMemberRankingUpdaterRepositoryInterface
 {

--- a/app/Models/RecommendRepositories/CategoryRankingRepository.php
+++ b/app/Models/RecommendRepositories/CategoryRankingRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\RecommendRepositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class CategoryRankingRepository implements RecommendRankingRepositoryInterface
 {

--- a/app/Models/RecommendRepositories/OfficialRoomRankingRepository.php
+++ b/app/Models/RecommendRepositories/OfficialRoomRankingRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\RecommendRepositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OfficialRoomRankingRepository implements RecommendRankingRepositoryInterface
 {

--- a/app/Models/RecommendRepositories/RecommendRankingRepository.php
+++ b/app/Models/RecommendRepositories/RecommendRankingRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\RecommendRepositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class RecommendRankingRepository implements RecommendRankingRepositoryInterface
 {

--- a/app/Models/Repositories/DB.php
+++ b/app/Models/Repositories/DB.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Repositories;
+
+use App\Config\AppConfig;
+use Shadow\DBInterface;
+
+class DB extends \Shadow\DB implements DBInterface
+{
+    public static ?\PDO $pdo = null;
+
+    public static function connect(string $class = ''): \PDO
+    {
+        return parent::connect($class ?: AppConfig::$databaseConfigClass);
+    }
+}

--- a/app/Models/Repositories/DeleteOpenChatRepository.php
+++ b/app/Models/Repositories/DeleteOpenChatRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Repositories;
 
 use App\Models\CommentRepositories\DeleteCommentRepositoryInterface;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use App\Models\Repositories\RankingPosition\RankingPositionRepositoryInterface;
 use App\Models\Repositories\Statistics\StatisticsRepositoryInterface;
 

--- a/app/Models/Repositories/Log/LogRepository.php
+++ b/app/Models/Repositories/Log/LogRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Repositories\Log;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class LogRepository implements LogRepositoryInterface
 {

--- a/app/Models/Repositories/OpenChatDataForUpdaterWithCacheRepository.php
+++ b/app/Models/Repositories/OpenChatDataForUpdaterWithCacheRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Repositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use App\Services\OpenChat\Dto\OpenChatRepositoryDto;
 use RuntimeException;
 

--- a/app/Models/Repositories/OpenChatListRepository.php
+++ b/app/Models/Repositories/OpenChatListRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Repositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatListRepository implements OpenChatListRepositoryInterface
 {

--- a/app/Models/Repositories/OpenChatPageRepository.php
+++ b/app/Models/Repositories/OpenChatPageRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Repositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatPageRepository implements OpenChatPageRepositoryInterface
 {

--- a/app/Models/Repositories/OpenChatRepository.php
+++ b/app/Models/Repositories/OpenChatRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Repositories;
 
 use App\Config\AppConfig;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use App\Services\OpenChat\Dto\OpenChatDto;
 use App\Models\Repositories\Statistics\StatisticsRepositoryInterface;
 

--- a/app/Models/Repositories/ParallelDownloadOpenChatStateRepository.php
+++ b/app/Models/Repositories/ParallelDownloadOpenChatStateRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Repositories;
 
 use App\Services\OpenChat\Enum\RankingType;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class ParallelDownloadOpenChatStateRepository implements ParallelDownloadOpenChatStateRepositoryInterface
 {

--- a/app/Models/Repositories/SyncOpenChatStateRepository.php
+++ b/app/Models/Repositories/SyncOpenChatStateRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Repositories;
 
 use App\Services\Cron\Enum\SyncOpenChatStateType;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class SyncOpenChatStateRepository implements SyncOpenChatStateRepositoryInterface
 {

--- a/app/Models/Repositories/UpdateOpenChatRepository.php
+++ b/app/Models/Repositories/UpdateOpenChatRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Repositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use App\Services\OpenChat\Dto\OpenChatRepositoryDto;
 use App\Services\OpenChat\Dto\OpenChatUpdaterDto;
 

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\SQLite;
 
 use Shadow\DBInterface;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 abstract class AbstractSQLite extends DB implements DBInterface
 {

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRankingUpdaterRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRankingUpdaterRepository.php
@@ -8,7 +8,7 @@ use App\Models\ExecuteSqlFile;
 use App\Models\Importer\SqlInsert;
 use App\Models\Repositories\Statistics\StatisticsRankingUpdaterRepositoryInterface;
 use App\Models\SQLite\SQLiteStatistics;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use Shadow\DBInterface;
 
 class SqliteStatisticsRankingUpdaterRepository implements StatisticsRankingUpdaterRepositoryInterface

--- a/app/Models/UserLogRepositories/UserLogRepository.php
+++ b/app/Models/UserLogRepositories/UserLogRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\UserLogRepositories;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class UserLogRepository
 {

--- a/app/Services/OpenChat/OpenChatApiDataParallelDownloader.php
+++ b/app/Services/OpenChat/OpenChatApiDataParallelDownloader.php
@@ -18,7 +18,7 @@ use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Cron\Enum\SyncOpenChatStateType;
 use App\Services\OpenChat\Enum\RankingType;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatApiDataParallelDownloader
 {

--- a/app/Services/OpenChat/OpenChatApiDbMerger.php
+++ b/app/Services/OpenChat/OpenChatApiDbMerger.php
@@ -19,7 +19,7 @@ use App\Exceptions\ApplicationException;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Cron\Enum\SyncOpenChatStateType;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatApiDbMerger
 {

--- a/app/Services/OpenChat/OpenChatHourlyInvitationTicketUpdater.php
+++ b/app/Services/OpenChat/OpenChatHourlyInvitationTicketUpdater.php
@@ -8,7 +8,7 @@ use App\Config\AdminConfig;
 use App\Models\Repositories\Log\LogRepositoryInterface;
 use App\Models\Repositories\UpdateOpenChatRepositoryInterface;
 use App\Services\OpenChat\Crawler\OpenChatApiFromEmidDownloader;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatHourlyInvitationTicketUpdater
 {

--- a/app/Services/OpenChat/Store/OpenChatImageStore.php
+++ b/app/Services/OpenChat/Store/OpenChatImageStore.php
@@ -7,7 +7,7 @@ namespace App\Services\OpenChat\Store;
 use App\Config\AppConfig;
 use App\Services\OpenChat\Crawler\OpenChatImgDownloader;
 use App\Models\Repositories\Log\LogRepositoryInterface;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatImageStore
 {

--- a/app/Services/OpenChat/Updater/Process/OpenChatApiDbMergerProcess.php
+++ b/app/Services/OpenChat/Updater/Process/OpenChatApiDbMergerProcess.php
@@ -9,7 +9,7 @@ use App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepositoryInterface;
 use App\Models\Repositories\OpenChatRepositoryInterface;
 use App\Services\OpenChat\Dto\OpenChatDto;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class OpenChatApiDbMergerProcess
 {

--- a/app/Services/OpenChatAdmin/AdminEndPoint.php
+++ b/app/Services/OpenChatAdmin/AdminEndPoint.php
@@ -8,7 +8,7 @@ use App\Services\Recommend\RecommendUpdater;
 use App\Services\Recommend\RecommendUtility;
 use Shared\Exceptions\BadRequestException as Bad;
 use Shadow\Kernel\Reception as R;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class AdminEndPoint
 {

--- a/app/Services/OpenChatAdmin/AdminOpenChat.php
+++ b/app/Services/OpenChatAdmin/AdminOpenChat.php
@@ -7,7 +7,7 @@ namespace App\Services\OpenChatAdmin;
 use App\Models\CommentRepositories\CommentListRepositoryInterface;
 use App\Models\RecommendRepositories\RecommendRankingRepository;
 use App\Services\OpenChatAdmin\Dto\AdminOpenChatDto;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class AdminOpenChat
 {

--- a/app/Services/RankingBan/RankingBanTableUpdater.php
+++ b/app/Services/RankingBan/RankingBanTableUpdater.php
@@ -11,7 +11,7 @@ use App\Models\Repositories\RankingPosition\RankingPositionPageRepositoryInterfa
 use App\Models\Repositories\Statistics\StatisticsPageRepositoryInterface;
 use App\Services\OpenChat\Updater\OpenChatUpdaterFromApi;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class RankingBanTableUpdater
 {

--- a/app/Services/Recommend/RecommendUpdater.php
+++ b/app/Services/Recommend/RecommendUpdater.php
@@ -6,7 +6,7 @@ namespace App\Services\Recommend;
 
 use App\Config\AppConfig;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class RecommendUpdater
 {

--- a/app/Services/Recommend/RecommendUpdater2.php
+++ b/app/Services/Recommend/RecommendUpdater2.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Recommend;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class RecommendUpdater2 extends RecommendUpdater
 {

--- a/app/Services/Recommend/TopPageRecommendList.php
+++ b/app/Services/Recommend/TopPageRecommendList.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Recommend;
 
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class TopPageRecommendList
 {

--- a/app/Services/SitemapGenerator.php
+++ b/app/Services/SitemapGenerator.php
@@ -12,7 +12,7 @@ use Asika\Sitemap\ChangeFreq;
 use Asika\Sitemap\SitemapIndex;
 use App\Models\Repositories\OpenChatListRepositoryInterface;
 use App\Services\Recommend\RecommendUpdater;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class SitemapGenerator
 {

--- a/tests/oc_tests/DBTest.php
+++ b/tests/oc_tests/DBTest.php
@@ -10,7 +10,7 @@ use App\Services\OpenChat\Enum\RankingType;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
 use App\Services\StaticData\StaticTopPageDataGenerator;
 use PHPUnit\Framework\TestCase;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class DBTest extends TestCase
 {

--- a/tests/oc_tests/DuplicateOpenChatMegerTest.php
+++ b/tests/oc_tests/DuplicateOpenChatMegerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use App\Config\AppConfig;
 use App\Services\OpenChat\DuplicateOpenChatMeger;
 

--- a/tests/oc_tests/LogRepositoryTest.php
+++ b/tests/oc_tests/LogRepositoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 use App\Models\Repositories\Log\LogRepository;
 
 class LogRepositoryTest extends TestCase

--- a/tests/oc_tests/RankingPositionDailyUpdaterTest.php
+++ b/tests/oc_tests/RankingPositionDailyUpdaterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use App\Services\RankingPosition\RankingPositionDailyUpdater;
 use PHPUnit\Framework\TestCase;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class RankingPositionDailyUpdaterTest extends TestCase
 {

--- a/tests/oc_tests/SqliteStatisticsRepositoryTest.php
+++ b/tests/oc_tests/SqliteStatisticsRepositoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use App\Models\SQLite\Repositories\Statistics\SqliteStatisticsRepository;
 use App\Services\DailyUpdateCronService;
 use PHPUnit\Framework\TestCase;
-use Shadow\DB;
+use App\Models\Repositories\DB;
 
 class DailyUpdateCronServiceTest extends TestCase
 {


### PR DESCRIPTION
https://github.com/pika-0203/Open-Chat-Graph/pull/17 の続き

変更点
1. DB, RankingPositionDBの接続情報クラス名をAppConfigに定義
2. AppConfigから接続情報を参照する新しいDBクラスを実装

後続作業
1. AppConfigから接続情報を参照する新しいRankingPositionDBクラスを実装
2. SQLiteの参照元ファイル名を変更するロジックを実装