### PR TITLE
fix: SQLiteデータベースの並行アクセスエラーを解決（WALモード導入）

### DIFF
--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -38,6 +38,15 @@ abstract class AbstractSQLite extends DB implements DBInterface
 
         static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode);
 
+        // Enable WAL mode for concurrent read/write performance
+        static::$pdo->exec('PRAGMA journal_mode=WAL');
+
+        // Set synchronous mode to NORMAL for balanced performance
+        static::$pdo->exec('PRAGMA synchronous=NORMAL');
+
+        // Set busy timeout to 10 seconds to handle concurrent access
+        static::$pdo->exec('PRAGMA busy_timeout=10000');
+
         return static::$pdo;
     }
 

--- a/app/Models/SQLite/SQLiteOcgraphSqlapi.php
+++ b/app/Models/SQLite/SQLiteOcgraphSqlapi.php
@@ -38,6 +38,16 @@ class SQLiteOcgraphSqlapi extends AbstractSQLite implements DBInterface
         $mode = $config['mode'] ?? '?mode=rwc';
         static::$pdo = new \PDO('sqlite:file:' . AppConfig::SQLITE_OCGRAPH_SQLAPI_DB_PATH . $mode);
 
+        // Apply SQLite optimizations (inherited from AbstractSQLite pattern)
+        // Enable WAL mode for concurrent read/write performance
+        static::$pdo->exec('PRAGMA journal_mode=WAL');
+
+        // Set synchronous mode to NORMAL for balanced performance
+        static::$pdo->exec('PRAGMA synchronous=NORMAL');
+
+        // Set busy timeout to 10 seconds to handle concurrent access
+        static::$pdo->exec('PRAGMA busy_timeout=10000');
+
         return static::$pdo;
     }
 }


### PR DESCRIPTION
## 問題の概要

SQLiteデータベースへの並行アクセス時に `SQLSTATE[HY000]: General error: 5 database is locked` エラーが稀に発生し、データ更新処理が失敗する問題。

### ログから見る実際の状況

**エラー発生時のタイムライン（2026-01-11 02:13）**

```
01:35  クローリング処理：LINE公式APIからランキングデータ取得完了
01:35  クローリング処理：全部のランキングを取得中
00:35~ 毎時データ同期：統計データベース（SQLite）を読み取り専用で長時間オープン中
       ↓
02:13  ❌ エラー発生：database is locked
```

**問題の発生メカニズム**

オープンチャットのクローリングシステムは、新規オープンチャットを発見すると即座に統計データベース（SQLite）へ初期レコードを書き込みます。一方、毎時実行されるAPI用データ同期処理（[`OcreviewApiDataImporter`](https://github.com/mimimiku778/Open-Chat-Graph/blob/main/app/Services/Cron/OcreviewApiDataImporter.php#L114-L122)）が統計データベースを読み取り専用で長時間オープンしている間に、この書き込みが発生すると、SQLiteのデフォルト設定（DELETEジャーナルモード）では以下のロック競合が起きます：

1. **読み取り側**：`OcreviewApiDataImporter` が SHARED LOCK を数分〜数十分保持
2. **書き込み側**：新規オープンチャット発見時に EXCLUSIVE LOCK が必要
3. **結果**：`busy_timeout=0`（デフォルト）のため、即座にエラー

**エラーのスタックトレース**

```
SqliteStatisticsRepository::addNewOpenChatStatisticsFromDto()
  ↓ INSERT INTO statistics
  ↓
❌ PDOException: database is locked
```

該当コード：[`SqliteStatisticsRepository.php:16`](https://github.com/mimimiku778/Open-Chat-Graph/blob/main/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php#L14-L23)

---

## ⚠️ 緊急修正（2026-01-11 02:35）

### 発生した問題

WALモード導入後、読み取り専用モード（`mode=ro`）でデータベースを開く際に以下のエラーが大量発生：

```
PDOException: SQLSTATE[HY000]: General error: 14 unable to open database file
#0 AbstractSQLite.php(42): PDO->exec('PRAGMA journal_mode=WAL')
```

**原因**：読み取り専用モードではPRAGMA文を実行できないため、WALモード設定が失敗していた。

**影響範囲**：全ページ（特に台湾版`/tw/`）でGooglebot/Bingbotのクローリング時にエラー

### 修正内容

読み取り専用モード（`mode=ro`）の場合はPRAGMA設定をスキップ：

```php
// Apply PRAGMA settings only for read-write mode
// Read-only mode (mode=ro) cannot execute PRAGMA statements
if (!str_contains($mode, 'mode=ro')) {
    static::$pdo->exec('PRAGMA journal_mode=WAL');
    static::$pdo->exec('PRAGMA synchronous=NORMAL');
    static::$pdo->exec('PRAGMA busy_timeout=10000');
}
```

**理由**：WALモードは一度設定されればデータベースファイルに永続化されるため、読み取り専用で開く際は再設定不要。

**該当コミット**：[7d2fc5ea](https://github.com/mimimiku778/Open-Chat-Graph/commit/7d2fc5ea)

---

## 対処内容

### SQLiteのWAL（Write-Ahead Logging）モード導入

SQLiteの全データベース接続時に以下の最適化設定を適用：

**変更ファイル**
- [`app/Models/SQLite/AbstractSQLite.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/hotfix/sqlite/app/Models/SQLite/AbstractSQLite.php#L41-L52)
- [`app/Models/SQLite/SQLiteOcgraphSqlapi.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/hotfix/sqlite/app/Models/SQLite/SQLiteOcgraphSqlapi.php#L41-L54)

**適用した設定**

```php
// WALモード：読み取りと書き込みを並行実行可能にする
static::$pdo->exec('PRAGMA journal_mode=WAL');

// 同期モード：パフォーマンスと安全性のバランス
static::$pdo->exec('PRAGMA synchronous=NORMAL');

// ビジータイムアウト：ロック発生時に10秒間リトライ
static::$pdo->exec('PRAGMA busy_timeout=10000');
```

### 効果

**WALモードによる並行処理の実現**

```
【DELETEモード（従来）】
読み取りプロセス: [========SHARED LOCK保持========]
                          ↓
書き込みプロセス:         ❌ ブロック → タイムアウト

【WALモード（修正後）】
読み取りプロセス: [========データ読み取り========]
書き込みプロセス: [========WALファイルへ書き込み========] ✅並行実行
```

- 読み取り中でも書き込みが可能（完全に独立して動作）
- ロック発生時は最大10秒間自動リトライ
- 既存のリトライロジック（5回）と組み合わせで最大50秒の待機

### 安全性

- **WALモード**：SQLite公式推奨、Chrome/Firefox/GitHub Desktopなど多数の実績
- **synchronous=NORMAL**：WALモードでの推奨設定、データ整合性は完全に保証
- **副作用**：`.db-wal`と`.db-shm`ファイルが作成 → ✅既に`.gitignore`に含まれています

## 参考資料

- [SQLite公式：Write-Ahead Logging](https://www.sqlite.org/wal.html)
- [SQLite公式：PRAGMA synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous)