### PR TITLE
refactor: おすすめ情報更新処理をバックグラウンドスクリプトに移動

### DIFF
--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -16,7 +16,6 @@ use App\Services\OpenChat\OpenChatImageUpdater;
 use App\Services\RankingBan\RankingBanTableUpdater;
 use App\Services\RankingPosition\Persistence\RankingPositionHourPersistence;
 use App\Services\RankingPosition\Persistence\RankingPositionHourPersistenceLastHourChecker;
-use App\Services\Recommend\RecommendUpdater;
 use App\Services\SitemapGenerator;
 use App\Services\UpdateHourlyMemberColumnService;
 use App\Services\UpdateHourlyMemberRankingService;
@@ -33,7 +32,6 @@ class SyncOpenChat
         private UpdateHourlyMemberColumnService $hourlyMemberColumn,
         private OpenChatImageUpdater $OpenChatImageUpdater,
         private OpenChatHourlyInvitationTicketUpdater $invitationTicketUpdater,
-        private RecommendUpdater $recommendUpdater,
         private RankingBanTableUpdater $rankingBanUpdater,
         private SyncOpenChatStateRepositoryInterface $state,
     ) {
@@ -137,14 +135,6 @@ class SyncOpenChat
                 $this->state->setFalse(StateType::isUpdateInvitationTicketActive);
             }, '参加URL一括取得'],
             [fn() => $this->rankingBanUpdater->updateRankingBanTable(), 'ランキングBAN情報更新'],
-            [function () {
-                if ($this->state->getBool(StateType::isDailyTaskActive)) {
-                    addCronLog('おすすめ情報更新をスキップ（日次処理中のため）');
-                    return;
-                }
-
-                $this->recommendUpdater->updateRecommendTables();
-            }, 'おすすめ情報更新'],
         );
 
         // アーカイブ用DBインポート処理をバックグラウンドで実行（日本のみ）

--- a/batch/exec/update_recommend_static_data.php
+++ b/batch/exec/update_recommend_static_data.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Admin\AdminTool;
 use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\Recommend\RecommendUpdater;
 use App\Services\Recommend\StaticData\RecommendStaticDataGenerator;
 use ExceptionHandler\ExceptionHandler;
 use Shared\MimimalCmsConfig;
@@ -41,6 +42,15 @@ try {
     $state->setTrue(StateType::isUpdateRecommendStaticDataActive);
 
     /**
+     * @var RecommendUpdater $recommendUpdater
+     */
+    $recommendUpdater = app(RecommendUpdater::class);
+
+    addVerboseCronLog('おすすめ情報更新中（バックグラウンド）');
+    $recommendUpdater->updateRecommendTables();
+    addVerboseCronLog('おすすめ情報更新完了（バックグラウンド）');
+
+    /**
      * @var RecommendStaticDataGenerator $recommendStaticDataGenerator
      */
     $recommendStaticDataGenerator = app(RecommendStaticDataGenerator::class);
@@ -55,7 +65,8 @@ try {
     addVerboseCronLog('CDNキャッシュ削除中（バックグラウンド）');
     purgeCacheCloudFlare();
     addVerboseCronLog('CDNキャッシュ削除完了（バックグラウンド）');
-
+    
+    addVerboseCronLog('【毎時処理】バックグラウンド処理完了');
     // 実行中フラグを下ろす
     $state->setFalse(StateType::isUpdateRecommendStaticDataActive);
 } catch (\Throwable $e) {


### PR DESCRIPTION
## 変更内容

おすすめ情報更新処理を毎時処理から静的データ生成バッチに移動しました。

### 変更点

1. **`SyncOpenChat.php`から削除**
   - 毎時処理で実行されていた「おすすめ情報更新」を削除
   - `RecommendUpdater`の依存関係を削除

2. **`update_recommend_static_data.php`に追加**
   - 静的データ生成の前に`recommendUpdater->updateRecommendTables()`を実行
   - 処理順序: おすすめ情報更新 → 静的データ生成 → CDNキャッシュ削除

## 効果

おすすめ関連の処理がバックグラウンドスクリプトに集約され、処理の流れが明確になりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)