### PR TITLE
refactor: 広告タグ出力メソッドの不要な引数を削除

### DIFF
--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -14,7 +14,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
 <body>
   <?php viewComponent('site_header') ?>
   <?php if ($enableAdsense): ?>
-    <?php \App\Views\Ads\GoogleAdsense::gTag('bottom') ?>
+    <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
     <?php GAd::output(GAd::AD_SLOTS['ocTopRectangle'], true) ?>
   <?php endif ?>
 

--- a/app/Views/oc_content_jump.php
+++ b/app/Views/oc_content_jump.php
@@ -14,7 +14,7 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
     }
   </style>
   <?php viewComponent('site_header') ?>
-  <?php \App\Views\Ads\GoogleAdsense::gTag('bottom') ?>
+  <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
   <?php GAd::output(GAd::AD_SLOTS['siteTopRectangle'], true) ?>
   <div class="unset openchat body" style="overflow: hidden; max-width: 600px;">
     <article class="unset" style="display: block;">

--- a/app/Views/oc_content_jump_th.php
+++ b/app/Views/oc_content_jump_th.php
@@ -23,7 +23,7 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
 <body>
   <?php viewComponent('site_header') ?>
   <div class="unset openchat body" style="overflow: hidden;">
-    <?php \App\Views\Ads\GoogleAdsense::gTag('bottom') ?>
+    <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
     <article class="unset" style="display: block;">
       <section class="oc-jump-section oc-info-section">
         <h2 class="oc-jump-main-title">⚠️โปรดอ่านก่อนเข้าร่วม</h2>

--- a/app/Views/ranking_react_content.php
+++ b/app/Views/ranking_react_content.php
@@ -16,7 +16,7 @@ $enableAdsense = \Shared\MimimalCmsConfig::$urlRoot === ''; // 日本語版の�
     <script defer="defer" src="<?php echo fileUrl($_js, urlRoot: '') ?>"></script>
     <link rel="canonical" href="<?php echo url('ranking') . ($category ? '/' . $category : '') ?>">
     <?php if ($enableAdsense): ?>
-        <?php \App\Views\Ads\GoogleAdsense::gTag('bottom') ?>
+        <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
     <?php endif ?>
 
 </head>

--- a/app/Views/recent_comment.php
+++ b/app/Views/recent_comment.php
@@ -12,7 +12,7 @@ viewComponent('head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']) ?
 
 <body class="body">
     <?php if ($enableAdsense): ?>
-        <?php \App\Views\Ads\GoogleAdsense::gTag('bottom') ?>
+        <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
     <?php endif ?>
     <style>
         .list-title {

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -25,7 +25,7 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
 
 <body>
   <?php if ($enableAdsense): ?>
-    <?php \App\Views\Ads\GoogleAdsense::gTag('bottom') ?>
+    <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
     <?php GAd::output(GAd::AD_SLOTS['recommendTopRectangle'], true) ?>
   <?php endif ?>
 

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -13,7 +13,7 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
 <body class="top-page">
     <?php if ($enableAdsense): ?>
-        <?php \App\Views\Ads\GoogleAdsense::gTag('bottom') ?>
+        <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
     <?php endif ?>
 
     <?php viewComponent('site_header', compact('_updatedAt')) ?>


### PR DESCRIPTION
## 概要
各ビューファイルで `gTag('bottom')` の引数 `'bottom'` を削除し、`gTag()` に統一。

## 変更ファイル
- `oc_content.php`
- `oc_content_jump.php`
- `oc_content_jump_th.php`
- `ranking_react_content.php`
- `recent_comment.php`
- `recommend_content.php`
- `top_content.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)