### PR TITLE
fix: 日次データ更新処理のretry時の誤通知とプロセス終了処理を修正

### DIFF
--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -337,6 +337,45 @@ function isDailyUpdateTime(
     return false;
 }
 
+/**
+ * Daily Cron開始時刻からの経過時間を計算
+ *
+ * @param string|null $urlRoot 言語（null = 現在の言語）
+ * @param DateTime|null $currentTime 現在時刻（null = 現在時刻）
+ * @return float 経過時間（時間単位）
+ */
+function getDailyCronElapsedHours(?string $urlRoot = null, ?DateTime $currentTime = null): float
+{
+    $urlRoot = $urlRoot ?? MimimalCmsConfig::$urlRoot;
+    $currentTime = $currentTime ?? new DateTime();
+
+    $cronStartTime = (new DateTime())->setTime(
+        AppConfig::CRON_MERGER_HOUR_RANGE_START[$urlRoot],
+        AppConfig::CRON_START_MINUTE[$urlRoot],
+        0
+    );
+
+    // cronが前日開始の場合
+    if ($cronStartTime > $currentTime) {
+        $cronStartTime->modify('-1 day');
+    }
+
+    return ($currentTime->getTimestamp() - $cronStartTime->getTimestamp()) / 3600;
+}
+
+/**
+ * Daily Cronが指定時間以内に開始されたかチェック
+ *
+ * @param float $withinHours 開始から何時間以内か
+ * @param string|null $urlRoot 言語（null = 現在の言語）
+ * @param DateTime|null $currentTime 現在時刻（null = 現在時刻）
+ * @return bool 指定時間以内ならtrue
+ */
+function isDailyCronWithinHours(float $withinHours, ?string $urlRoot = null, ?DateTime $currentTime = null): bool
+{
+    return getDailyCronElapsedHours($urlRoot, $currentTime) < $withinHours;
+}
+
 function checkLineSiteRobots(int $retryLimit = 3, int $retryInterval = 1): string
 {
     $retryCount = 0;

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -9,6 +9,7 @@ use App\Services\Admin\AdminTool;
 use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
 use App\Services\OpenChat\OpenChatApiDbMerger;
 use App\Services\DailyUpdateCronService;
+use App\Services\OpenChat\OpenChatApiDbMergerWithParallelDownloader;
 use App\Services\OpenChat\OpenChatDailyCrawling;
 use App\Services\OpenChat\OpenChatDailyCrawlingParallel;
 use App\Services\OpenChat\OpenChatHourlyInvitationTicketUpdater;
@@ -155,6 +156,7 @@ class SyncOpenChat
     {
         addCronLog('Retry hourlyTask');
         OpenChatApiDbMerger::setKillFlagTrue();
+        OpenChatApiDbMergerWithParallelDownloader::setKillFlagTrue();
         sleep(30);
 
         $this->handle();
@@ -197,6 +199,7 @@ class SyncOpenChat
 
         addCronLog('Retry dailyTask');
         OpenChatApiDbMerger::setKillFlagTrue();
+        OpenChatApiDbMergerWithParallelDownloader::setKillFlagTrue();
         OpenChatDailyCrawling::setKillFlagTrue();
         OpenChatDailyCrawlingParallel::setKillFlagTrue();
         sleep(30);

--- a/batch/cron/cron_crawling.php
+++ b/batch/cron/cron_crawling.php
@@ -39,5 +39,18 @@ try {
     }
 } catch (\Throwable $e) {
     addCronLog($e->__toString());
-    AdminTool::sendDiscordNotify($e->__toString());
+
+    // killフラグによる強制終了の場合、開始から10時間以内ならDiscord通知しない
+    $shouldNotify = true;
+    if ($e instanceof \App\Exceptions\ApplicationException && $e->getCode() === AppConfig::DAILY_UPDATE_EXCEPTION_ERROR_CODE) {
+        if (isDailyCronWithinHours(10)) {
+            $shouldNotify = false;
+            $elapsedHours = getDailyCronElapsedHours();
+            addCronLog("killフラグによる強制終了（開始から" . round($elapsedHours, 2) . "時間経過）Discord通知スキップ");
+        }
+    }
+
+    if ($shouldNotify) {
+        AdminTool::sendDiscordNotify($e->__toString());
+    }
 }

--- a/batch/cron/cron_half_check.php
+++ b/batch/cron/cron_half_check.php
@@ -25,5 +25,18 @@ try {
     $syncOpenChat->handleHalfHourCheck();
 } catch (\Throwable $e) {
     addCronLog($e->__toString());
-    AdminTool::sendDiscordNotify($e->__toString());
+
+    // killフラグによる強制終了の場合、開始から10時間以内ならDiscord通知しない
+    $shouldNotify = true;
+    if ($e instanceof \App\Exceptions\ApplicationException && $e->getCode() === AppConfig::DAILY_UPDATE_EXCEPTION_ERROR_CODE) {
+        if (isDailyCronWithinHours(10)) {
+            $shouldNotify = false;
+            $elapsedHours = getDailyCronElapsedHours();
+            addCronLog("killフラグによる強制終了（開始から" . round($elapsedHours, 2) . "時間経過）Discord通知スキップ");
+        }
+    }
+
+    if ($shouldNotify) {
+        AdminTool::sendDiscordNotify($e->__toString());
+    }
 }


### PR DESCRIPTION
## 問題の概要
PR #73 で実装した日次データ更新処理の最適化において、以下の問題が残っていました。

### 1. クローリング処理時間の増加によるretry時のDiscord誤通知
当初の設計よりもクローリングに時間がかかるようになったため、次の時間の毎時処理に間に合わずリトライが発生し、その度にDiscord通知が来る問題がありました。処理開始から10時間以内のkillフラグ終了は通知を無効化することで対処しました。

**修正前：** [batch/cron/cron_crawling.php:40-42](https://github.com/mimimiku778/Open-Chat-Graph/blob/f34a80c3a19d602e680c43d47dbb640f85be32f0/batch/cron/cron_crawling.php#L40-L42)  
**修正後：** [batch/cron/cron_crawling.php:42-54](https://github.com/mimimiku778/Open-Chat-Graph/blob/0555c6da/batch/cron/cron_crawling.php#L42-L54)

### 2. 子プロセスのkillフラグチェック漏れ
子プロセスがkillフラグをチェックしていないため、親プロセスが終了要求を出しても子プロセスが残り続ける可能性がありました。各ループでkillフラグをチェックして自主的に終了するように修正しました。

**修正前：** [batch/exec/daily_crawling_child.php:50-70](https://github.com/mimimiku778/Open-Chat-Graph/blob/f34a80c3a19d602e680c43d47dbb640f85be32f0/batch/exec/daily_crawling_child.php#L50-L70)  
**修正後：** [batch/exec/daily_crawling_child.php:57-61](https://github.com/mimimiku778/Open-Chat-Graph/blob/0555c6da/batch/exec/daily_crawling_child.php#L57-L61)

### 3. OpenChatApiDbMergerWithParallelDownloaderのkillフラグ設定漏れ
retry時に、OpenChatApiDbMergerWithParallelDownloaderのkillフラグが設定されていないため、このプロセスが実行中の場合、killフラグで終了できませんでした。

**修正前：** [app/Services/Cron/SyncOpenChat.php:155-160](https://github.com/mimimiku778/Open-Chat-Graph/blob/f34a80c3a19d602e680c43d47dbb640f85be32f0/app/Services/Cron/SyncOpenChat.php#L155-L160)  
**修正後：** [app/Services/Cron/SyncOpenChat.php:157-159](https://github.com/mimimiku778/Open-Chat-Graph/blob/0555c6da/app/Services/Cron/SyncOpenChat.php#L157-L159)

### 4. 親プロセスでのkillフラグ最終チェック漏れ
子プロセスがkillフラグで終了した場合、親プロセスがそれを検知できないため、例外が投げられずに処理が続行される問題がありました。全プロセス終了後に最終チェックを追加しました。

**修正前：** [app/Services/OpenChat/OpenChatDailyCrawlingParallel.php:130-138](https://github.com/mimimiku778/Open-Chat-Graph/blob/f34a80c3a19d602e680c43d47dbb640f85be32f0/app/Services/OpenChat/OpenChatDailyCrawlingParallel.php#L130-L138)  
**修正後：** [app/Services/OpenChat/OpenChatDailyCrawlingParallel.php:140-142](https://github.com/mimimiku778/Open-Chat-Graph/blob/0555c6da/app/Services/OpenChat/OpenChatDailyCrawlingParallel.php#L140-L142)

### 5. 不要なAPI待機
並列化しているため、子プロセス側のusleep(100000)は不要でした（親プロセス側で既に実行しているため）。削除しました。

**修正前：** [batch/exec/daily_crawling_child.php:70-71](https://github.com/mimimiku778/Open-Chat-Graph/blob/f34a80c3a19d602e680c43d47dbb640f85be32f0/batch/exec/daily_crawling_child.php#L70-L71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)