### PR TITLE
Enable Rank Ban Analysis

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -202,7 +202,7 @@ Route::path(
         handleRequestWithETagAndCache("labs/tags");
     }); */
 
-/* Route::path(
+Route::path(
     'labs/publication-analytics',
     [RankingBanLabsPageController::class, 'index']
 )
@@ -216,7 +216,7 @@ Route::path(
             return false;
 
         handleRequestWithETagAndCache(json_encode($reception->input()));
-    }); */
+    });
 
 // コメントAPI
 Route::path(

--- a/app/Controllers/Pages/AdminPageController.php
+++ b/app/Controllers/Pages/AdminPageController.php
@@ -76,6 +76,15 @@ class AdminPageController
         return view('admin/admin_message_page', ['title' => 'exec', 'message' => $path . ' を実行しました。']);
     }
 
+    function rankingban_test()
+    {
+        $path = AppConfig::ROOT_PATH . 'batch/exec/ranking_ban_test.php';
+
+        exec(AppConfig::$phpBinary . " {$path} >/dev/null 2>&1 &");
+
+        return view('admin/admin_message_page', ['title' => 'exec', 'message' => $path . ' を実行しました。']);
+    }
+
     function retry_daily_test()
     {
         $urlRoot = MimimalCmsConfig::$urlRoot;

--- a/app/Models/RankingBanRepositories/RankingBanPageRepository.php
+++ b/app/Models/RankingBanRepositories/RankingBanPageRepository.php
@@ -105,7 +105,7 @@ class RankingBanPageRepository
     {
         $updatedAtValue = $change === 0
             ? "AND (rb.updated_at >= 1 OR (rb.update_items IS NOT NULL AND rb.update_items != ''))"
-            : ($change === 1 ? "AND (rb.updated_at = 0 AND (rb.update_items IS NULL OR rb.update_items = ''))" : '');
+            : ($change === 1 ? "AND (rb.updated_at = 0 AND (rb.update_items IS NULL OR rb.update_items = '') AND rb.datetime >= '2025-08-10 23:59:59')" : '');
 
         $endDatetime = $publish === 0
             ? "AND rb.end_datetime IS NOT NULL"

--- a/app/Models/Repositories/UpdateOpenChatRepository.php
+++ b/app/Models/Repositories/UpdateOpenChatRepository.php
@@ -60,7 +60,7 @@ class UpdateOpenChatRepository implements UpdateOpenChatRepositoryInterface
             'category' => $dto->category ?? null,
             'emblem' => $dto->emblem ?? null,
             'join_method_type' => $dto->joinMethodType ?? null,
-            // 'update_items' => $dto->getUpdateItems(),
+            'update_items' => $dto->getUpdateItems(),
         ];
 
         $columnsToUpdate = array_filter($columnsToSet, fn ($value) => $value !== null);

--- a/app/Services/Admin/test/AdminToolTest.php
+++ b/app/Services/Admin/test/AdminToolTest.php
@@ -2,21 +2,16 @@
 
 declare(strict_types=1);
 
-use App\Config\AppConfig;
-use App\Models\Importer\SqlInsertWithBindValue;
+use App\Services\Admin\AdminTool;
 use PHPUnit\Framework\TestCase;
 
 class AdminToolTest extends TestCase
 {
-    public SqlInsertWithBindValue $sqlInsertWithBindValue;
-
-    public function setUp(): void
+    // discordテスト
+    public function testDiscordWebhook()
     {
-        $this->sqlInsertWithBindValue = app(SqlInsertWithBindValue::class);
-    }
-
-    public function test()
-    {
-        $this->assertTrue(true);
+        $result = AdminTool::sendDiscordNotify('テストメッセージ');
+        debug($result);
+        $this->assertIsString($result);
     }
 }

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -136,7 +136,7 @@ class SyncOpenChat
                 $this->invitationTicketUpdater->updateInvitationTicketAll();
                 $this->state->setFalse(StateType::isUpdateInvitationTicketActive);
             }, 'updateInvitationTicketAll'],
-            //[fn() => $this->rankingBanUpdater->updateRankingBanTable(), 'updateRankingBanTable'],
+            [fn() => $this->rankingBanUpdater->updateRankingBanTable(), 'updateRankingBanTable'],
             [function () {
                 if ($this->state->getBool(StateType::isDailyTaskActive)) {
                     addCronLog('Skip updateRecommendTables because dailyTask is active');

--- a/app/Services/RankingBan/ProgressNotifier.php
+++ b/app/Services/RankingBan/ProgressNotifier.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\RankingBan;
+
+use App\Services\Admin\AdminTool;
+
+class ProgressNotifier
+{
+    private int $totalCount = 0;
+    private int $processedCount = 0;
+    private ?\DateTime $startTime = null;
+    private ?\DateTime $lastNotifyTime = null;
+    private int $notifyIntervalSeconds = 300; // 5分
+    
+    public function setTotalCount(int $totalCount): void
+    {
+        $this->totalCount = $totalCount;
+        $this->processedCount = 0;
+        $this->startTime = new \DateTime();
+        $this->lastNotifyTime = null;
+    }
+    
+    public function notifyStart(string $processName): void
+    {
+        if ($this->totalCount <= 100) {
+            return;
+        }
+        
+        if (!$this->startTime) {
+            return;
+        }
+        
+        AdminTool::sendDiscordNotify(
+            "{$processName} 開始: {$this->totalCount}件の処理を開始します"
+        );
+        
+        $this->lastNotifyTime = new \DateTime();
+    }
+    
+    public function incrementAndNotify(string $processName): void
+    {
+        $this->processedCount++;
+        
+        if ($this->totalCount <= 100 || !$this->startTime) {
+            return;
+        }
+        
+        $now = new \DateTime();
+        
+        // 最後の処理の場合
+        if ($this->processedCount >= $this->totalCount) {
+            $duration = $now->diff($this->startTime);
+            AdminTool::sendDiscordNotify(
+                "{$processName} 完了: {$this->processedCount}/{$this->totalCount}件 (処理時間: {$duration->format('%H:%I:%S')})"
+            );
+            return;
+        }
+        
+        // 5分経過した場合
+        if ($this->lastNotifyTime && $now->getTimestamp() - $this->lastNotifyTime->getTimestamp() >= $this->notifyIntervalSeconds) {
+            AdminTool::sendDiscordNotify(
+                "{$processName} 進捗: {$this->processedCount}/{$this->totalCount}件"
+            );
+            $this->lastNotifyTime = $now;
+        }
+    }    
+}

--- a/app/Services/RankingBan/RakingBanPageService.php
+++ b/app/Services/RankingBan/RakingBanPageService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\RankingBan;
 
 use App\Services\Traits\TraitPaginationRecordsCalculator;
-use App\Config\AppConfig;
 use App\Models\RankingBanRepositories\RankingBanPageRepository;
 
 class RakingBanPageService

--- a/app/Services/RankingBan/RankingBanTableUpdater.php
+++ b/app/Services/RankingBan/RankingBanTableUpdater.php
@@ -12,6 +12,7 @@ use App\Models\Repositories\Statistics\StatisticsPageRepositoryInterface;
 use App\Services\OpenChat\Updater\OpenChatUpdaterFromApi;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
 use App\Models\Repositories\DB;
+use Shared\MimimalCmsConfig;
 
 class RankingBanTableUpdater
 {
@@ -160,6 +161,11 @@ class RankingBanTableUpdater
 
     function updateRankingBanTable()
     {
+        // 日本以外の場合、更新をスキップする
+        if (MimimalCmsConfig::$urlRoot !== '') {
+            return;
+        }
+
         $openChatArray = DB::fetchAll(
             "SELECT
                 oc.id,

--- a/app/Services/RankingBan/test/RankingBanTableUpdaterTest.php
+++ b/app/Services/RankingBan/test/RankingBanTableUpdaterTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Config\AppConfig;
 use App\Services\RankingBan\RankingBanTableUpdater;
 use PHPUnit\Framework\TestCase;
 
@@ -12,6 +13,7 @@ class RankingBanTableUpdaterTest extends TestCase
     {
         $this->inst = app(RankingBanTableUpdater::class);
 
+        AppConfig::$isDevlopment = false;
         $this->inst->updateRankingBanTable();
 
         $this->assertTrue(true);

--- a/app/Services/RankingBan/test/RankingBanTableUpdaterTest.php
+++ b/app/Services/RankingBan/test/RankingBanTableUpdaterTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Config\AppConfig;
+use App\Services\OpenChat\Utility\OpenChatServicesUtility;
 use App\Services\RankingBan\RankingBanTableUpdater;
 use PHPUnit\Framework\TestCase;
 
@@ -11,10 +12,10 @@ class RankingBanTableUpdaterTest extends TestCase
     private RankingBanTableUpdater $inst;
     public function test()
     {
-        $this->inst = app(RankingBanTableUpdater::class);
+        $this->inst = app(RankingBanTableUpdater::class, ['time' => new \DateTime('2023-01-31 16:30:00')]);
 
         AppConfig::$isDevlopment = false;
-        $this->inst->updateRankingBanTable();
+        $this->inst->updateRankingBanTable(OpenChatServicesUtility::getModifiedCronTime('now'));
 
         $this->assertTrue(true);
     }

--- a/app/Views/components/open_chat_list_ranking_ban.php
+++ b/app/Views/components/open_chat_list_ranking_ban.php
@@ -60,7 +60,9 @@
                 <?php endif ?>
               <?php endforeach ?>
             <?php else : ?>
-              <span>ルーム内容変更なし</span>
+              <?php if (strtotime($oc['old_datetime']) > strtotime('2025-08-10 23:59:59')) : ?>
+                <span>ルーム内容変更なし</span>
+              <?php endif ?>
             <?php endif ?>
           </div>
 

--- a/app/Views/ranking_ban_content.php
+++ b/app/Views/ranking_ban_content.php
@@ -84,7 +84,6 @@ viewComponent('head', compact('_css', '_meta')) ?>
     <!-- 固定ヘッダー -->
     <?php viewComponent('site_header', compact('_updatedAt')) ?>
     <main style="max-width: 600px; padding: 0 1rem; overflow: hidden;">
-        <?php \App\Views\Ads\GoogleAdsence::output(\App\Views\Ads\GoogleAdsence::AD_SLOTS['siteTopRectangle']) ?>
         <header class="openchat-list-title-area unset" style="padding-top: 1rem;">
             <div style="flex-direction: column;">
                 <h2 class="list-title">
@@ -205,7 +204,6 @@ viewComponent('head', compact('_css', '_meta')) ?>
             </div>
         </form>
         <!-- select要素ページネーション -->
-        <?php \App\Views\Ads\GoogleAdsence::output(\App\Views\Ads\GoogleAdsence::AD_SLOTS['siteTopRectangle']) ?>
         <?php if (isset($_select)) : ?>
             <nav class="page-select unset" style="flex-direction: column; padding: 1rem 0 0 0; margin: 0 0 12px 0;">
                 <div style="font-weight: bold; font-size: 13px;">

--- a/batch/exec/ranking_ban_test.php
+++ b/batch/exec/ranking_ban_test.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Config\AppConfig;
+use App\Services\Admin\AdminTool;
+use App\Services\OpenChat\Utility\OpenChatServicesUtility;
+use App\Services\RankingBan\RankingBanTableUpdater;
+
+set_time_limit(60 * 60);
+
+AppConfig::$isDevlopment = false;
+
+try {
+    /**
+     * @var RankingBanTableUpdater $oc
+     */
+    $oc = app(RankingBanTableUpdater::class, ['time' => new \DateTime('2023-01-31 16:30:00')]);
+
+    AdminTool::sendDiscordNotify('RankingBanTableUpdater start');
+
+    $oc->updateRankingBanTable(OpenChatServicesUtility::getModifiedCronTime('now'));
+
+    AdminTool::sendDiscordNotify('RankingBanTableUpdater done');
+} catch (\Throwable $e) {
+    addCronLog($e->__toString());
+    AdminTool::sendDiscordNotify($e->__toString());
+}


### PR DESCRIPTION
This pull request introduces several significant improvements and new features to the RankingBan update process, including progress notifications, enhanced testability, and bug fixes. The most notable changes are the addition of a progress notifier for long-running batch processes, updates to the `RankingBanTableUpdater` to support dependency injection and progress reporting, and the creation of a new batch test script. Additionally, there are bug fixes and minor adjustments to the routing and data handling logic.

**RankingBan Batch Process Improvements**

* Introduced a new `ProgressNotifier` class to send Discord notifications about the progress, start, and completion of long-running batch processes, such as updating the ranking ban table.
* Updated `RankingBanTableUpdater` to accept a notifier and a custom time for easier testing, and integrated progress notifications into the update and crawl methods. Also added a country check to skip updates outside Japan. [[1]](diffhunk://#diff-e96b2f98c281fb2b69e07929913a8327005f0a85c46811b000d930968afea4ccR15-R30) [[2]](diffhunk://#diff-e96b2f98c281fb2b69e07929913a8327005f0a85c46811b000d930968afea4ccR87-R90) [[3]](diffhunk://#diff-e96b2f98c281fb2b69e07929913a8327005f0a85c46811b000d930968afea4ccR130-R132) [[4]](diffhunk://#diff-e96b2f98c281fb2b69e07929913a8327005f0a85c46811b000d930968afea4ccR147-R150) [[5]](diffhunk://#diff-e96b2f98c281fb2b69e07929913a8327005f0a85c46811b000d930968afea4ccR164-R166) [[6]](diffhunk://#diff-e96b2f98c281fb2b69e07929913a8327005f0a85c46811b000d930968afea4ccL161-R183)
* Added a new batch script `ranking_ban_test.php` to facilitate testing of the batch process with Discord notifications for start and completion, and improved the related admin controller to trigger this script. [[1]](diffhunk://#diff-7d41c0014d0d0711cef775c501a24bf2db13194c0fee9657956b6bdfbe6443a6R1-R28) [[2]](diffhunk://#diff-177073a25d650f8aae4c6a3df48b62087139110bd4beca8c805f878e8c4310c5R79-R87)

**Testing and Code Quality**

* Improved testability by allowing `RankingBanTableUpdater` to accept a custom time and updated the test to use this feature, ensuring more reliable and reproducible tests. [[1]](diffhunk://#diff-ffe078e18899dccac2d0aba92f621801865e2f53f931df03d83690f9ed42be76R5-R6) [[2]](diffhunk://#diff-ffe078e18899dccac2d0aba92f621801865e2f53f931df03d83690f9ed42be76L13-R18)
* Enhanced the admin tool test to include a Discord webhook test, verifying notification functionality.

**Bug Fixes and Data Handling**

* Fixed a bug in the ranking ban page repository to ensure that only records after a specific date are considered for certain queries.
* Enabled the update of the `update_items` field in the open chat record update logic, ensuring data consistency.
* Adjusted the open chat list view to display "no content changes" only for records after a certain date.

**Other Adjustments**

* Minor routing and code cleanup, such as uncommenting and enabling routes and tasks, and removing unnecessary code. [[1]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L205-R205) [[2]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L219-R219) [[3]](diffhunk://#diff-27373e158f664b3443798a13425c67d14c3704662ca00458fe13e1d42fca9699L139-R139) [[4]](diffhunk://#diff-5fdbd9de70e023777163e64c52fcd6df7d760061017609660e831f4efbac8f94L8)
* Removed certain ad slots from the ranking ban content view for a cleaner user experience. [[1]](diffhunk://#diff-5b5315a152060efb32f838e55d3c759994acffd273106ea3d6e7139921c9e391L87) [[2]](diffhunk://#diff-5b5315a152060efb32f838e55d3c759994acffd273106ea3d6e7139921c9e391L208)