### PR TITLE
fix: CloudFlare APIのprefixesからURIスキームを除去

### DIFF
--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -796,3 +796,20 @@ function getSiteDomainUrl(string|array ...$paths): string
 
     return  AppConfig::$siteDomain . ($urlRoot ?? MimimalCmsConfig::$urlRoot) . $uri;
 }
+
+/**
+ * CloudFlare APIのprefixes用URLを生成する（スキームなし）
+ *
+ * CloudFlare APIの仕様:
+ * - files: フルURL必要（https://example.com/path）
+ * - prefixes: スキームなし（example.com/path）
+ *
+ * @param string|array ...$paths The paths to append to the site domain URL.
+ * @return string The site domain URL without scheme.
+ *
+ * * **Example :** Input: `getCdnPrefixUrl("ranking")`  Output: `openchat-review.me/ranking`
+ */
+function getCdnPrefixUrl(string|array ...$paths): string
+{
+    return preg_replace('#^https?://#', '', getSiteDomainUrl(...$paths));
+}

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -144,9 +144,9 @@ class SyncOpenChat
                 function () {
                     $result = purgeCacheCloudFlare(
                         prefixes: [
-                            getSiteDomainUrl('oc'),
-                            getSiteDomainUrl('ranking'),
-                            getSiteDomainUrl('oclist'),
+                            getCdnPrefixUrl('oc'),
+                            getCdnPrefixUrl('ranking'),
+                            getCdnPrefixUrl('oclist'),
                         ]
                     );
                     CronUtility::addVerboseCronLog($result);

--- a/batch/exec/update_recommend_static_data.php
+++ b/batch/exec/update_recommend_static_data.php
@@ -70,14 +70,14 @@ try {
             ltrim(getSiteDomainUrl(), "/"),
         ],
         prefixes: [
-            getSiteDomainUrl('recommend'),
-            getSiteDomainUrl('oc'),
-            getSiteDomainUrl('ranking'),
-            getSiteDomainUrl('oclist'),
-            getSiteDomainUrl('recently-registered'),
-            getSiteDomainUrl('labs'),
-            getSiteDomainUrl('policy'),
-            getSiteDomainUrl('furigana'),
+            getCdnPrefixUrl('recommend'),
+            getCdnPrefixUrl('oc'),
+            getCdnPrefixUrl('ranking'),
+            getCdnPrefixUrl('oclist'),
+            getCdnPrefixUrl('recently-registered'),
+            getCdnPrefixUrl('labs'),
+            getCdnPrefixUrl('policy'),
+            getCdnPrefixUrl('furigana'),
         ]
     );
 


### PR DESCRIPTION
## 問題の概要
CDNキャッシュ削除処理でCloudFlare APIのprefixesパラメータにスキーム（`https://`）付きURLを渡していたため、エラーが発生していました。

## エラー内容
```
RuntimeException: CDNキャッシュ削除失敗: URI scheme provided in prefix https://openchat-review.me/recommend. URI schemes must not be provided.
```

## CloudFlare APIの仕様
- `files`: フルURL必要（`https://example.com/path`）
- `prefixes`: スキームなし（`example.com/path`）

参考: https://developers.cloudflare.com/api/resources/cache/

## 対処内容
- `getCdnPrefixUrl()` 関数を追加（スキームを除去したURLを生成）
- `purgeCacheCloudFlare()` の `prefixes` に渡すURLを修正

https://claude.ai/code/session_01Uw1Ccm2m8STYnCR4bd5s2E