### PR TITLE
fix: 管理者クッキーのチェックを削除し、関連するコードをクリーンアップ

### DIFF
--- a/app/Controllers/Pages/RecentCommentPageController.php
+++ b/app/Controllers/Pages/RecentCommentPageController.php
@@ -38,8 +38,6 @@ class RecentCommentPageController
         $pageTitle = 'コメントのタイムライン';
         $_css = ['room_list', 'site_header', 'site_footer'];
 
-        $isAdmin = isAdsAdmin();
-
         // ページネーションのselect要素
         [$title, $_select, $_label] = $this->pagination->geneSelectElementPagerAsc(
             $path,
@@ -71,7 +69,6 @@ class RecentCommentPageController
                 '_select',
                 '_label',
                 'path',
-                'isAdmin',
                 '_breadcrumbsShema',
                 'topPageDto',
                 'unmodifeidPageNumber',

--- a/app/Controllers/Pages/RecentOpenChatPageController.php
+++ b/app/Controllers/Pages/RecentOpenChatPageController.php
@@ -35,8 +35,6 @@ class RecentOpenChatPageController
         $pageTitle = 'オプチャグラフに最近登録されたオープンチャット';
         $_css = ['room_list', 'site_header', 'site_footer'];
 
-        $isAdmin = isAdsAdmin();
-
         // ページネーションのselect要素
         [$title, $_select, $_label] = $this->pagination->geneSelectElementPagerAsc(
             $path,
@@ -55,7 +53,7 @@ class RecentOpenChatPageController
 
         return view(
             'recent_content',
-            compact('_meta', '_css', '_select', '_label', 'path', 'isAdmin', '_breadcrumbsShema') + $rankingList
+            compact('_meta', '_css', '_select', '_label', 'path', '_breadcrumbsShema') + $rankingList
         );
     }
 }

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -685,17 +685,6 @@ function adminMode(): true
     return true;
 }
 
-function isAdsAdmin(): bool
-{
-    if (!AppConfig::$enableCloudflare) {
-        /** @var AdminAuthService $adminAuthService */
-        $adminAuthService = app(AdminAuthService::class);
-        return $adminAuthService->auth();
-    }
-
-    return false;
-}
-
 function getStorageFileTime(string $filename, bool $fullPath = false): int|false
 {
     $path = $fullPath === false ? (__DIR__ . '/../../storage/' . $filename) : $filename;

--- a/app/Views/components/open_chat_list.php
+++ b/app/Views/components/open_chat_list.php
@@ -18,7 +18,7 @@
       <footer class="openchat-item-lower-outer">
         <div class="openchat-item-lower unset <?php echo ($oc['diff_member'] ?? 1) > 0 ? 'positive' : 'negative' ?>">
           <?php if (isset($oc['datetime'])) : ?>
-            <span class="registration-date blue"><?php echo ($isAdmin ?? false) ? convertDatetime($oc['datetime'], true) : getCronModifiedDateTime($oc['datetime']) ?></span>
+            <span class="registration-date blue"><?php echo getCronModifiedDateTime($oc['datetime']) ?></span>
           <?php endif ?>
           <?php if (isset($oc['member'])) : ?>
             <span>メンバー <?php echo formatMember($oc['member']) ?></span>

--- a/app/Views/live_content.php
+++ b/app/Views/live_content.php
@@ -80,9 +80,7 @@
         const liveTalkAnalyzer = new LiveTalkAnalyzerEventListener(7);
         liveTalkAnalyzer.eventListener();
     </script>
-    <script>
-        const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-    </script>
+
     <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
 </body>
 

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -296,9 +296,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
   ?>
     <script defer type="module" crossorigin src="/<?php echo getFilePath('js/comment', 'index-*.js') ?>"></script>
   <?php endif ?>
-  <script>
-    const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-  </script>
+
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
 
   <?php if ($enableAdsense): ?>

--- a/app/Views/oc_content_jump.php
+++ b/app/Views/oc_content_jump.php
@@ -80,9 +80,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
     <?php viewComponent('footer_inner') ?>
   </div>
   <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-  <script>
-    const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-  </script>
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
   <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
 </body>

--- a/app/Views/oc_content_jump_th.php
+++ b/app/Views/oc_content_jump_th.php
@@ -284,9 +284,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
     <?php viewComponent('footer_inner') ?>
   </div>
   <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-  <script>
-    const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-  </script>
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
   <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
   <script>

--- a/app/Views/recent_comment.php
+++ b/app/Views/recent_comment.php
@@ -140,9 +140,7 @@ viewComponent('head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']) ?
 
         applyTimeElapsedString()
     </script>
-    <script>
-        const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-    </script>
+
     <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
     <?php if ($enableAdsense): ?>
         <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>

--- a/app/Views/recent_content.php
+++ b/app/Views/recent_content.php
@@ -57,16 +57,14 @@
                     <label for="page-selector" class="unset"><span><?php echo $_label ?></span></label>
                 </form>
             </nav>
-            <?php viewComponent('open_chat_list', compact('openChatList', 'isAdmin')) ?>
+            <?php viewComponent('open_chat_list', compact('openChatList')) ?>
             <!-- 次のページ・前のページボタン -->
             <?php viewComponent('pager_nav', compact('pageNumber', 'maxPageNumber') + ['path' => $path]) ?>
         </article>
     </main>
     <?php viewComponent('footer_inner') ?>
     <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-    <script>
-        const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-    </script>
+
     <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
     <script>
         ;

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -178,9 +178,6 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
 
   <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
 
-  <script>
-    const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-  </script>
   <script defer src="<?php echo fileurl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
 
   <?php if ($enableAdsense): ?>

--- a/app/Views/register_form_content.php
+++ b/app/Views/register_form_content.php
@@ -86,9 +86,7 @@
         // 古いSafariの対策
         addOpenChatForm.addEventListener('submit', e => e.target.elements['submit'].disabled && e.preventDefault())
     </script>
-    <script>
-        const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-    </script>
+
     <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
 </body>
 

--- a/app/Views/tags_content.php
+++ b/app/Views/tags_content.php
@@ -136,9 +136,7 @@ function memberCount(int $count)
     </main>
     <?php viewComponent('footer_inner') ?>
     <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-    <script>
-        const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-    </script>
+
     <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
     <?php if ($isAdminPage && isset($adsList)) : ?>
         <script>

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -74,9 +74,7 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
         </div>
     </div>
     <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-    <script>
-        const admin = <?php echo isAdsAdmin() ? 1 : 0; ?>;
-    </script>
+
     <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
     <?php if ($enableAdsense): ?>
         <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>


### PR DESCRIPTION
## 概要
広告ブロック検出処理から管理者クッキーのチェック機能を削除

## 変更内容
- PHPテンプレートから`isAdmin()`関数の呼び出しを削除
- `isAdmin()`ヘルパー関数を削除
- 不要なController処理を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)