### PR TITLE
fix: 日次データ更新処理の二重実行問題を修正

### DIFF
--- a/app/Controllers/Pages/AdminPageController.php
+++ b/app/Controllers/Pages/AdminPageController.php
@@ -293,7 +293,10 @@ class AdminPageController
 
     function killdaily(SyncOpenChatStateRepositoryInterface $syncOpenChatStateRepository)
     {
-        $syncOpenChatStateRepository->setTrue(SyncOpenChatStateType::openChatDailyCrawlingKillFlag);
+        $syncOpenChatStateRepository->setString(
+            SyncOpenChatStateType::openChatDailyCrawlingKillFlag,
+            date('Y-m-d H:i:s')
+        );
         return view('admin/admin_message_page', ['title' => 'OpenChatApiDbMerger', 'message' => 'OpenChatDailyCrawlingを強制終了しました']);
     }
 

--- a/app/Services/OpenChat/OpenChatDailyCrawling.php
+++ b/app/Services/OpenChat/OpenChatDailyCrawling.php
@@ -18,6 +18,8 @@ class OpenChatDailyCrawling
     // interval for checking kill flag
     const CHECK_KILL_FLAG_INTERVAL = 3;
 
+    private string $startTime;
+
     function __construct(
 
         private OpenChatUpdaterFromApi $openChatUpdater,
@@ -32,7 +34,12 @@ class OpenChatDailyCrawling
      */
     function crawling(array $openChatIdArray, ?int $intervalSecond = null): int
     {
-        $this->setKillFlagFalse();
+        // 実行開始日時を記録し、この日時をkillフラグの値として設定
+        $this->startTime = date('Y-m-d H:i:s');
+        $this->syncOpenChatStateRepository->setString(
+            SyncOpenChatStateType::openChatDailyCrawlingKillFlag,
+            $this->startTime
+        );
 
         foreach ($openChatIdArray as $key => $id) {
             if ($key % self::CHECK_KILL_FLAG_INTERVAL === 0) {
@@ -62,23 +69,24 @@ class OpenChatDailyCrawling
 
     private function checkKillFlag(int $key): void
     {
-        if ($this->syncOpenChatStateRepository->getBool(SyncOpenChatStateType::openChatDailyCrawlingKillFlag)) {
+        $killFlagTime = $this->syncOpenChatStateRepository->getString(SyncOpenChatStateType::openChatDailyCrawlingKillFlag);
 
+        // killフラグの時刻が自分の開始時刻より新しい場合、より新しいリトライが開始されたので終了
+        if ($killFlagTime !== '' && $killFlagTime > $this->startTime) {
             throw new ApplicationException((string)$key, AppConfig::DAILY_UPDATE_EXCEPTION_ERROR_CODE);
         }
     }
 
+    /**
+     * 現在日時をkillフラグに設定して、既存のcrawling処理を停止させる
+     */
     static function setKillFlagTrue()
     {
         /** @var SyncOpenChatStateRepositoryInterface $syncOpenChatStateRepository */
         $syncOpenChatStateRepository = app(SyncOpenChatStateRepositoryInterface::class);
-        $syncOpenChatStateRepository->setTrue(SyncOpenChatStateType::openChatDailyCrawlingKillFlag);
-    }
-
-    static function setKillFlagFalse()
-    {
-        /** @var SyncOpenChatStateRepositoryInterface $syncOpenChatStateRepository */
-        $syncOpenChatStateRepository = app(SyncOpenChatStateRepositoryInterface::class);
-        $syncOpenChatStateRepository->setFalse(SyncOpenChatStateType::openChatDailyCrawlingKillFlag);
+        $syncOpenChatStateRepository->setString(
+            SyncOpenChatStateType::openChatDailyCrawlingKillFlag,
+            date('Y-m-d H:i:s')
+        );
     }
 }


### PR DESCRIPTION
## 問題

### 日次データ更新のクローリング処理が二重実行される可能性

**前提:**
日次処理は「毎時処理」→「クローリング処理」の順に実行される。
リトライ時は前の日次処理を停止するため`setKillFlagTrue()`でフラグを立て、新しい日次処理を開始する。

**問題の本質:**
クローリング処理(`crawling()`)は開始時に`setKillFlagFalse()`でフラグを下げる設計だった。

しかし、リトライが実行された時点で前の日次処理がまだクローリング処理に到達していない場合:
1. リトライ側が`setKillFlagTrue()`でフラグを立てる
2. 前の日次処理がクローリング処理に到達
3. クローリング処理の開始時に`setKillFlagFalse()`でフラグを下げてしまう
4. **結果**: リトライ側が立てたフラグが無効化され、両方の日次処理が並行実行される

従来は毎時処理が10分程度で終わる想定だったため、クローリング処理到達前にリトライが実行されることはなかった。しかし最近処理時間が長くなり、この問題が現実的に発生する可能性が出てきた。

## 対処内容

### クローリング処理の停止フラグを日時ベースに変更

停止フラグ(`openChatDailyCrawlingKillFlag`)を`bool`値から`string`値（実行開始日時`Y-m-d H:i:s`）に変更。

- `crawling()`開始時に実行開始日時を記録し、フラグに設定
- `checkKillFlag()`でフラグの日時が自分の開始日時より新しい場合は強制終了
- リトライ時は現在日時をフラグに設定

これにより、`crawling()`内でフラグを上書きしても、リトライ側が設定したより新しい日時と比較して自動終了する。

### 毎時処理のAPIマージ処理は変更なし

毎時処理で使用する`openChatApiDbMergerKillFlag`は従来通り`bool`値のまま。
理由：APIマージ処理は処理時間が短く、二重実行のリスクが低いため。

## 変更ファイル

- `app/Services/OpenChat/OpenChatDailyCrawling.php`
- `app/Controllers/Pages/AdminPageController.php`（管理画面からの手動終了も対応）