### PR TITLE
MySQL、SQLiteの接続先DBを言語毎に切り替える

### DIFF
--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -116,6 +116,6 @@ class AppConfig
     const COMMENT_DATA_FILE_PATH = __DIR__ . '/../../storage/CommentBackupData';
     const ACCREDITATION_DATA_FILE_PATH = __DIR__ . '/../../storage/AccreditationBackupData';
 
-    public static string $databaseConfigClass = '';
-    public static string $rankingPositionDBConfigClass = '';
+    public static string $DatabaseConfigClass = '';
+    public static string $RankingPositionDBConfigClass = '';
 }

--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -118,4 +118,7 @@ class AppConfig
 
     public static string $DatabaseConfigClass = '';
     public static string $RankingPositionDBConfigClass = '';
+
+    public static string $SQLiteRankingPositionDbfile = '';
+    public static string $SQLiteStatisticsDbfile = '';
 }

--- a/app/Config/AppDynamicConfig.php
+++ b/app/Config/AppDynamicConfig.php
@@ -1,44 +1,39 @@
 <?php
 
 use App\Config\AppConfig;
-use App\Config\RankingPositionDBConfig;
 use App\Config\Shadow\DatabaseConfig;
-use App\Config\DatabaseConfigTw;
 use App\Config\DatabaseConfigTh;
-use App\Config\RankingPositionDBConfigTw;
+use App\Config\DatabaseConfigTw;
+use App\Config\RankingPositionDBConfig;
 use App\Config\RankingPositionDBConfigTh;
+use App\Config\RankingPositionDBConfigTw;
 
-if (URL_ROOT === '/tw') {
-    AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/tw/static_data_top/daily_updated_at.dat';
-    AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/tw/static_data_top/hourly_updated_at.dat';
-    AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/tw/static_data_top/real_updated_at.dat';
+(function () {
+    if (URL_ROOT === '/tw') {
+        $STORAGE_DIR = __DIR__ . '/../../tw/storage';
 
-    AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR =    __DIR__ . '/../../storage/tw/ranking_position/ranking';
-    AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/tw/ranking_position/rising';
-    AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/tw/ranking_position/filter.dat';
+        AppConfig::$DatabaseConfigClass = DatabaseConfigTw::class;
+        AppConfig::$RankingPositionDBConfigClass = RankingPositionDBConfigTw::class;
+    } elseif (URL_ROOT === '/th') {
+        $STORAGE_DIR = __DIR__ . '/../../th/storage';
 
-    AppConfig::$DatabaseConfigClass =               DatabaseConfigTw::class;
-    AppConfig::$RankingPositionDBConfigClass =      RankingPositionDBConfigTw::class;
-} elseif (URL_ROOT === '/th') {
-    AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/th/static_data_top/daily_updated_at.dat';
-    AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/th/static_data_top/hourly_updated_at.dat';
-    AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/th/static_data_top/real_updated_at.dat';
+        AppConfig::$DatabaseConfigClass = DatabaseConfigTh::class;
+        AppConfig::$RankingPositionDBConfigClass = RankingPositionDBConfigTh::class;
+    } else {
+        $STORAGE_DIR = __DIR__ . '/../../storage';
 
-    AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR =    __DIR__ . '/../../storage/th/ranking_position/ranking';
-    AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/th/ranking_position/rising';
-    AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/th/ranking_position/filter.dat';
+        AppConfig::$DatabaseConfigClass = DatabaseConfig::class;
+        AppConfig::$RankingPositionDBConfigClass = RankingPositionDBConfig::class;
+    }
 
-    AppConfig::$DatabaseConfigClass =               DatabaseConfigTh::class;
-    AppConfig::$RankingPositionDBConfigClass =      RankingPositionDBConfigTh::class;
-} else {
-    AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/static_data_top/daily_updated_at.dat';
-    AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/static_data_top/hourly_updated_at.dat';
-    AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/static_data_top/real_updated_at.dat';
+    AppConfig::$DAILY_CRON_UPDATED_AT_DATE =      $STORAGE_DIR . '/static_data_top/daily_updated_at.dat';
+    AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME = $STORAGE_DIR . '/static_data_top/hourly_updated_at.dat';
+    AppConfig::$HOURLY_REAL_UPDATED_AT_DATETIME = $STORAGE_DIR . '/static_data_top/real_updated_at.dat';
 
-    AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR =    __DIR__ . '/../../storage/ranking_position/ranking';
-    AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/ranking_position/rising';
-    AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/ranking_position/filter.dat';
+    AppConfig::$OPEN_CHAT_RANKING_POSITION_DIR =  $STORAGE_DIR . '/ranking_position/ranking';
+    AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =   $STORAGE_DIR . '/ranking_position/rising';
+    AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =    $STORAGE_DIR . '/ranking_position/filter.dat';
 
-    AppConfig::$DatabaseConfigClass =               DatabaseConfig::class;
-    AppConfig::$RankingPositionDBConfigClass =      RankingPositionDBConfig::class;
-}
+    AppConfig::$SQLiteStatisticsDbfile =          $STORAGE_DIR . '/SQLite/statistics/statistics.db';
+    AppConfig::$SQLiteRankingPositionDbfile =     $STORAGE_DIR . '/SQLite/ranking_position/ranking_position.db';
+})();

--- a/app/Config/AppDynamicConfig.php
+++ b/app/Config/AppDynamicConfig.php
@@ -17,8 +17,8 @@ if (URL_ROOT === '/tw') {
     AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/tw/ranking_position/rising';
     AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/tw/ranking_position/filter.dat';
 
-    AppConfig::$databaseConfigClass =               DatabaseConfigTw::class;
-    AppConfig::$rankingPositionDBConfigClass =      RankingPositionDBConfigTw::class;
+    AppConfig::$DatabaseConfigClass =               DatabaseConfigTw::class;
+    AppConfig::$RankingPositionDBConfigClass =      RankingPositionDBConfigTw::class;
 } elseif (URL_ROOT === '/th') {
     AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/th/static_data_top/daily_updated_at.dat';
     AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/th/static_data_top/hourly_updated_at.dat';
@@ -28,8 +28,8 @@ if (URL_ROOT === '/tw') {
     AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/th/ranking_position/rising';
     AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/th/ranking_position/filter.dat';
 
-    AppConfig::$databaseConfigClass =               DatabaseConfigTh::class;
-    AppConfig::$rankingPositionDBConfigClass =      RankingPositionDBConfigTh::class;
+    AppConfig::$DatabaseConfigClass =               DatabaseConfigTh::class;
+    AppConfig::$RankingPositionDBConfigClass =      RankingPositionDBConfigTh::class;
 } else {
     AppConfig::$DAILY_CRON_UPDATED_AT_DATE =        __DIR__ . '/../../storage/static_data_top/daily_updated_at.dat';
     AppConfig::$HOURLY_CRON_UPDATED_AT_DATETIME =   __DIR__ . '/../../storage/static_data_top/hourly_updated_at.dat';
@@ -39,6 +39,6 @@ if (URL_ROOT === '/tw') {
     AppConfig::$OPEN_CHAT_RISING_POSITION_DIR =     __DIR__ . '/../../storage/ranking_position/rising';
     AppConfig::$OPEN_CHAT_HOUR_FILTER_ID_DIR =      __DIR__ . '/../../storage/ranking_position/filter.dat';
 
-    AppConfig::$databaseConfigClass =               DatabaseConfig::class;
-    AppConfig::$rankingPositionDBConfigClass =      RankingPositionDBConfig::class;
+    AppConfig::$DatabaseConfigClass =               DatabaseConfig::class;
+    AppConfig::$RankingPositionDBConfigClass =      RankingPositionDBConfig::class;
 }

--- a/app/Config/AppDynamicConfig.php
+++ b/app/Config/AppDynamicConfig.php
@@ -10,12 +10,12 @@ use App\Config\RankingPositionDBConfigTw;
 
 (function () {
     if (URL_ROOT === '/tw') {
-        $STORAGE_DIR = __DIR__ . '/../../tw/storage';
+        $STORAGE_DIR = __DIR__ . '/../../storage/tw';
 
         AppConfig::$DatabaseConfigClass = DatabaseConfigTw::class;
         AppConfig::$RankingPositionDBConfigClass = RankingPositionDBConfigTw::class;
     } elseif (URL_ROOT === '/th') {
-        $STORAGE_DIR = __DIR__ . '/../../th/storage';
+        $STORAGE_DIR = __DIR__ . '/../../storage/th';
 
         AppConfig::$DatabaseConfigClass = DatabaseConfigTh::class;
         AppConfig::$RankingPositionDBConfigClass = RankingPositionDBConfigTh::class;

--- a/app/Models/RankingPositionDB/RankingPositionDB.php
+++ b/app/Models/RankingPositionDB/RankingPositionDB.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\RankingPositionDB;
 
-use App\Config\RankingPositionDBConfig;
+use App\Config\AppConfig;
 use Shadow\DBInterface;
 use Shadow\DB;
 
@@ -12,8 +12,8 @@ class RankingPositionDB extends DB implements DBInterface
 {
     public static ?\PDO $pdo = null;
 
-    public static function connect(string $class = RankingPositionDBConfig::class): \PDO
+    public static function connect(string $class = ''): \PDO
     {
-        return parent::connect($class);
+        return parent::connect($class ?: AppConfig::$RankingPositionDBConfigClass);
     }
 }

--- a/app/Models/Repositories/DB.php
+++ b/app/Models/Repositories/DB.php
@@ -13,6 +13,6 @@ class DB extends \Shadow\DB implements DBInterface
 
     public static function connect(string $class = ''): \PDO
     {
-        return parent::connect($class ?: AppConfig::$databaseConfigClass);
+        return parent::connect($class ?: AppConfig::$DatabaseConfigClass);
     }
 }

--- a/app/Models/Repositories/OpenChatDataForUpdaterWithCacheRepository.php
+++ b/app/Models/Repositories/OpenChatDataForUpdaterWithCacheRepository.php
@@ -55,7 +55,10 @@ class OpenChatDataForUpdaterWithCacheRepository implements OpenChatDataForUpdate
          */
         $dataArray = DB::fetchAll($query);
         if (!$dataArray) {
-            throw new RuntimeException('DBが空です');
+            self::$openChatDataCache = [];
+            self::$openChatIdCache = [];
+            self::$openChatEmidCache = [];
+            return;
         }
 
         self::$openChatIdCache = array_column($dataArray, 'id');

--- a/app/Models/SQLite/SQLiteRankingPosition.php
+++ b/app/Models/SQLite/SQLiteRankingPosition.php
@@ -4,10 +4,20 @@ declare(strict_types=1);
 
 namespace App\Models\SQLite;
 
+use App\Config\AppConfig;
 use Shadow\DBInterface;
 
 class SQLiteRankingPosition extends AbstractSQLite implements DBInterface
 {
-    public static string $dbfile = __DIR__ . '/../../../storage/SQLite/ranking_position/ranking_position.db';
+    public static string $dbfile = '';
     public static ?\PDO $pdo = null;
+
+    /**
+     * @throws \PDOException
+     */
+    public static function connect(string $mode = '?mode=rwc'): \PDO
+    {
+        self::$dbfile = AppConfig::$SQLiteRankingPositionDbfile;
+        return parent::connect($mode);
+    }
 }

--- a/app/Models/SQLite/SQLiteStatistics.php
+++ b/app/Models/SQLite/SQLiteStatistics.php
@@ -4,10 +4,20 @@ declare(strict_types=1);
 
 namespace App\Models\SQLite;
 
+use App\Config\AppConfig;
 use Shadow\DBInterface;
 
 class SQLiteStatistics extends AbstractSQLite implements DBInterface
 {
-    public static string $dbfile = __DIR__ . '/../../../storage/SQLite/statistics/statistics.db';
+    public static string $dbfile = '';
     public static ?\PDO $pdo = null;
+
+    /**
+     * @throws \PDOException
+     */
+    public static function connect(string $mode = '?mode=rwc'): \PDO
+    {
+        self::$dbfile = AppConfig::$SQLiteStatisticsDbfile;
+        return parent::connect($mode);
+    }
 }


### PR DESCRIPTION
#20 の続き

DBクラス(DBInterface)の `DB`, `RankingPositionDB`, `SQLiteRankingPosition`, `SQLiteStatistics` が各言語（日本・タイ・台湾）に応じてDBを切り替え可能になった。

今回の一連のHotfixの目的は、まずはCronでオプチャ公式サイトからのデータ収集を定期実行させること。
そのため、人数統計の収集に最低限必要な実装をする。

`DB`, `RankingPositionDB`, `SQLiteRankingPosition`, `SQLiteStatistics` は統計の収集に必須なDBクラスのため今回の改修対象となった。

本来の多言語対応リリースでは、今回の暫定的なHotfixのほかに、静的データ生成の保存先ディレクトリなどの切り替え実装が必要となる。