### PR TITLE
perf: 毎時ランキング更新処理の実行時間を20分短縮（バックグラウンド処理化）

### DIFF
--- a/app/Services/Cron/Enum/SyncOpenChatStateType.php
+++ b/app/Services/Cron/Enum/SyncOpenChatStateType.php
@@ -11,6 +11,7 @@ enum SyncOpenChatStateType: string
     case openChatApiDbMergerKillFlag = 'openChatApiDbMergerKillFlag';
     case openChatDailyCrawlingKillFlag = 'openChatDailyCrawlingKillFlag';
     case isUpdateInvitationTicketActive = 'isUpdateInvitationTicketActive';
+    case isUpdateRecommendStaticDataActive = 'isUpdateRecommendStaticDataActive';
     case persistMemberStatsLastDate = 'persistMemberStatsLastDate';
     case filterCacheDate = 'filterCacheDate';
 }

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -120,7 +120,7 @@ class SyncOpenChat
             [fn() => $this->OpenChatImageUpdater->hourlyImageUpdate(), '毎時画像更新'],
             [fn() => $this->hourlyMemberColumn->update(), '毎時メンバーカラム更新'],
             [fn() => $this->hourlyMemberRanking->update(), '毎時メンバーランキング関連の処理'],
-            [fn() => purgeCacheCloudFlare(), 'CDNキャッシュ削除'],
+            // CDNキャッシュ削除はバックグラウンドバッチに移行（update_recommend_static_data.php）
             [function () {
                 if ($this->state->getBool(StateType::isUpdateInvitationTicketActive)) {
                     // 既に実行中の場合は1回だけスキップする

--- a/batch/exec/update_recommend_static_data.php
+++ b/batch/exec/update_recommend_static_data.php
@@ -1,0 +1,68 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
+use App\Services\Admin\AdminTool;
+use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\Recommend\StaticData\RecommendStaticDataGenerator;
+use Shared\MimimalCmsConfig;
+
+set_time_limit(3600 * 2);
+
+try {
+    if (isset($argv[1]) && $argv[1]) {
+        MimimalCmsConfig::$urlRoot = $argv[1];
+    }
+
+    /**
+     * @var SyncOpenChatStateRepositoryInterface $state
+     */
+    $state = app(SyncOpenChatStateRepositoryInterface::class);
+
+    // 既に実行中の場合はkill
+    if ($state->getBool(StateType::isUpdateRecommendStaticDataActive)) {
+        $message = 'おすすめ静的データ生成: 既に実行中のため前回の処理をkill';
+        addCronLog($message);
+        AdminTool::sendDiscordNotify($message);
+
+        // 自分以外のバックグラウンドプロセスをkill
+        $myPid = getmypid();
+        $cmd = "ps aux | grep update_recommend_static_data.php | grep -v grep | grep -v '{$myPid}' | awk '{print \$2}' | xargs -r kill";
+        exec($cmd, $output, $returnCode);
+        addCronLog('kill結果: ' . implode(' ', $output) . ' (return code: ' . $returnCode . ')');
+
+        $state->setFalse(StateType::isUpdateRecommendStaticDataActive);
+        sleep(5); // プロセス終了を待つ
+    }
+
+    // 実行中フラグを立てる
+    $state->setTrue(StateType::isUpdateRecommendStaticDataActive);
+
+    /**
+     * @var RecommendStaticDataGenerator $recommendStaticDataGenerator
+     */
+    $recommendStaticDataGenerator = app(RecommendStaticDataGenerator::class);
+
+    addVerboseCronLog('おすすめ静的データを生成中（バックグラウンド）');
+
+    $recommendStaticDataGenerator->updateStaticData();
+
+    addVerboseCronLog('おすすめ静的データ生成完了（バックグラウンド）');
+
+    // CDNキャッシュ削除
+    addVerboseCronLog('CDNキャッシュ削除中（バックグラウンド）');
+    purgeCacheCloudFlare();
+    addVerboseCronLog('CDNキャッシュ削除完了（バックグラウンド）');
+
+    // 実行中フラグを下ろす
+    $state->setFalse(StateType::isUpdateRecommendStaticDataActive);
+} catch (\Throwable $e) {
+    addCronLog($e->__toString());
+    AdminTool::sendDiscordNotify($e->__toString());
+
+    // エラー時もフラグを下ろす
+    if (isset($state)) {
+        $state->setFalse(StateType::isUpdateRecommendStaticDataActive);
+    }
+}


### PR DESCRIPTION
## 問題の概要

毎時30分に実行されるランキング更新処理において、おすすめ静的データ生成とCDNキャッシュ削除に約20分かかり、その間メイン処理がブロックされていた問題を解決。

## 対処内容

### 1. おすすめ静的データ生成とCDNキャッシュ削除をバックグラウンド化
- 新規バッチファイル [`batch/exec/update_recommend_static_data.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/fa0aba64/batch/exec/update_recommend_static_data.php) を作成
- 約20分かかる処理を非同期実行に切り出し

### 2. 同時実行防止機構の実装
- [`SyncOpenChatStateType::isUpdateRecommendStaticDataActive`](https://github.com/mimimiku778/Open-Chat-Graph/blob/fa0aba64/app/Services/Cron/Enum/SyncOpenChatStateType.php#L14) フラグを追加
- 既に実行中の場合は前回のプロセスをkill（自分自身のPIDは除外）
- Discord通知でkill状況を記録

### 3. 毎時処理からの切り出し
- [`UpdateHourlyMemberRankingService::updateStaticData()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/fa0aba64/app/Services/UpdateHourlyMemberRankingService.php#L45-L55): バックグラウンド起動に変更
- [`SyncOpenChat::hourlyTaskAfterDbMerge()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/fa0aba64/app/Services/Cron/SyncOpenChat.php#L123): CDNキャッシュ削除処理を削除（バックグラウンドバッチに移行）

## 効果

- 毎時ランキング更新処理のブロッキング時間が約20分短縮
- メイン処理がより高速に完了し、他の処理への影響を軽減
- バックグラウンドで並行実行されるため、全体の処理効率が向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)