### PR TITLE
fix: 大量データ処理時のメモリ不足・タイムアウトを回避するため、レコード数の整合性検証を無効化

### DIFF
--- a/app/Services/Cron/OcreviewApiDataImporter.php
+++ b/app/Services/Cron/OcreviewApiDataImporter.php
@@ -458,22 +458,24 @@ class OcreviewApiDataImporter
         );
 
         // レコード数の整合性を検証し、不一致があれば修正
-        $this->verifyAndFixRecordCount(
-            'statistics',
-            'daily_member_statistics',
-            'id',
-            'record_id',
-            function ($row) {
-                return [
-                    'record_id' => $row['id'],
-                    'openchat_id' => $row['open_chat_id'],
-                    'member_count' => $row['member'],
-                    'statistics_date' => $row['date']
-                ];
-            },
-            $this->sqliteStatisticsPdo,
-            $this->targetPdo
-        );
+        // ※ 本番環境の大量データ（8700万行）でメモリ不足・タイムアウトが発生するため無効化
+        // IDベースの差分同期のため、チャンク処理が正常完了すれば整合性は保証される
+        // $this->verifyAndFixRecordCount(
+        //     'statistics',
+        //     'daily_member_statistics',
+        //     'id',
+        //     'record_id',
+        //     function ($row) {
+        //         return [
+        //             'record_id' => $row['id'],
+        //             'openchat_id' => $row['open_chat_id'],
+        //             'member_count' => $row['member'],
+        //             'statistics_date' => $row['date']
+        //         ];
+        //     },
+        //     $this->sqliteStatisticsPdo,
+        //     $this->targetPdo
+        // );
     }
 
     /**
@@ -530,23 +532,25 @@ class OcreviewApiDataImporter
         );
 
         // レコード数の整合性を検証し、不一致があれば修正
-        $this->verifyAndFixRecordCount(
-            'total_count',
-            'line_official_ranking_total_count',
-            'id',
-            'record_id',
-            function ($row) {
-                return [
-                    'record_id' => $row['id'],
-                    'activity_trending_total_count' => $row['total_count_rising'],
-                    'activity_ranking_total_count' => $row['total_count_ranking'],
-                    'recorded_at' => $row['time'],
-                    'category_id' => $row['category']
-                ];
-            },
-            $this->sqliteRankingPositionPdo,
-            $this->targetPdo
-        );
+        // ※ 時系列データのため将来的に大量データになる可能性があり、メモリ不足・タイムアウトが発生するため無効化
+        // IDベースの差分同期のため、チャンク処理が正常完了すれば整合性は保証される
+        // $this->verifyAndFixRecordCount(
+        //     'total_count',
+        //     'line_official_ranking_total_count',
+        //     'id',
+        //     'record_id',
+        //     function ($row) {
+        //         return [
+        //             'record_id' => $row['id'],
+        //             'activity_trending_total_count' => $row['total_count_rising'],
+        //             'activity_ranking_total_count' => $row['total_count_ranking'],
+        //             'recorded_at' => $row['time'],
+        //             'category_id' => $row['category']
+        //         ];
+        //     },
+        //     $this->sqliteRankingPositionPdo,
+        //     $this->targetPdo
+        // );
     }
 
     /**
@@ -612,25 +616,27 @@ class OcreviewApiDataImporter
             );
 
             // レコード数の整合性を検証し、不一致があれば修正
-            $this->verifyAndFixRecordCount(
-                $sourceTable,
-                $targetTable,
-                'id',
-                'record_id',
-                function ($row) use ($sourceTable) {
-                    $positionColumn = $sourceTable === 'ranking' ? 'activity_ranking_position' : 'activity_trending_position';
-                    return [
-                        'record_id' => $row['id'],
-                        'openchat_id' => $row['open_chat_id'],
-                        'category_id' => $row['category'],
-                        $positionColumn => $row['position'],
-                        'recorded_at' => date('Y-m-d H:i:s', strtotime($row['time'])),
-                        'record_date' => date('Y-m-d', strtotime($row['date']))
-                    ];
-                },
-                $this->sqliteRankingPositionPdo,
-                $this->targetPdo
-            );
+            // ※ 履歴データは数千万行規模になる可能性があり、メモリ不足・タイムアウトが発生するため無効化
+            // IDベースの差分同期のため、チャンク処理が正常完了すれば整合性は保証される
+            // $this->verifyAndFixRecordCount(
+            //     $sourceTable,
+            //     $targetTable,
+            //     'id',
+            //     'record_id',
+            //     function ($row) use ($sourceTable) {
+            //         $positionColumn = $sourceTable === 'ranking' ? 'activity_ranking_position' : 'activity_trending_position';
+            //         return [
+            //             'record_id' => $row['id'],
+            //             'openchat_id' => $row['open_chat_id'],
+            //             'category_id' => $row['category'],
+            //             $positionColumn => $row['position'],
+            //             'recorded_at' => date('Y-m-d H:i:s', strtotime($row['time'])),
+            //             'record_date' => date('Y-m-d', strtotime($row['date']))
+            //         ];
+            //     },
+            //     $this->sqliteRankingPositionPdo,
+            //     $this->targetPdo
+            // );
         }
     }
 


### PR DESCRIPTION
This pull request disables several record count verification and correction steps in the `OcreviewApiDataImporter` service. These steps have been commented out to prevent memory exhaustion and timeouts when processing very large datasets in production. The integrity of the data is still ensured by chunked, ID-based differential synchronization.

The most important changes are:

**Performance and Stability Improvements:**

* Disabled the call to `verifyAndFixRecordCount` for the `statistics` and `daily_member_statistics` tables to avoid memory issues with the 87 million row production dataset.
* Disabled the call to `verifyAndFixRecordCount` for the `total_count` and `line_official_ranking_total_count` tables due to the potential for large time-series data growth and associated resource constraints.
* Disabled the call to `verifyAndFixRecordCount` for history data tables that could grow to tens of millions of rows, again to prevent memory and timeout problems.

**Data Integrity Approach:**

* Added comments explaining that ID-based differential synchronization with chunked processing guarantees data consistency, making the disabled verification steps unnecessary under current conditions. [[1]](diffhunk://#diff-e1691f8aa738c4569178a3866b6ee199809f2fe5c7ee22d6d20b5ac6c831ad61L461-R478) [[2]](diffhunk://#diff-e1691f8aa738c4569178a3866b6ee199809f2fe5c7ee22d6d20b5ac6c831ad61L533-R553) [[3]](diffhunk://#diff-e1691f8aa738c4569178a3866b6ee199809f2fe5c7ee22d6d20b5ac6c831ad61L615-R639)