### PR TITLE
refactor: ルーティングの改善とETagキャッシュ処理の修正

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -110,7 +110,7 @@ Route::path(
         if (!$isValid)
             return false;
 
-        handleRequestWithETagAndCache(json_encode($reception->input() . MimimalCmsConfig::$urlRoot));
+        handleRequestWithETagAndCache(json_encode($reception->input()) . MimimalCmsConfig::$urlRoot);
         return true;
     });
 
@@ -146,7 +146,7 @@ Route::path(
     ->matchNum('category', min: 0)
     ->matchStr('sort', regex: ['ranking', 'rising'])
     ->match(function (Reception $reception) {
-        handleRequestWithETagAndCache(json_encode($reception->input() . MimimalCmsConfig::$urlRoot));
+        handleRequestWithETagAndCache(json_encode($reception->input()) . MimimalCmsConfig::$urlRoot);
     });
 
 // TODO: test-api


### PR DESCRIPTION
This pull request updates the route definitions in `app/Config/routing.php` to improve cache key handling, tighten admin and API access controls, and refactor some route match logic for clarity and correctness. The most important changes are summarized below:

### Cache Key and ETag Handling

* Updated all calls to `handleRequestWithETagAndCache` to append `MimimalCmsConfig::$urlRoot` to the cache key, ensuring that cache entries are correctly segmented by URL root. This change affects multiple routes, including open chat, recommendations, and recently registered pages. [[1]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L72-L88) [[2]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L110-R113) [[3]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L182-R188) [[4]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L203-R209) [[5]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L212-R218) [[6]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R128-R149)

### Access Control and Security

* Strengthened admin and API security by adding explicit checks for `MimimalCmsConfig::$urlRoot` and `SecretsConfig::$adminApiKey` in several routes, returning `false` early to restrict access when conditions are not met. This impacts open chat API, ranking, database, and admin log routes. [[1]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R128-R149) [[2]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R369-R375) [[3]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R491-L500) [[4]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R525-L519)
* Refactored admin authentication logic to ensure that admin-only routes are only accessible when `MimimalCmsConfig::$urlRoot` is empty, and authentication passes. [[1]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R369-R375) [[2]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L340-R348)

### Route Refactoring and Logic Cleanup

* Moved the `oc/{open_chat_id}/position_hour` route definition to a new location and updated its cache key logic. [[1]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R128-R149) [[2]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L150-L160)
* Simplified match function returns by removing redundant `return` statements and clarifying early exits for unauthorized access. [[1]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898L340-R348) [[2]](diffhunk://#diff-c9aca4fed5c3dca5240a940a8f3d260971e5fa15ad23fb3a1901502f581d8898R491-L500)

These changes collectively improve the security, correctness, and maintainability of the route configuration.