### PR TITLE
fix: 大量データ処理時のメモリ不足・タイムアウトを回避するため、レコード数の整合性検証を無効化

### DIFF
--- a/app/Services/Cron/OcreviewApiDataImporter.php
+++ b/app/Services/Cron/OcreviewApiDataImporter.php
@@ -535,22 +535,24 @@ class OcreviewApiDataImporter
         );
 
         // レコード数の整合性を検証し、不一致があれば修正
-        $this->verifyAndFixRecordCount(
-            'statistics',
-            'daily_member_statistics',
-            'id',
-            'record_id',
-            function ($row) {
-                return [
-                    'record_id' => $row['id'],
-                    'openchat_id' => $row['open_chat_id'],
-                    'member_count' => $row['member'],
-                    'statistics_date' => $row['date']
-                ];
-            },
-            $this->sqliteStatisticsPdo,
-            $this->targetPdo
-        );
+        // ※ 本番環境の大量データ（8700万行）でメモリ不足・タイムアウトが発生するため無効化
+        // IDベースの差分同期のため、チャンク処理が正常完了すれば整合性は保証される
+        // $this->verifyAndFixRecordCount(
+        //     'statistics',
+        //     'daily_member_statistics',
+        //     'id',
+        //     'record_id',
+        //     function ($row) {
+        //         return [
+        //             'record_id' => $row['id'],
+        //             'openchat_id' => $row['open_chat_id'],
+        //             'member_count' => $row['member'],
+        //             'statistics_date' => $row['date']
+        //         ];
+        //     },
+        //     $this->sqliteStatisticsPdo,
+        //     $this->targetPdo
+        // );
     }
 
     /**
@@ -619,23 +621,25 @@ class OcreviewApiDataImporter
         );
 
         // レコード数の整合性を検証し、不一致があれば修正
-        $this->verifyAndFixRecordCount(
-            'total_count',
-            'line_official_ranking_total_count',
-            'id',
-            'record_id',
-            function ($row) {
-                return [
-                    'record_id' => $row['id'],
-                    'activity_trending_total_count' => $row['total_count_rising'],
-                    'activity_ranking_total_count' => $row['total_count_ranking'],
-                    'recorded_at' => $row['time'],
-                    'category_id' => $row['category']
-                ];
-            },
-            $this->sqliteRankingPositionPdo,
-            $this->targetPdo
-        );
+        // ※ 時系列データのため将来的に大量データになる可能性があり、メモリ不足・タイムアウトが発生するため無効化
+        // IDベースの差分同期のため、チャンク処理が正常完了すれば整合性は保証される
+        // $this->verifyAndFixRecordCount(
+        //     'total_count',
+        //     'line_official_ranking_total_count',
+        //     'id',
+        //     'record_id',
+        //     function ($row) {
+        //         return [
+        //             'record_id' => $row['id'],
+        //             'activity_trending_total_count' => $row['total_count_rising'],
+        //             'activity_ranking_total_count' => $row['total_count_ranking'],
+        //             'recorded_at' => $row['time'],
+        //             'category_id' => $row['category']
+        //         ];
+        //     },
+        //     $this->sqliteRankingPositionPdo,
+        //     $this->targetPdo
+        // );
     }
 
     /**
@@ -722,25 +726,27 @@ class OcreviewApiDataImporter
             );
 
             // レコード数の整合性を検証し、不一致があれば修正
-            $this->verifyAndFixRecordCount(
-                $sourceTable,
-                $targetTable,
-                'id',
-                'record_id',
-                function ($row) use ($sourceTable) {
-                    $positionColumn = $sourceTable === 'ranking' ? 'activity_ranking_position' : 'activity_trending_position';
-                    return [
-                        'record_id' => $row['id'],
-                        'openchat_id' => $row['open_chat_id'],
-                        'category_id' => $row['category'],
-                        $positionColumn => $row['position'],
-                        'recorded_at' => date('Y-m-d H:i:s', strtotime($row['time'])),
-                        'record_date' => date('Y-m-d', strtotime($row['date']))
-                    ];
-                },
-                $this->sqliteRankingPositionPdo,
-                $this->targetPdo
-            );
+            // ※ 履歴データは数千万行規模になる可能性があり、メモリ不足・タイムアウトが発生するため無効化
+            // IDベースの差分同期のため、チャンク処理が正常完了すれば整合性は保証される
+            // $this->verifyAndFixRecordCount(
+            //     $sourceTable,
+            //     $targetTable,
+            //     'id',
+            //     'record_id',
+            //     function ($row) use ($sourceTable) {
+            //         $positionColumn = $sourceTable === 'ranking' ? 'activity_ranking_position' : 'activity_trending_position';
+            //         return [
+            //             'record_id' => $row['id'],
+            //             'openchat_id' => $row['open_chat_id'],
+            //             'category_id' => $row['category'],
+            //             $positionColumn => $row['position'],
+            //             'recorded_at' => date('Y-m-d H:i:s', strtotime($row['time'])),
+            //             'record_date' => date('Y-m-d', strtotime($row['date']))
+            //         ];
+            //     },
+            //     $this->sqliteRankingPositionPdo,
+            //     $this->targetPdo
+            // );
         }
     }
 


### PR DESCRIPTION
This pull request disables record count verification and correction steps in the `OcreviewApiDataImporter` service for several large tables. The main reason is to prevent memory exhaustion and timeouts in production due to the massive size of the datasets. Instead, data integrity will rely on chunked ID-based synchronization, which is considered sufficient for these cases.

**Performance and reliability improvements:**

* Disabled the `verifyAndFixRecordCount` step for the `statistics` and `daily_member_statistics` tables to avoid memory issues with 87 million rows in production. Integrity is now ensured via chunked ID-based sync.
* Disabled the `verifyAndFixRecordCount` step for the `total_count` and `line_official_ranking_total_count` tables, anticipating future large data volumes and potential resource exhaustion.
* Disabled the `verifyAndFixRecordCount` step for history tables such as `ranking` and `trending`, which could reach tens of millions of rows, shifting integrity assurance to chunked ID-based sync.