### PR TITLE
fix: 初回実行時のファイル存在チェックエラーを修正

### DIFF
--- a/app/Services/UpdateHourlyMemberRankingService.php
+++ b/app/Services/UpdateHourlyMemberRankingService.php
@@ -72,7 +72,7 @@ class UpdateHourlyMemberRankingService
 
         // キャッシュの日付ファイルをチェック
         $cacheDateFilePath = AppConfig::getStorageFilePath('openChatHourFilterIdDate');
-        $cachedDate = @file_get_contents($cacheDateFilePath);
+        $cachedDate = file_exists($cacheDateFilePath) ? file_get_contents($cacheDateFilePath) : false;
 
         // すでに今日のキャッシュがある場合はスキップ
         // dailyTaskが同じ日に複数回実行されても、データ取得は1回のみ


### PR DESCRIPTION
## 問題

タイ版などで初回実行時に `filter_date.dat` が存在しない場合、エラーが発生：

```
ErrorException: file_get_contents(/home/ocgraph/.../storage/th/ranking_position/filter_date.dat): 
Failed to open stream: No such file or directory
in app/Services/UpdateHourlyMemberRankingService.php:75
```

## 原因

カスタムエラーハンドラーが設定されている環境では、`@` 演算子によるエラー抑制が効かない。

## 対処内容

**変更箇所**: [`app/Services/UpdateHourlyMemberRankingService.php:75`](https://github.com/mimimiku778/Open-Chat-Graph/blob/fix/filter-date-file-not-found/app/Services/UpdateHourlyMemberRankingService.php#L75)

```php
// 修正前
$cachedDate = @file_get_contents($cacheDateFilePath);

// 修正後
$cachedDate = file_exists($cacheDateFilePath) ? file_get_contents($cacheDateFilePath) : false;
```

`file_exists()` で明示的にチェックしてから読み込むように変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)