### PR TITLE
Fix/deploy ssh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,11 @@ jobs:
         mkdir -p ~/.ssh
         echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
-        echo "Host ${{ vars.SSH_HOST }}" >> ~/.ssh/config
-        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
-        echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+        echo "[${{ vars.SSH_HOST }}]:${{ vars.SSH_PORT }} ${{ secrets.SSH_HOST_KEY }}" >> ~/.ssh/known_hosts
 
     - name: Deploy
       run: |
-        ssh -p ${{ vars.SSH_PORT }} ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd ${{ vars.SSH_PATH }} && git pull"
+        ssh -p ${{ vars.SSH_PORT }} ${{ vars.SSH_USER }}@${{ vars.SSH_HOST }} "cd ${{ vars.SSH_PATH }} && git fetch origin && git reset --hard origin/main"
 
     - name: Checkout repository
       if: |


### PR DESCRIPTION
This pull request updates the deployment workflow by replacing the use of the `webfactory/ssh-agent` GitHub Action with manual SSH key setup and improves the deployment command for reliability. The changes enhance security and ensure the server is always in sync with the latest code.

**Deployment workflow improvements:**

* Replaced the `webfactory/ssh-agent` action with manual SSH key setup in the workflow, directly writing the private key and host key to the appropriate files for better transparency and control.
* Updated the deployment SSH command to use `git fetch origin` and `git reset --hard origin/main` instead of `git checkout main && git pull`, ensuring the deployment always matches the latest state of the `main` branch and reducing the risk of merge conflicts or stale code.