### PR TITLE
Api deleter

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -28,6 +28,7 @@ use App\Controllers\Pages\RecommendOpenChatPageController;
 use App\Controllers\Pages\RegisterOpenChatPageController;
 use App\Controllers\Pages\TagLabsPageController;
 use App\Middleware\VerifyCsrfToken;
+use App\ServiceProvider\ApiRepositoryServiceProvider;
 use Shadow\Kernel\Reception;
 use Shared\MimimalCmsConfig;
 
@@ -76,14 +77,7 @@ Route::path('ocapi/{open_chat_id}', [OpenChatPageController::class, 'index'])
         }
 
         handleRequestWithETagAndCache($open_chat_id);
-        app()->bind(
-            \App\Models\Repositories\OpenChatPageRepositoryInterface::class,
-            fn() => new \App\Models\Repositories\Api\ApiOpenChatPageRepository()
-        );
-        app()->bind(
-            \App\Models\Repositories\Statistics\StatisticsPageRepositoryInterface::class,
-            fn() => new \App\Models\Repositories\Api\ApiStatisticsPageRepository()
-        );
+        app(ApiRepositoryServiceProvider::class)->register();
     });
 
 Route::path('oclist', [OpenChatRankingPageApiController::class, 'index'])

--- a/app/Models/Repositories/Api/ApiDeletedOpenChatListRepository.php
+++ b/app/Models/Repositories/Api/ApiDeletedOpenChatListRepository.php
@@ -47,7 +47,7 @@ class ApiDeletedOpenChatListRepository
             FROM
                 openchat_master om
             JOIN
-                ocgraph_ocreview.open_chat_deleted ocd ON om.line_internal_id = ocd.emid
+                ocgraph_ocreview.open_chat_deleted ocd ON om.openchat_id = ocd.id
             JOIN
                 categories c ON om.category_id = c.category_id
             WHERE

--- a/app/Models/Repositories/DeleteOpenChatRepository.php
+++ b/app/Models/Repositories/DeleteOpenChatRepository.php
@@ -15,8 +15,7 @@ class DeleteOpenChatRepository implements DeleteOpenChatRepositoryInterface
         private StatisticsRepositoryInterface $statisticsRepository,
         private RankingPositionRepositoryInterface $rankingPositionRepository,
         private DeleteCommentRepositoryInterface $deleteCommentRepository,
-    ) {
-    }
+    ) {}
 
     public function deleteOpenChat(int $open_chat_id): bool
     {
@@ -34,5 +33,16 @@ class DeleteOpenChatRepository implements DeleteOpenChatRepositoryInterface
         $this->deleteCommentRepository->deleteCommentsAll($open_chat_id);
 
         return $result;
+    }
+
+    public function insertDeletedOpenChat(int $open_chat_id, string $emid): void
+    {
+        DB::executeAndCheckResult(
+            "INSERT IGNORE INTO
+                open_chat_deleted (id, emid)
+            VALUES
+                (:open_chat_id, :emid)",
+            compact('open_chat_id', 'emid')
+        );
     }
 }

--- a/app/Models/Repositories/DeleteOpenChatRepositoryInterface.php
+++ b/app/Models/Repositories/DeleteOpenChatRepositoryInterface.php
@@ -7,4 +7,6 @@ namespace App\Models\Repositories;
 interface DeleteOpenChatRepositoryInterface
 {
     public function deleteOpenChat(int $open_chat_id): bool;
+
+    public function insertDeletedOpenChat(int $open_chat_id, string $emid): void;
 }

--- a/app/Models/Repositories/test/DeleteOpenChatRepositoryTest.php
+++ b/app/Models/Repositories/test/DeleteOpenChatRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Repositories\DeleteOpenChatRepository;
+use App\Models\Repositories\DeleteOpenChatRepositoryInterface;
+use App\Models\Repositories\DB;
+use PHPUnit\Framework\TestCase;
+
+class DeleteOpenChatRepositoryTest extends TestCase
+{
+    private DeleteOpenChatRepositoryInterface $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = app(DeleteOpenChatRepositoryInterface::class);
+        DB::connect();
+    }
+
+    public function testInsertDeletedOpenChat(): void
+    {
+        $openChatId = 12345;
+        $emid = 'test_emid_' . time();
+
+        // Test insertion
+        $this->repository->insertDeletedOpenChat($openChatId, $emid);
+
+        // Verify the record was inserted
+        $stmt = DB::$pdo->prepare(
+            "SELECT * FROM open_chat_deleted WHERE id = :id AND emid = :emid"
+        );
+        $stmt->execute(['id' => $openChatId, 'emid' => $emid]);
+        $result = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        $this->assertNotEmpty($result);
+        $this->assertEquals($openChatId, (int)$result['id']);
+        $this->assertEquals($emid, $result['emid']);
+
+        // Clean up - remove the test record
+        $stmt = DB::$pdo->prepare(
+            "DELETE FROM open_chat_deleted WHERE id = :id AND emid = :emid"
+        );
+        $stmt->execute(['id' => $openChatId, 'emid' => $emid]);
+    }
+
+    public function testInsertDeletedOpenChatIgnoresDuplicates(): void
+    {
+        $openChatId = 12346;
+        $emid = 'test_emid_duplicate_' . time();
+
+        // Insert first time
+        $this->repository->insertDeletedOpenChat($openChatId, $emid);
+
+        // Insert same record again (should be ignored due to INSERT IGNORE)
+        $this->repository->insertDeletedOpenChat($openChatId, $emid);
+
+        // Verify only one record exists
+        $stmt = DB::$pdo->prepare(
+            "SELECT COUNT(*) as count FROM open_chat_deleted WHERE id = :id AND emid = :emid"
+        );
+        $stmt->execute(['id' => $openChatId, 'emid' => $emid]);
+        $result = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        $this->assertEquals(1, (int)$result['count']);
+
+        // Clean up
+        $stmt = DB::$pdo->prepare(
+            "DELETE FROM open_chat_deleted WHERE id = :id AND emid = :emid"
+        );
+        $stmt->execute(['id' => $openChatId, 'emid' => $emid]);
+    }
+}

--- a/app/ServiceProvider/ApiOpenChatDeleterServiceProvider.php
+++ b/app/ServiceProvider/ApiOpenChatDeleterServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ServiceProvider;
+
+use App\Services\OpenChat\Api\ApiOpenChatDeleter;
+use App\Services\OpenChat\Updater\OpenChatDeleterInterface;
+
+class ApiOpenChatDeleterServiceProvider implements ServiceProviderInterface
+{
+    function register(): void
+    {
+        app()->bind(OpenChatDeleterInterface::class, ApiOpenChatDeleter::class);
+    }
+}

--- a/app/ServiceProvider/ApiRepositoryServiceProvider.php
+++ b/app/ServiceProvider/ApiRepositoryServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ServiceProvider;
+
+use App\Models\Repositories\OpenChatPageRepositoryInterface;
+use App\Models\Repositories\Api\ApiOpenChatPageRepository;
+use App\Models\Repositories\Statistics\StatisticsPageRepositoryInterface;
+use App\Models\Repositories\Api\ApiStatisticsPageRepository;
+
+class ApiRepositoryServiceProvider implements ServiceProviderInterface
+{
+    function register(): void
+    {
+        app()->bind(
+            OpenChatPageRepositoryInterface::class,
+            fn() => new ApiOpenChatPageRepository()
+        );
+        
+        app()->bind(
+            StatisticsPageRepositoryInterface::class,
+            fn() => new ApiStatisticsPageRepository()
+        );
+    }
+}

--- a/app/ServiceProvider/ApiRepositoryServiceProvider.php
+++ b/app/ServiceProvider/ApiRepositoryServiceProvider.php
@@ -13,14 +13,8 @@ class ApiRepositoryServiceProvider implements ServiceProviderInterface
 {
     function register(): void
     {
-        app()->bind(
-            OpenChatPageRepositoryInterface::class,
-            fn() => new ApiOpenChatPageRepository()
-        );
-        
-        app()->bind(
-            StatisticsPageRepositoryInterface::class,
-            fn() => new ApiStatisticsPageRepository()
-        );
+        app()->bind(OpenChatPageRepositoryInterface::class, ApiOpenChatPageRepository::class);
+
+        app()->bind(StatisticsPageRepositoryInterface::class, ApiStatisticsPageRepository::class);
     }
 }

--- a/app/ServiceProvider/ServiceProviderInterface.php
+++ b/app/ServiceProvider/ServiceProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ServiceProvider;
+
+interface ServiceProviderInterface
+{
+    function register(): void;
+}

--- a/app/ServiceProvider/test/AbstractServiceProviderTestCase.php
+++ b/app/ServiceProvider/test/AbstractServiceProviderTestCase.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ServiceProvider\test;
+
+use PHPUnit\Framework\TestCase;
+use Shadow\Kernel\Application;
+
+abstract class AbstractServiceProviderTestCase extends TestCase
+{
+    protected Application $app;
+    
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app = new Application();
+    }
+    
+    /**
+     * Test that a service provider correctly binds interfaces to implementations
+     *
+     * @param string $serviceProviderClass The service provider class to test
+     * @param array $bindings Array of [interface => implementation] pairs to verify
+     */
+    protected function assertServiceProviderBindings(string $serviceProviderClass, array $bindings): void
+    {
+        $serviceProvider = new $serviceProviderClass();
+        $serviceProvider->register();
+        
+        foreach ($bindings as $interface => $implementation) {
+            $resolved = $this->app->make($interface);
+            
+            $this->assertInstanceOf(
+                $implementation,
+                $resolved,
+                "Failed to bind {$interface} to {$implementation}"
+            );
+            
+            $this->assertInstanceOf(
+                $interface,
+                $resolved,
+                "Resolved class does not implement {$interface}"
+            );
+        }
+    }
+    
+    /**
+     * Test that singleton bindings work correctly
+     *
+     * @param string $serviceProviderClass The service provider class to test
+     * @param array $singletons Array of interfaces that should be singletons
+     */
+    protected function assertServiceProviderSingletons(string $serviceProviderClass, array $singletons): void
+    {
+        $serviceProvider = new $serviceProviderClass();
+        $serviceProvider->register();
+        
+        foreach ($singletons as $interface) {
+            $instance1 = $this->app->make($interface);
+            $instance2 = $this->app->make($interface);
+            
+            $this->assertSame(
+                $instance1,
+                $instance2,
+                "{$interface} should be registered as a singleton"
+            );
+        }
+    }
+    
+    /**
+     * Test that non-singleton bindings create new instances
+     *
+     * @param string $serviceProviderClass The service provider class to test
+     * @param array $nonSingletons Array of interfaces that should NOT be singletons
+     */
+    protected function assertServiceProviderNonSingletons(string $serviceProviderClass, array $nonSingletons): void
+    {
+        $serviceProvider = new $serviceProviderClass();
+        $serviceProvider->register();
+        
+        foreach ($nonSingletons as $interface) {
+            $instance1 = $this->app->make($interface);
+            $instance2 = $this->app->make($interface);
+            
+            $this->assertNotSame(
+                $instance1,
+                $instance2,
+                "{$interface} should NOT be registered as a singleton"
+            );
+        }
+    }
+}

--- a/app/ServiceProvider/test/ApiOpenChatDeleterServiceProviderTest.php
+++ b/app/ServiceProvider/test/ApiOpenChatDeleterServiceProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ServiceProvider\test;
+
+use App\ServiceProvider\ApiOpenChatDeleterServiceProvider;
+use App\Services\OpenChat\Api\ApiOpenChatDeleter;
+use App\Services\OpenChat\Updater\OpenChatDeleterInterface;
+
+class ApiOpenChatDeleterServiceProviderTest extends AbstractServiceProviderTestCase
+{
+    public function testRegisterBindsCorrectly(): void
+    {
+        $this->assertServiceProviderBindings(
+            ApiOpenChatDeleterServiceProvider::class,
+            [
+                OpenChatDeleterInterface::class => ApiOpenChatDeleter::class
+            ]
+        );
+    }
+    
+    public function testBindingsAreNotSingletons(): void
+    {
+        $this->assertServiceProviderNonSingletons(
+            ApiOpenChatDeleterServiceProvider::class,
+            [
+                OpenChatDeleterInterface::class
+            ]
+        );
+    }
+}

--- a/app/ServiceProvider/test/ApiRepositoryServiceProviderTest.php
+++ b/app/ServiceProvider/test/ApiRepositoryServiceProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ServiceProvider\test;
+
+use App\ServiceProvider\ApiRepositoryServiceProvider;
+use App\Models\Repositories\OpenChatPageRepositoryInterface;
+use App\Models\Repositories\Api\ApiOpenChatPageRepository;
+use App\Models\Repositories\Statistics\StatisticsPageRepositoryInterface;
+use App\Models\Repositories\Api\ApiStatisticsPageRepository;
+
+class ApiRepositoryServiceProviderTest extends AbstractServiceProviderTestCase
+{
+    public function testRegisterBindsCorrectly(): void
+    {
+        $this->assertServiceProviderBindings(
+            ApiRepositoryServiceProvider::class,
+            [
+                OpenChatPageRepositoryInterface::class => ApiOpenChatPageRepository::class,
+                StatisticsPageRepositoryInterface::class => ApiStatisticsPageRepository::class
+            ]
+        );
+    }
+    
+    public function testBindingsAreNotSingletons(): void
+    {
+        $this->assertServiceProviderNonSingletons(
+            ApiRepositoryServiceProvider::class,
+            [
+                OpenChatPageRepositoryInterface::class,
+                StatisticsPageRepositoryInterface::class
+            ]
+        );
+    }
+}

--- a/app/Services/OpenChat/Api/ApiOpenChatDeleter.php
+++ b/app/Services/OpenChat/Api/ApiOpenChatDeleter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\OpenChat\Api;
 
+use App\Models\Repositories\DeleteOpenChatRepositoryInterface;
 use App\Services\OpenChat\Crawler\OpenChatUrlChecker;
 use App\Services\OpenChat\Dto\OpenChatRepositoryDto;
 use App\Services\OpenChat\Updater\OpenChatDeleter;
@@ -14,11 +15,15 @@ class ApiOpenChatDeleter implements OpenChatDeleterInterface
     function __construct(
         private OpenChatDeleter $openChatDeleter,
         private OpenChatUrlChecker $openChatUrlChecker,
+        private DeleteOpenChatRepositoryInterface $deleteOpenChatRepository,
     ) {}
 
     function deleteOpenChat(OpenChatRepositoryDto $repoDto): void
     {
         $this->openChatDeleter->deleteOpenChat($repoDto);
-        $this->openChatUrlChecker->isOpenChatUrlAvailable($repoDto->invitationTicket);
+
+        if (!$this->openChatUrlChecker->isOpenChatUrlAvailable($repoDto->invitationTicket)) {
+            $this->deleteOpenChatRepository->insertDeletedOpenChat($repoDto->open_chat_id, '');
+        }
     }
 }

--- a/app/Services/OpenChat/Api/ApiOpenChatDeleter.php
+++ b/app/Services/OpenChat/Api/ApiOpenChatDeleter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\OpenChat\Api;
+
+use App\Services\OpenChat\Crawler\OpenChatUrlChecker;
+use App\Services\OpenChat\Dto\OpenChatRepositoryDto;
+use App\Services\OpenChat\Updater\OpenChatDeleter;
+use App\Services\OpenChat\Updater\OpenChatDeleterInterface;
+
+class ApiOpenChatDeleter implements OpenChatDeleterInterface
+{
+    function __construct(
+        private OpenChatDeleter $openChatDeleter,
+        private OpenChatUrlChecker $openChatUrlChecker,
+    ) {}
+
+    function deleteOpenChat(OpenChatRepositoryDto $repoDto): void
+    {
+        $this->openChatDeleter->deleteOpenChat($repoDto);
+        $this->openChatUrlChecker->isOpenChatUrlAvailable($repoDto->invitationTicket);
+    }
+}

--- a/app/Services/OpenChat/Dto/OpenChatRepositoryDto.php
+++ b/app/Services/OpenChat/Dto/OpenChatRepositoryDto.php
@@ -20,7 +20,7 @@ class OpenChatRepositoryDto
     private string $local_img_url;
 
     /**
-     * @param array{ emid: string, name: string, description: string, img_url: string, local_img_url: string, member: string, api_created_at: int | null, category: int | null, emblem: int | null }[] $openChatData
+     * @param array{ emid: string, name: string, description: string, img_url: string, local_img_url: string, member: int, api_created_at: int | null, category: int | null, emblem: int | null } $openChatData
      */
     function __construct(int $id, array $openChatData)
     {

--- a/app/Services/OpenChat/Updater/OpenChatDeleter.php
+++ b/app/Services/OpenChat/Updater/OpenChatDeleter.php
@@ -6,6 +6,7 @@ namespace App\Services\OpenChat\Updater;
 
 use App\Services\OpenChat\Dto\OpenChatUpdaterDtoFactory;
 use App\Models\Repositories\UpdateOpenChatRepositoryInterface;
+use App\Services\OpenChat\Dto\OpenChatRepositoryDto;
 use App\Services\OpenChat\Store\OpenChatImageStore;
 
 class OpenChatDeleter implements OpenChatDeleterInterface
@@ -17,10 +18,10 @@ class OpenChatDeleter implements OpenChatDeleterInterface
     ) {
     }
 
-    function deleteOpenChat(int $open_chat_id, string $imgUrl): void
+    function deleteOpenChat(OpenChatRepositoryDto $repoDto): void
     {
-        $updaterDto = $this->openChatUpdaterDtoFactory->mapToDeleteOpenChatDto($open_chat_id);
+        $updaterDto = $this->openChatUpdaterDtoFactory->mapToDeleteOpenChatDto($repoDto->open_chat_id);
         $this->updateRepository->updateOpenChatRecord($updaterDto);
-        $this->openChatImageStore->deleteImage($open_chat_id, $imgUrl);
+        $this->openChatImageStore->deleteImage($repoDto->open_chat_id, $repoDto->getLocalImgUrl());
     }
 }

--- a/app/Services/OpenChat/Updater/OpenChatDeleterInterface.php
+++ b/app/Services/OpenChat/Updater/OpenChatDeleterInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\OpenChat\Updater;
 
+use App\Services\OpenChat\Dto\OpenChatRepositoryDto;
+
 interface OpenChatDeleterInterface
 {
     /**
@@ -12,5 +14,5 @@ interface OpenChatDeleterInterface
      * @param int $open_chat_id The ID of the open chat to delete.
      * @param string $imgUrl The URL of the image associated with the open chat.
      */
-    function deleteOpenChat(int $open_chat_id, string $imgUrl): void;
+    function deleteOpenChat(OpenChatRepositoryDto $repoDto): void;
 }

--- a/app/Services/OpenChat/Updater/Process/OpenChatApiDbMergerProcess.php
+++ b/app/Services/OpenChat/Updater/Process/OpenChatApiDbMergerProcess.php
@@ -9,7 +9,6 @@ use App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepositoryInterface;
 use App\Models\Repositories\OpenChatRepositoryInterface;
 use App\Services\OpenChat\Dto\OpenChatDto;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
-use App\Models\Repositories\DB;
 
 class OpenChatApiDbMergerProcess
 {

--- a/app/Services/OpenChat/Updater/Process/OpenChatMargeUpdateProcess.php
+++ b/app/Services/OpenChat/Updater/Process/OpenChatMargeUpdateProcess.php
@@ -24,7 +24,7 @@ class OpenChatMargeUpdateProcess
     function mergeUpdateOpenChat(OpenChatRepositoryDto $repoDto, OpenChatDto|false $ocDto, bool $updateMember = true): OpenChatUpdaterDto|false
     {
         if ($ocDto === false || OpenChatServicesUtility::containsHashtagNolog($ocDto)) {
-            $this->openChatDeleter->deleteOpenChat($repoDto->open_chat_id, $repoDto->getLocalImgUrl());
+            $this->openChatDeleter->deleteOpenChat($repoDto);
             return false;
         }
 

--- a/batch/cron/cron_crawling.php
+++ b/batch/cron/cron_crawling.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use App\Config\AppConfig;
+use App\ServiceProvider\ApiOpenChatDeleterServiceProvider;
 use App\Services\Cron\SyncOpenChat;
 use App\Services\Admin\AdminTool;
 use Shared\MimimalCmsConfig;
@@ -10,6 +11,10 @@ use Shared\MimimalCmsConfig;
 try {
     if (isset($argv[1]) && $argv[1]) {
         MimimalCmsConfig::$urlRoot = $argv[1];
+    }
+
+    if (!MimimalCmsConfig::$urlRoot) {
+        app(ApiOpenChatDeleterServiceProvider::class)->register();
     }
 
     /**
@@ -25,7 +30,7 @@ try {
 
     if (!MimimalCmsConfig::$urlRoot) {
         set_time_limit(3600);
-        
+
         // Create an instance of OcreviewApiDataImporter
         $importer = app(\App\Services\Cron\OcreviewApiDataImporter::class);
 

--- a/batch/cron/cron_half_check.php
+++ b/batch/cron/cron_half_check.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+use App\ServiceProvider\ApiOpenChatDeleterServiceProvider;
 use App\Services\Cron\SyncOpenChat;
 use App\Services\Admin\AdminTool;
 use Shared\MimimalCmsConfig;
@@ -9,6 +10,10 @@ use Shared\MimimalCmsConfig;
 try {
     if (isset($argv[1]) && $argv[1]) {
         MimimalCmsConfig::$urlRoot = $argv[1];
+    }
+
+    if (!MimimalCmsConfig::$urlRoot) {
+        app(ApiOpenChatDeleterServiceProvider::class)->register();
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a service provider pattern for repository and deleter bindings, refactors the open chat deletion workflow to use DTOs, and adds new methods and tests for managing deleted open chats. The changes improve code modularity, testability, and maintainability by centralizing dependency bindings and updating interfaces for more robust data handling.

**Service Provider Pattern and Dependency Injection**

* Added `ApiRepositoryServiceProvider` and `ApiOpenChatDeleterServiceProvider` to centralize and standardize the binding of repository and deleter interfaces to their implementations. Updated routing and batch scripts to use these providers for dependency registration. [[1]](diffhunk://#diff-14159c53b3423869597dfc5fe31643f9eef82f18e55e75a84bd14dd9ccac1c82R1-R20) [[2]](diffhunk://#diff-0b7f46c9ebdc81218427e6d4dc2666d024ece7f3e69f8fd4c33596c6efc43894R1-R16) [[3]](diffhunk://#diff-4668321722c352d744750a3db395ce55c3cdcde7b72803d6ac55eaf0ea19b3a0R1-R10) [[4]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R31) [[5]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L79-R80) [[6]](diffhunk://#diff-31c70b8e0c4702b77323a186aca504a2207cfa8b584bac6d70a2a56a16cc2559R6) [[7]](diffhunk://#diff-31c70b8e0c4702b77323a186aca504a2207cfa8b584bac6d70a2a56a16cc2559R16-R19) [[8]](diffhunk://#diff-30157b26773799e9e755e53565c0666228f74a8fae2b91ec1165dd06f9c0d53bR5) [[9]](diffhunk://#diff-30157b26773799e9e755e53565c0666228f74a8fae2b91ec1165dd06f9c0d53bR15-R18)

* Added comprehensive test coverage for service providers, including abstract test cases and specific tests for binding and singleton behavior. [[1]](diffhunk://#diff-23cc4db60e9829b4ea43f379ac5768b3882c23b4e787568743579bb1de36db1dR1-R93) [[2]](diffhunk://#diff-b96167169c4dcfa156d207cd80f1e48bb119833b2b1f7a3f8abdc10a0aa98b4cR1-R32) [[3]](diffhunk://#diff-e7c1625e5d0ccec71da38f9ec0e0b8f6f12fb037702053a379c228658dfa648bR1-R36)

**Open Chat Deletion Workflow Refactor**

* Updated `OpenChatDeleterInterface` and its implementations to accept an `OpenChatRepositoryDto` instead of separate parameters, and refactored related code to use the new DTO-based method signature. [[1]](diffhunk://#diff-b5f0827c05cc145eee099ae8cda70ada77fa13a6b250d08e52aa5b6979b8680dR9) [[2]](diffhunk://#diff-b5f0827c05cc145eee099ae8cda70ada77fa13a6b250d08e52aa5b6979b8680dL20-R25) [[3]](diffhunk://#diff-250c1b1fe2e9bc6b7e551779e7108125df12af2c97df5f2c3d44c29613ff69f9R7-R8) [[4]](diffhunk://#diff-250c1b1fe2e9bc6b7e551779e7108125df12af2c97df5f2c3d44c29613ff69f9L15-R17) [[5]](diffhunk://#diff-fd5cd2fef7296dd26777686841cbfa6855253e54b6859be88a7d3ffff99c020bL27-R27) [[6]](diffhunk://#diff-80c1045d1695d719859a063064fe16d715f2b70322259d095fb80a20f4503a50R1-R29)

**Deleted Open Chat Management**

* Added `insertDeletedOpenChat` method to `DeleteOpenChatRepository` and its interface, allowing insertion of deleted open chat records. Updated SQL join logic for consistency. [[1]](diffhunk://#diff-3b67e32432aba9fa5f098b25a6f224860e42534cc84bf56042d8a74aae149f10R37-R47) [[2]](diffhunk://#diff-07739088a0d0a5275f685a8fdefc265a10beb58da08a8ff0ff304236fe568edbR10-R11) [[3]](diffhunk://#diff-e288045ab032b42978d92e7c5e539c85625e0cbb4d308e8603e59e63254e69ebL50-R50)

* Added tests for the new `insertDeletedOpenChat` method, including duplicate handling and cleanup logic.

**Minor DTO and Codebase Updates**

* Corrected the `member` field type in `OpenChatRepositoryDto` from `string` to `int` for type safety.

* Minor code style and constructor simplifications. [[1]](diffhunk://#diff-3b67e32432aba9fa5f098b25a6f224860e42534cc84bf56042d8a74aae149f10L18-R18) [[2]](diffhunk://#diff-4737625c524aced5ee245c2c12ad3b201b8e82b542e324b41f85f59cfe7931edL12)