### PR TITLE
fix: デプロイ時のSSH接続エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,17 +44,13 @@ jobs:
         echo "CI Test passed. Proceeding with deployment."
 
     - name: Setup SSH
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        echo "Host ${{ vars.SSH_HOST }}" >> ~/.ssh/config
-        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
-        echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
     - name: Deploy
       run: |
-        ssh -p ${{ vars.SSH_PORT }} ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd ${{ vars.SSH_PATH }} && git pull"
+        ssh -o StrictHostKeyChecking=no -p ${{ vars.SSH_PORT }} ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd ${{ vars.SSH_PATH }} && git checkout main && git pull"
 
     - name: Checkout repository
       if: |


### PR DESCRIPTION
## 問題の概要
PRマージ後のデプロイが「Connection closed」エラーで失敗する

### エラーログ
```
Warning: Permanently added '[ocgraph.stars.ne.jp]:10022' (ED25519) to the list of known hosts.
Connection closed by 85.131.206.11 port 10022
```

## 対処内容
SSH秘密鍵の設定を `webfactory/ssh-agent` アクションに変更

手動で秘密鍵をファイルに書き込む方式では、GitHubシークレットに保存した際の改行フォーマットが原因で認証に失敗することがあるため、広く使われている `webfactory/ssh-agent` アクションを使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)