### PR TITLE
perf: 毎時ランキング更新処理を並列化し、ダウンロードとDB反映を同時実行可能に

### DIFF
--- a/app/Models/Repositories/SyncOpenChatStateRepository.php
+++ b/app/Models/Repositories/SyncOpenChatStateRepository.php
@@ -53,4 +53,20 @@ class SyncOpenChatStateRepository implements SyncOpenChatStateRepositoryInterfac
             ['type' => $type->value, 'value' => $value]
         );
     }
+
+    public function getArray(SyncOpenChatStateType $type): array
+    {
+        $json = $this->getString($type);
+        if (!$json) {
+            return [];
+        }
+
+        $result = json_decode($json, true);
+        return is_array($result) ? $result : [];
+    }
+
+    public function setArray(SyncOpenChatStateType $type, array $value): void
+    {
+        $this->setString($type, json_encode($value));
+    }
 }

--- a/app/Models/Repositories/SyncOpenChatStateRepositoryInterface.php
+++ b/app/Models/Repositories/SyncOpenChatStateRepositoryInterface.php
@@ -15,4 +15,7 @@ interface SyncOpenChatStateRepositoryInterface
     /** レコードが存在しない場合は空文字を返す */
     public function getString(SyncOpenChatStateType $type): string;
     public function setString(SyncOpenChatStateType $type, string $value): void;
+    /** レコードが存在しない場合は空配列を返す */
+    public function getArray(SyncOpenChatStateType $type): array;
+    public function setArray(SyncOpenChatStateType $type, array $value): void;
 }

--- a/app/Services/Admin/AdminTool.php
+++ b/app/Services/Admin/AdminTool.php
@@ -92,7 +92,6 @@ class AdminTool
 
             curl_setopt_array($ch, $options);
             $response = curl_exec($ch);
-            curl_close($ch);
 
             return (string)$response;
         };

--- a/app/Services/Cron/Enum/SyncOpenChatStateType.php
+++ b/app/Services/Cron/Enum/SyncOpenChatStateType.php
@@ -12,6 +12,7 @@ enum SyncOpenChatStateType: string
     case openChatDailyCrawlingKillFlag = 'openChatDailyCrawlingKillFlag';
     case isUpdateInvitationTicketActive = 'isUpdateInvitationTicketActive';
     case isUpdateRecommendStaticDataActive = 'isUpdateRecommendStaticDataActive';
+    case rankingPersistenceBackground = 'rankingPersistenceBackground';
     case persistMemberStatsLastDate = 'persistMemberStatsLastDate';
     case filterCacheDate = 'filterCacheDate';
 }

--- a/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php
+++ b/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php
@@ -8,20 +8,43 @@ use App\Config\AppConfig;
 use App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepositoryInterface;
 use App\Models\Repositories\RankingPosition\Dto\RankingPositionHourInsertDto;
 use App\Models\Repositories\RankingPosition\RankingPositionHourRepositoryInterface;
+use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
+use App\Services\Admin\AdminTool;
+use App\Services\Cron\Enum\SyncOpenChatStateType;
 use App\Services\OpenChat\Enum\RankingType;
+use App\Services\OpenChat\Utility\OpenChatServicesUtility;
 use App\Services\RankingPosition\Store\RankingPositionStore;
 use App\Services\RankingPosition\Store\RisingPositionStore;
 use Shared\MimimalCmsConfig;
 
+/**
+ * 毎時ランキングデータのDB反映処理
+ *
+ * ダウンロード処理と並列実行するため、バックグラウンドプロセスで動作する。
+ * ストレージファイルを監視し、ファイルが準備でき次第、順次DB反映を行う。
+ *
+ * 処理フロー:
+ * 1. メインプロセス: startBackgroundPersistence() でバックグラウンドプロセスを起動
+ * 2. メインプロセス: ランキングダウンロード処理を実行（並列）
+ * 3. バックグラウンド: persistAllCategoriesBackground() でストレージ監視＆DB反映
+ * 4. メインプロセス: waitForBackgroundCompletion() でバックグラウンド完了を待機
+ */
 class RankingPositionHourPersistence
 {
+    /** バックグラウンドプロセスの最大待機時間（秒） */
+    private const MAX_WAIT_SECONDS = 2400; // 最大40分待機
+
     function __construct(
         private OpenChatDataForUpdaterWithCacheRepositoryInterface $openChatDataWithCache,
         private RankingPositionHourRepositoryInterface $rankingPositionHourRepository,
         private RisingPositionStore $risingPositionStore,
-        private RankingPositionStore $rankingPositionStore
+        private RankingPositionStore $rankingPositionStore,
+        private SyncOpenChatStateRepositoryInterface $state
     ) {}
 
+    /**
+     * 経過時間を分秒形式でフォーマット
+     */
     private function formatElapsedTime(float $startTime): string
     {
         $elapsedSeconds = microtime(true) - $startTime;
@@ -30,96 +53,260 @@ class RankingPositionHourPersistence
         return $minutes > 0 ? "{$minutes}分{$seconds}秒" : "{$seconds}秒";
     }
 
+    /**
+     * ログ用のカテゴリラベルを生成
+     */
     private function getCategoryLabelWithCount(string $categoryName, string $typeLabel, ?int $count = null): string
     {
         return "{$categoryName}の{$typeLabel}" . (is_null($count) ? "" : " {$count}件");
     }
 
-    function persistStorageFileToDb(): void
+    /**
+     * バックグラウンドプロセスを起動
+     *
+     * persist_ranking_position_background.php を別プロセスとして起動し、
+     * DB反映処理をバックグラウンドで実行する。これにより、メインプロセスは
+     * ランキングダウンロード処理を並行して実行できる。
+     */
+    function startBackgroundPersistence(): void
     {
-        $fileTime = $this->persist();
+        $parentPid = getmypid();
+        $arg = escapeshellarg(\Shared\MimimalCmsConfig::$urlRoot);
+        $parentPidArg = escapeshellarg((string)$parentPid);
+        $path = AppConfig::ROOT_PATH . 'batch/exec/persist_ranking_position_background.php';
+        exec(PHP_BINARY . " {$path} {$arg} {$parentPidArg} >/dev/null 2>&1 &");
+        addVerboseCronLog('毎時ランキングDB反映をバックグラウンドで開始');
+    }
 
-        $this->rankingPositionHourRepository->insertTotalCount($fileTime);
-        addCronLog("毎時ランキング全データをデータベースに反映完了（{$fileTime}）");
+    /**
+     * バックグラウンドプロセスの完了を待つ
+     *
+     * PID監視により、バックグラウンドプロセスの状態を確認する。
+     * - PIDがクリアされた: 正常終了
+     * - プロセスが死んでいる: 異常終了
+     * - タイムアウト: 処理時間超過
+     *
+     * @throws \RuntimeException バックグラウンドプロセスが異常終了またはタイムアウトした場合
+     */
+    function waitForBackgroundCompletion(): void
+    {
+        addVerboseCronLog('バックグラウンドDB反映の完了を待機中');
 
-        $deleteTime = new \DateTime($fileTime);
+        while (true) {
+            // バックグラウンドプロセスの状態を取得
+            $bgState = $this->state->getArray(SyncOpenChatStateType::rankingPersistenceBackground);
+            $pid = $bgState['pid'] ?? null;
+            $startTime = $bgState['startTime'] ?? null;
+
+            // PIDがクリアされていたら正常終了
+            if (!$pid) {
+                addVerboseCronLog('バックグラウンドDB反映完了を確認');
+                return;
+            }
+
+            // posix_getpgid()でプロセスの生存確認（falseならプロセスが死んでいる）
+            if (posix_getpgid((int)$pid) === false) {
+                throw new \RuntimeException("バックグラウンドDB反映プロセスが異常終了 (PID: {$pid})");
+            }
+
+            // 開始時刻からの経過時間をチェック
+            if ($startTime && time() - (int)$startTime > self::MAX_WAIT_SECONDS) {
+                exec("kill {$pid}");
+                throw new \RuntimeException("バックグラウンドDB反映の待機タイムアウト（40分） (PID: {$pid})");
+            }
+
+            sleep(2);
+        }
+    }
+
+    /**
+     * バックグラウンドでの全カテゴリDB反映処理
+     *
+     * ストレージファイルを監視し、ファイルが準備でき次第、順次DB反映を行う。
+     * ダウンロード処理と並行して動作するため、全ファイルが揃うのを待たずに処理できる。
+     *
+     * 処理フロー:
+     * 1. 全カテゴリ×2種類（急上昇/ランキング）の処理状態を初期化
+     * 2. whileループでストレージファイルを監視
+     * 3. ファイルのタイムスタンプが期待値と一致したらDB反映
+     * 4. 全カテゴリ完了後、集計処理と古いデータ削除を実行
+     *
+     * @throws \RuntimeException タイムアウトの場合
+     */
+    function persistAllCategoriesBackground(): void
+    {
+        // OpenChatデータのキャッシュを初期化（emid→id変換用）
+        $this->openChatDataWithCache->clearCache();
+        $this->openChatDataWithCache->cacheOpenChatData(true);
+
+        // cron実行時刻を毎時0分に調整した期待値（例: "2024-01-15 12:00:00"）
+        $expectedFileTime = OpenChatServicesUtility::getModifiedCronTime('now')->format('Y-m-d H:i:s');
+        addVerboseCronLog("毎時ランキングDB反映バックグラウンド開始（対象時刻: {$expectedFileTime}）");
+
+        // 各カテゴリの処理状態を追跡（未処理: false、処理済み: true）
+        // 例: [0 => ['rising' => false, 'ranking' => false], 1 => [...], ...]
+        $categories = AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot];
+        $processed = array_fill_keys(
+            array_values($categories),
+            ['rising' => false, 'ranking' => false]
+        );
+
+        // 処理対象の定義（急上昇とランキングの2種類）
+        $processTargets = [
+            ['type' => RankingType::Rising, 'store' => $this->risingPositionStore, 'key' => 'rising'],
+            ['type' => RankingType::Ranking, 'store' => $this->rankingPositionStore, 'key' => 'ranking'],
+        ];
+
+        // ストレージファイル監視ループ（ファイルが準備でき次第、順次処理）
+        $startTime = time();
+
+        $loopCount = 0;
+        while (true) {
+            $allCompleted = true;
+            $loopCount++;
+
+            // 全カテゴリ×2種類（急上昇/ランキング）をチェック
+            foreach ($categories as $key => $category) {
+                foreach ($processTargets as $target) {
+                    // 既に処理済みならスキップ
+                    if ($processed[$category][$target['key']]) {
+                        continue;
+                    }
+
+                    // ファイルが準備できていたら処理、まだならfalseが返る
+                    if (!$this->processCategoryTarget($category, $key, $target, $expectedFileTime, $processed)) {
+                        $allCompleted = false;
+                    }
+                }
+            }
+
+            // 全カテゴリ×2種類の処理が完了したらループを抜ける
+            if ($allCompleted) {
+                break;
+            }
+
+            // 10秒ごとに待機中のログを出力
+            if ($loopCount % 10 === 0) {
+                $elapsed = time() - $startTime;
+                $remaining = count(array_filter($processed, fn($p) => !$p['rising'] || !$p['ranking']));
+                addVerboseCronLog("ストレージファイル待機中: {$elapsed}秒経過、残り{$remaining}カテゴリ");
+            }
+
+            // タイムアウトチェック（40分経過したらエラー）
+            if (time() - $startTime > self::MAX_WAIT_SECONDS) {
+                $message = "毎時ランキングDB反映バックグラウンド: タイムアウト（" . self::MAX_WAIT_SECONDS . "秒）";
+                addCronLog($message);
+                AdminTool::sendDiscordNotify($message);
+
+                // 親プロセスをkillしてcron_crawling.phpを再実行
+                $bgState = $this->state->getArray(SyncOpenChatStateType::rankingPersistenceBackground);
+                $parentPid = $bgState['parentPid'] ?? null;
+
+                if ($parentPid) {
+                    addCronLog("親プロセス (PID: {$parentPid}) をkillします");
+                    exec("kill {$parentPid}");
+                    sleep(1);
+
+                    // cron_crawling.phpを再実行
+                    $arg = escapeshellarg(MimimalCmsConfig::$urlRoot);
+                    $path = AppConfig::ROOT_PATH . 'batch/cron/cron_crawling.php';
+                    exec(PHP_BINARY . " {$path} {$arg} >/dev/null 2>&1 &");
+                    addCronLog('cron_crawling.phpを再実行しました');
+                }
+
+                throw new \RuntimeException($message);
+            }
+
+            // CPU負荷軽減のため1秒待機してから再チェック
+            sleep(1);
+        }
+
+        // 最終処理：全体集計と古いデータ削除
+        addVerboseCronLog('全カテゴリのDB反映完了、最終処理を実行');
+        $this->rankingPositionHourRepository->insertTotalCount($expectedFileTime);
+        addCronLog("毎時ランキング全データをデータベースに反映完了（{$expectedFileTime}）");
+
+        // 1日前より古いデータを削除
+        $deleteTime = new \DateTime($expectedFileTime);
         $deleteTime->modify('- 1day');
         $this->rankingPositionHourRepository->delete($deleteTime);
 
         $deleteTimeStr = $deleteTime->format('Y-m-d H:i:s');
         addCronLog("古いランキングデータを削除（{$deleteTimeStr}以前）");
-    }
-
-    private function persist(): string
-    {
-        $this->openChatDataWithCache->clearCache();
-        $this->openChatDataWithCache->cacheOpenChatData(true);
-
-        $fileTime = '';
-        foreach (AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot] as $key => $category) {
-            // 急上昇
-            $risingStartTime = microtime(true);
-            $risingLabel = $this->getCategoryLabelWithCount($key, '急上昇', null);
-            addVerboseCronLog("{$risingLabel}をデータベースに反映中");
-
-            [$risingFileTime, $risingOcDtoArray] = $this->risingPositionStore->getStorageData((string)$category);
-            $risingInsertDtoArray = $this->createInsertDtoArray($risingOcDtoArray);
-
-
-            unset($risingOcDtoArray);
-
-            $this->rankingPositionHourRepository->insertFromDtoArray(RankingType::Rising, $risingFileTime, $risingInsertDtoArray);
-            if ($category === 0) {
-                $this->rankingPositionHourRepository->insertHourMemberFromDtoArray($risingFileTime, $risingInsertDtoArray);
-            }
-
-            addVerboseCronLog("{$risingLabel}をデータベースに反映完了（{$this->formatElapsedTime($risingStartTime)}）", count($risingInsertDtoArray));
-            unset($risingInsertDtoArray);
-
-            // ランキング
-            $rankingStartTime = microtime(true);
-            $rankingLabel = $this->getCategoryLabelWithCount($key, 'ランキング', null);
-            addVerboseCronLog("{$rankingLabel}をデータベースに反映中");
-
-            [$rankingFileTime, $rankingOcDtoArray] = $this->rankingPositionStore->getStorageData((string)$category);
-            $rankingInsertDtoArray = $this->createInsertDtoArray($rankingOcDtoArray);
-
-            unset($rankingOcDtoArray);
-
-            $this->rankingPositionHourRepository->insertFromDtoArray(RankingType::Ranking, $rankingFileTime, $rankingInsertDtoArray);
-            $this->rankingPositionHourRepository->insertHourMemberFromDtoArray($rankingFileTime, $rankingInsertDtoArray);
-
-            addVerboseCronLog("{$rankingLabel}をデータベースに反映完了（{$this->formatElapsedTime($rankingStartTime)}）", count($rankingInsertDtoArray));
-            unset($rankingInsertDtoArray);
-
-            $fileTime = $rankingFileTime;
-        }
 
         $this->openChatDataWithCache->clearCache();
-        return $fileTime;
     }
 
     /**
-     * @param OpenChatDto[] $data 
-     * @return RankingPositionHourInsertDto[]
+     * カテゴリとターゲット（Rising/Ranking）の組み合わせを処理
+     *
+     * ストレージファイルのタイムスタンプをチェックし、期待値と一致していれば
+     * DB反映処理を実行する。まだファイルが準備できていない場合はfalseを返す。
+     *
+     * @param int $category カテゴリID
+     * @param string $categoryName カテゴリ名（ログ用）
+     * @param array $target 処理対象情報（type, store, key）
+     * @param string $expectedFileTime 期待されるファイルタイムスタンプ
+     * @param array $processed 処理状態の配列（参照渡し）
+     * @return bool 処理が完了した場合true、まだファイルが準備できていない場合false
+     */
+    private function processCategoryTarget(int $category, string $categoryName, array $target, string $expectedFileTime, array &$processed): bool
+    {
+        $categoryStr = (string)$category;
+
+        // ストレージファイルのタイムスタンプをチェック
+        try {
+            $fileTime = $target['store']->getFileDateTime($categoryStr)->format('Y-m-d H:i:s');
+            if ($fileTime !== $expectedFileTime) {
+                return false; // タイムスタンプが一致しない（まだダウンロード中）
+            }
+        } catch (\Throwable) {
+            return false; // ファイルがまだ存在しない
+        }
+
+        // DB反映処理を実行
+        $typeLabel = $target['type'] === RankingType::Rising ? '急上昇' : 'ランキング';
+        $label = $this->getCategoryLabelWithCount($categoryName, $typeLabel);
+        $perfStartTime = microtime(true);
+        addVerboseCronLog("{$label}をデータベースに反映中");
+
+        // ストレージからデータを取得してDTO配列に変換
+        [, $ocDtoArray] = $target['store']->getStorageData($categoryStr);
+        $insertDtoArray = $this->createInsertDtoArray($ocDtoArray);
+        unset($ocDtoArray); // メモリ解放
+
+        // ランキングデータをDBに挿入
+        $this->rankingPositionHourRepository->insertFromDtoArray($target['type'], $expectedFileTime, $insertDtoArray);
+
+        // ランキングタイプまたは全体カテゴリ（0）の場合、メンバー数も記録
+        if ($target['type'] === RankingType::Ranking || (int)$category === 0) {
+            $this->rankingPositionHourRepository->insertHourMemberFromDtoArray($expectedFileTime, $insertDtoArray);
+        }
+
+        addVerboseCronLog("{$label}をデータベースに反映完了（{$this->formatElapsedTime($perfStartTime)}）", count($insertDtoArray));
+        unset($insertDtoArray); // メモリ解放
+
+        // 処理完了フラグを立てる
+        $processed[$category][$target['key']] = true;
+        return true;
+    }
+
+    /**
+     * OpenChatDto配列をRankingPositionHourInsertDto配列に変換
+     *
+     * emidからopenChatIdを取得し、IDが見つからないものは除外する。
+     *
+     * @param OpenChatDto[] $data ストレージから取得したランキングデータ
+     * @return RankingPositionHourInsertDto[] DB挿入用DTO配列
      */
     private function createInsertDtoArray(array $data): array
     {
-        $result = [];
-        foreach ($data as $key => $dto) {
-            $id = $this->openChatDataWithCache->getOpenChatIdByEmid($dto->emid);
-            if (!$id) {
-                continue;
-            }
-
-            $result[] = new RankingPositionHourInsertDto(
-                $id,
-                $key + 1,
-                $dto->category ?? 0,
-                $dto->memberCount
-            );
-        }
-
-        return $result;
+        return array_values(array_filter(array_map(
+            fn($dto, $key) => ($id = $this->openChatDataWithCache->getOpenChatIdByEmid($dto->emid))
+                ? new RankingPositionHourInsertDto($id, $key + 1, $dto->category ?? 0, $dto->memberCount)
+                : null, // IDが見つからない場合はnull（後でfilterで除外）
+            $data,
+            array_keys($data)
+        )));
     }
 }

--- a/app/Services/RankingPosition/Persistence/test/RankingPositionHourPersistenceTest.php
+++ b/app/Services/RankingPosition/Persistence/test/RankingPositionHourPersistenceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Services\RankingPosition\Persistence\RankingPositionHourPersistence;
 use PHPUnit\Framework\TestCase;
 
+// docker compose exec app ./vendor/bin/phpunit app/Services/RankingPosition/Persistence/test/RankingPositionHourPersistenceTest.php
 class RankingPositionHourPersistenceTest extends TestCase
 {
     public RankingPositionHourPersistence $instance;
@@ -13,7 +14,7 @@ class RankingPositionHourPersistenceTest extends TestCase
     {
         $this->instance = app(RankingPositionHourPersistence::class);
 
-        $this->instance->persistStorageFileToDb();
+        $this->instance->persistAllCategoriesBackground();
 
         $this->assertEquals(0, 0);
     }

--- a/batch/exec/persist_ranking_position_background.php
+++ b/batch/exec/persist_ranking_position_background.php
@@ -1,0 +1,62 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
+use App\Services\Admin\AdminTool;
+use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\RankingPosition\Persistence\RankingPositionHourPersistence;
+use Shared\MimimalCmsConfig;
+
+set_time_limit(3600 * 2);
+
+try {
+    if (isset($argv[1]) && $argv[1]) {
+        MimimalCmsConfig::$urlRoot = $argv[1];
+    }
+
+    $parentPid = isset($argv[2]) && $argv[2] ? (int)$argv[2] : null;
+
+    /**
+     * @var SyncOpenChatStateRepositoryInterface $state
+     */
+    $state = app(SyncOpenChatStateRepositoryInterface::class);
+
+    // 二重実行チェック
+    $bgState = $state->getArray(StateType::rankingPersistenceBackground);
+    $existingPid = $bgState['pid'] ?? null;
+
+    if ($existingPid) {
+        // 既存のプロセスが生きているか確認
+        if (posix_getpgid((int)$existingPid) !== false) {
+            addCronLog("バックグラウンドDB反映プロセスが既に実行中です (PID: {$existingPid})");
+            exit(1);
+        }
+
+        // プロセスが死んでいる場合は古い状態をクリア
+        addVerboseCronLog("古いバックグラウンドプロセス (PID: {$existingPid}) の状態をクリア");
+    }
+
+    // PID、親PID、開始時刻を記録
+    $state->setArray(StateType::rankingPersistenceBackground, [
+        'pid' => getmypid(),
+        'parentPid' => $parentPid,
+        'startTime' => time(),
+    ]);
+
+    /**
+     * @var RankingPositionHourPersistence $persistence
+     */
+    $persistence = app(RankingPositionHourPersistence::class);
+
+    // 全カテゴリのDB反映処理を実行
+    $persistence->persistAllCategoriesBackground();
+
+    // 正常終了：状態をクリア
+    $state->setArray(StateType::rankingPersistenceBackground, []);
+} catch (\Throwable $e) {
+    addCronLog($e->__toString());
+    AdminTool::sendDiscordNotify($e->__toString());
+
+    // エラー時は状態を残す（メインプロセスがプロセス死亡を検知できるように）
+}


### PR DESCRIPTION
## 問題の概要

### 毎時ランキング更新処理の非効率な直列実行

毎時30分に実行される以下の処理が直列実行されており、全体の処理時間が長くなっていた：
1. ランキングデータのダウンロード（全カテゴリ×2種類）
2. **ダウンロード完了後に**DB反映開始

しかし、ダウンロードが完了したカテゴリから順次DB反映を開始すれば、全体の処理時間を短縮できる。

### ログから見る実際の状況

#### 現在の処理タイムライン（直列実行）

```
08:30:01  【開始】ランキングダウンロード
08:31:08  ├─ ゲームのランキング取得完了（1分11秒）
08:32:20  ├─ スポーツのランキング取得完了（55秒）
   ...    ├─ （以下、24カテゴリ×2種類のダウンロードが続く）
08:45:45  └─ すべてのランキング取得完了（1分25秒）
          ▼ ダウンロード完了: 15分44秒

08:45:45  【開始】DB反映処理
08:45:46  ├─ ゲームのランキング反映開始
08:45:56  ├─ スポーツのランキング反映開始
   ...    ├─ （以下、全カテゴリのDB反映が続く）
08:47:47  └─ すべてのランキング反映完了（6秒）
          ▼ DB反映完了: 2分2秒

【合計処理時間】17分46秒 = ダウンロード15分44秒 + DB反映2分2秒
```

#### 並列化後の処理タイムライン（期待値）

```
08:30:01  【開始】ランキングダウンロード + バックグラウンドDB反映
08:31:08  ├─ ゲームのランキング取得完了
          ├──→ [BG] ゲームDB反映開始（8秒）
08:32:20  ├─ スポーツのランキング取得完了
          ├──→ [BG] スポーツDB反映開始（7秒）
   ...    ├─ （ダウンロードとDB反映が並行実行）
08:45:45  └─ すべてのランキング取得完了
          └──→ [BG] すべてDB反映開始（6秒）

08:45:51  【完了】全処理完了
          ▼ 最後のDB反映: 6秒のみ追加

【合計処理時間】15分50秒 = ダウンロード15分44秒 + 最後のDB反映6秒
【短縮時間】約2分（17分46秒 → 15分50秒）
```

**改善効果**: DB反映処理（2分2秒）の大部分がダウンロード処理と並行実行されるため、最後のカテゴリのDB反映時間（6秒）のみが追加され、全体で約2分の短縮が見込まれる。

## 対処内容

### 1. バックグラウンドプロセスによる並列実行

**変更内容**: ランキングDB反映処理をバックグラウンドプロセスとして分離し、ダウンロードと並行実行

**実装**:
- [`RankingPositionHourPersistence::startBackgroundPersistence()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php#L71-L79) - バックグラウンドプロセス起動
- [`batch/exec/persist_ranking_position_background.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/batch/exec/persist_ranking_position_background.php) - バックグラウンドスクリプト
- [`RankingPositionHourPersistence::persistAllCategoriesBackground()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php#L134-L224) - ストレージファイル監視＆DB反映

**処理フロー**:
```
[メインプロセス]                    [バックグラウンドプロセス]
   |                                        |
   ├─ バックグラウンド起動 ─────────────────→ ストレージ監視開始
   |                                        |
   ├─ ランキングダウンロード開始              ├─ ファイル待機
   |  ├─ カテゴリ0ダウンロード               |
   |  |  └─ ファイル保存 ──────────────────→ DB反映開始（カテゴリ0）
   |  ├─ カテゴリ1ダウンロード               |
   |  |  └─ ファイル保存 ──────────────────→ DB反映開始（カテゴリ1）
   |  └─ ...                                |
   |                                        |
   ├─ ダウンロード完了                       ├─ 全カテゴリDB反映完了
   |                                        └─ 集計処理＆古いデータ削除
   |
   ├─ バックグラウンド完了待機
   |  └─ 完了確認
   |
   └─ 毎時処理の残りのタスク実行
```

### 2. PID+タイムスタンプによる状態管理

**変更内容**: boolean flagではなく、PIDとタイムスタンプをJSONで保存する方式に変更

**実装**:
- [`SyncOpenChatStateRepository::getArray()/setArray()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/app/Models/Repositories/SyncOpenChatStateRepository.php#L57-L71) - JSON配列の取得/設定
- [`batch/exec/persist_ranking_position_background.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/batch/exec/persist_ranking_position_background.php#L41-L45) - PID、親PID、タイムスタンプ記録
- [`RankingPositionHourPersistence::waitForBackgroundCompletion()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php#L89-L118) - PID監視による完了待機

**状態管理方式**:
```json
{
  "pid": 12345,
  "parentPid": 12340,
  "startTime": 1768092441
}
```

**エラー検知**:
- `posix_getpgid()` でプロセスの生存確認
- PIDが存在しない場合は異常終了と判定
- タイムアウト（40分）でプロセスをkill

### 3. 二重実行防止

**変更内容**: バックグラウンドスクリプト起動時に既存プロセスをチェック

**実装**: [`batch/exec/persist_ranking_position_background.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/batch/exec/persist_ranking_position_background.php#L25-L38)

**動作**:
- 既存のPIDが生きている場合はexit(1)で終了
- プロセスが死んでいる場合は古い状態をクリアして続行

### 4. タイムアウト時の自動リカバリー

**変更内容**: バックグラウンドプロセスがタイムアウトした場合、親プロセスをkillしてcron_crawling.phpを再実行

**実装**: [`RankingPositionHourPersistence::persistAllCategoriesBackground()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php#L195-L218)

**動作**:
- 40分経過してもストレージファイルが揃わない場合
- 親プロセス（ダウンロード処理実行中）をkill
- `cron_crawling.php`を再実行して処理をリトライ

**背景**: ダウンロード処理（`fetchOpenChatApiRankingAll()`）が固まることがあるため、バックグラウンド側から親プロセスをkillして確実にリカバリーする

### 5. URL取得遅延の監視

**変更内容**: API URL取得に30秒以上かかった場合、警告ログを出力

**実装**: [`OpenChatApiDbMerger::fetchOpenChatApiRankingAllProcess()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/ranking-persistence-background-parallel/app/Services/OpenChat/OpenChatApiDbMerger.php#L102-L133)

**ログ出力例**:
```
[警告] URL1件の取得に32.5秒: 125件目（カテゴリ開始から3分15秒経過）
```

**目的**: どのカテゴリのどのタイミングでAPI取得が遅延しているかを把握し、問題の早期発見につなげる

## 期待される効果

- ダウンロードとDB反映の並列実行により、全体の処理時間を約2分短縮（17分46秒 → 15分50秒）
- PID監視により、プロセスの異常終了を確実に検知
- 二重実行防止により、リソースの無駄遣いを回避
- タイムアウト時の自動リカバリーにより、処理の信頼性を向上
- URL取得遅延の可視化により、問題の早期発見が可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)