### PR TITLE
feat: CDNキャッシュパージを言語別プレフィックス対応に改善（全体パージ3回→必要な部分のみ）

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -61,7 +61,8 @@ Route::path('official-ranking', [ReactRankingPageController::class, 'ranking'])
     ->match(fn() => handleRequestWithETagAndCache("official-ranking"));
  */
 
-Route::path('policy');
+Route::path('policy')
+    ->match(fn() => handleRequestWithETagAndCache('policy'));
 
 Route::path('/')
     ->match(fn() => handleRequestWithETagAndCache('index'));
@@ -125,7 +126,7 @@ Route::path(
     ->matchStr('start_date')
     ->matchStr('end_date')
     ->match(function (string $start_date, string $end_date, string $user) {
-        if(MimimalCmsConfig::$urlRoot === '' && $user === SecretsConfig::$adminApiKey)
+        if (MimimalCmsConfig::$urlRoot === '' && $user === SecretsConfig::$adminApiKey)
             return false;
 
         $isValid = $start_date === date("Y-m-d", strtotime($start_date))

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -200,7 +200,8 @@ function handleRequestWithETagAndCache(string $content, int $maxAge = 0, int $sM
 function purgeCacheCloudFlare(
     ?string $zoneID = null,
     ?string $apiKey = null,
-    ?array $files = null
+    ?array $files = null,
+    ?array $prefixes = null
 ): string {
     $zoneID = $zoneID ?? SecretsConfig::$cloudFlareZoneId;
     $apiKey = $apiKey ?? SecretsConfig::$cloudFlareApiKey;
@@ -213,15 +214,20 @@ function purgeCacheCloudFlare(
     $ch = curl_init();
 
     // Cloudflare APIに送信するデータを設定
+    $payload = [];
     if ($files) {
-        $data = json_encode([
-            'files' => $files,
-        ]);
-    } else {
-        $data = json_encode([
-            'purge_everything' => true,
-        ]);
+        $payload['files'] = $files;
     }
+
+    if ($prefixes) {
+        $payload['prefixes'] = $prefixes;
+    }
+    
+    if (empty($payload)) {
+        $payload['purge_everything'] = true;
+    }
+
+    $data = json_encode($payload);
 
     curl_setopt($ch, CURLOPT_URL, "https://api.cloudflare.com/client/v4/zones/$zoneID/purge_cache");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/batch/exec/update_recommend_static_data.php
+++ b/batch/exec/update_recommend_static_data.php
@@ -64,7 +64,23 @@ try {
 
     // CDNキャッシュ削除
     CronUtility::addVerboseCronLog('CDNキャッシュ削除中（バックグラウンド）');
-    purgeCacheCloudFlare();
+
+    purgeCacheCloudFlare(
+        files: [
+            ltrim(url(), "/"),
+        ],
+        prefixes: [
+            url('recommend'),
+            url('oc'),
+            url('ranking'),
+            url('oclist'),
+            url('recently-registered'),
+            url('labs'),
+            url('policy'),
+            url('furigana'),
+        ]
+    );
+
     CronUtility::addVerboseCronLog('CDNキャッシュ削除完了（バックグラウンド）');
 
     CronUtility::addVerboseCronLog('【毎時処理】バックグラウンド処理完了');


### PR DESCRIPTION
## 問題の概要

オープンチャットの毎時ランキング更新処理は、3言語（日本語/繁体字中国語/タイ語）がそれぞれ5分おきに順次実行される。2025年5月以前のCloudflare無料プランでは全体キャッシュパージしか利用できなかったため、短時間で3回の全体パージが必要となり実用性が低かった。

## Cloudflareの新機能

2025年5月から、Cloudflareの無料プランでもURL prefixを指定した選択的キャッシュパージが利用可能になった。

参考: https://blog.cloudflare.com/ja-jp/instant-purge-for-all/

## 対処内容

### 1. `purgeCacheCloudFlare()` 関数の拡張
[`app/Helpers/functions.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/cloudflare-prefix-purge/app/Helpers/functions.php#L200-L234)

- `$prefixes` パラメータを追加し、URL prefixを指定したキャッシュパージに対応
- `files` と `prefixes` を同時に指定可能
- いずれも指定されない場合は従来通り全体パージ

### 2. 毎時更新処理でのパージ方法変更
[`batch/exec/update_recommend_static_data.php`](https://github.com/mimimiku778/Open-Chat-Graph/blob/feature/cloudflare-prefix-purge/batch/exec/update_recommend_static_data.php#L67-L82)

全体パージから、以下の2種類のパージ方法を組み合わせた方式に変更：

**`files` パラメータ（従来から対応）:**
- トップページ（`url()` で取得、言語プレフィックス含む）
- 特定のURLを正確に指定してパージ
- **制限**: 一度に100URLまで

**`prefixes` パラメータ（今回新規追加）:**
- `/recommend`、`/oc`、`/ranking`、`/oclist`、`/recently-registered`、`/labs`、`/policy`、`/furigana`
- 指定したパス以下のすべてのURLを一括パージ
- **利点**: 特定パス以下の数万件のURLも一気にパージ可能

`url()` 関数は言語ごとのプレフィックス（`/ja/`、`/tw/`、`/th/`）を含むURLを返すため、各言語の処理実行時に、その言語のパスのみ効率的にパージできる。

### 3. その他の改善

- `policy` ルートにETagキャッシュ処理を追加

## メリット

- **効率的なキャッシュパージ**: 更新されたデータに関連するパスのみパージ
- **大量URLの一括処理**: `prefixes` により、100URLの制限を超えて数万件を一気にパージ可能
- **言語別対応**: 各言語の処理実行時に、その言語のパスのみパージ
- **CDN負荷軽減**: 全体パージから必要な部分のみのパージへ

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)