### PR TITLE
日本語以外の急上昇APIにcreatedAtが存在しない問題を修正

### DIFF
--- a/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloader.php
+++ b/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloader.php
@@ -49,7 +49,7 @@ class OpenChatApiRankingDownloader
     {
         $resultCount = 0;
 
-        $ct = '0';
+        $ct = '';
         while ($ct !== false) {
             $response = $this->openChatApiRankingDownloaderProcess->fetchOpenChatApiRankingProcess($category, $ct, $callback);
 

--- a/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloader.php
+++ b/app/Services/OpenChat/Crawler/OpenChatApiRankingDownloader.php
@@ -48,8 +48,8 @@ class OpenChatApiRankingDownloader
     function fetchOpenChatApiRanking(string $category, \Closure $callback): int
     {
         $resultCount = 0;
-
         $ct = '';
+
         while ($ct !== false) {
             $response = $this->openChatApiRankingDownloaderProcess->fetchOpenChatApiRankingProcess($category, $ct, $callback);
 

--- a/app/Services/OpenChat/Dto/OpenChatApiDtoFactory.php
+++ b/app/Services/OpenChat/Dto/OpenChatApiDtoFactory.php
@@ -65,8 +65,10 @@ class OpenChatApiDtoFactory
             $dto->emblem = Validator::num($square['square']['emblems'][0] ?? null, emptyAble: true, default: 0, e: $exceptionClass);
             $dto->joinMethodType = Validator::num($square['square']['joinMethodType'], e: $exceptionClass);
 
-            $createdAt = Validator::num($square['createdAt'], e: $exceptionClass);
-            $dto->createdAt = (int)floor($createdAt / 1000);
+            if (isset($square['createdAt'])) {
+                $createdAt = Validator::num($square['createdAt'], e: $exceptionClass);
+                $dto->createdAt = (int)floor($createdAt / 1000);
+            }
         } catch (\Throwable $e) {
             $jsonString = json_encode($square, JSON_UNESCAPED_UNICODE);
             throw new $exceptionClass($e->__toString() . ": {$jsonString}");

--- a/app/Services/OpenChat/Dto/OpenChatUpdaterDtoFactory.php
+++ b/app/Services/OpenChat/Dto/OpenChatUpdaterDtoFactory.php
@@ -44,6 +44,7 @@ class OpenChatUpdaterDtoFactory
             || $updaterDto->joinMethodType !== null
             || $updaterDto->category !== null
             || $updaterDto->emblem !== null
+            //|| $updaterDto->createdAt !== null
         ) {
             $updaterDto->rewriteUpdateAtTime($this->dateTime);
         }

--- a/app/Services/OpenChat/Updater/OpenChatUpdaterFromApi.php
+++ b/app/Services/OpenChat/Updater/OpenChatUpdaterFromApi.php
@@ -77,6 +77,7 @@ class OpenChatUpdaterFromApi
             || $repoDto->invitationTicket !== $ocDto->invitationTicket
             || $repoDto->memberCount !== $ocDto->memberCount
             || $repoDto->joinMethodType !== $ocDto->joinMethodType
+            // || $repoDto->createdAt !== $ocDto->createdAt
         ) {
             $updaterDto = !!$this->openChatMargeUpdateProcess->mergeUpdateOpenChat($repoDto, $ocDto);
         }


### PR DESCRIPTION
急上昇のJSONが日本語・他言語で微妙に違うことが判明したため対応

![image](https://github.com/user-attachments/assets/94c217af-da84-4c59-981b-25fde772bdfd)
