### PR TITLE
feat: プリビルドイメージの定期更新を追加（毎週月曜実行）

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -8,6 +8,9 @@ on:
       - 'docker/**'
       - 'composer.json'
       - 'composer.lock'
+  schedule:
+    # 毎週月曜日 0:00 (UTC) に実行してベースイメージの更新を取得
+    - cron: '0 0 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,9 @@ make show / help
 
 **GitHub Actions:**
 - `.github/workflows/ci.yml`: 自動テスト実行
-- `.github/workflows/build-images.yml`: プリビルドイメージのビルド＆プッシュ（main pushまたは手動実行）
+- `.github/workflows/build-images.yml`: プリビルドイメージのビルド＆プッシュ
+  - トリガー: mainへのpush（Docker/依存関係変更時）、毎週月曜0時（定期更新）、手動実行
+  - 定期実行でベースイメージ（php:8.3-apacheなど）のマイナーバージョン更新を取得
 - プリビルドイメージ: GitHub Container Registry (ghcr.io) にCI用イメージを保存
   - `ghcr.io/{owner}/oc-review-mock-app:latest`: アプリケーションイメージ
   - `ghcr.io/{owner}/oc-review-mock-line-mock-api:latest`: LINE Mock APIイメージ


### PR DESCRIPTION
## 概要
PHPなどのベースイメージのマイナーバージョン更新を自動取得するため、プリビルドイメージの定期再ビルドを追加。

## 問題
現状では、Dockerfileが`FROM php:8.3-apache`のように指定されている場合：
1. プリビルドイメージが`php:8.3.10`でビルドされる
2. その後`php:8.3.11`（セキュリティパッチ含む）がリリース
3. 新しいPRでは古いプリビルドイメージが使われ続ける
4. セキュリティアップデートが反映されない

## 解決策
`build-images.yml`に定期実行を追加：
```yaml
schedule:
  - cron: '0 0 * * 1'  # 毎週月曜日 0:00 (UTC)
```

## 効果
- ベースイメージのマイナーバージョン更新を自動取得
- セキュリティパッチの適用遅延を最小化（最大1週間）
- 手動実行の手間を削減

🤖 Generated with [Claude Code](https://claude.com/claude-code)