### PR TITLE
fix: Codespaces環境設定をlocal-secrets.phpに統合

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -12,19 +12,6 @@ sudo mv gh_2.63.2_linux_amd64/bin/gh /usr/local/bin/
 rm -rf gh_2.63.2_linux_amd64
 echo "✅ GitHub CLIのインストールが完了しました。"
 
-cat << 'EOF' > shared/secrets.php
-<?php
-
-if (
-    isset($_SERVER['HTTP_HOST'], $_SERVER["HTTP_X_FORWARDED_HOST"])
-    && str_contains($_SERVER["HTTP_X_FORWARDED_HOST"], 'github.dev')
-) {
-    $_SERVER['HTTP_HOST'] = $_SERVER["HTTP_X_FORWARDED_HOST"];
-    $_SERVER['HTTPS'] = 'on';
-}
-
-EOF
-
 # MySQL設定ファイルのパーミッションを修正（Codespaces環境でworld-writable警告を防ぐ）
 chmod 644 docker/mysql/server.cnf
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - IS_MOCK_ENVIRONMENT=${IS_MOCK_ENVIRONMENT:-0}
       # Xdebug有効化（1で有効、0で無効）
       - ENABLE_XDEBUG=${ENABLE_XDEBUG:-0}
+      - WEB_PORT=${WEB_PORT:-8000}
+      - HTTPS_PORT=${HTTPS_PORT:-8443}
   mysql:
     build:
       context: "docker/mysql/"

--- a/setup/local-setup.default.sh
+++ b/setup/local-setup.default.sh
@@ -187,6 +187,22 @@ if (function_exists('getenv') && ($isMockEnv = getenv('IS_MOCK_ENVIRONMENT')) !=
     AppConfig::$isMockEnvironment = false;
 }
 
+// GitHub Codespaces環境対応
+if (
+    isset($_SERVER['HTTP_HOST'], $_SERVER["HTTP_X_FORWARDED_HOST"])
+    && str_contains($_SERVER["HTTP_X_FORWARDED_HOST"], 'github.dev')
+) {
+    $_SERVER['HTTP_HOST'] = $_SERVER["HTTP_X_FORWARDED_HOST"];
+    $_SERVER['HTTPS'] = 'on';
+
+    // モック環境の場合、LINE画像URLをCodespaces用に変更
+    if (function_exists('getenv') && ($isMockEnv = getenv('IS_MOCK_ENVIRONMENT')) !== false) {
+        $host = $_SERVER['HTTP_HOST'];
+        $host = str_replace(getenv('HTTPS_PORT'), getenv('LINE_MOCK_PORT'), $host);
+        AppConfig::$lineImageUrl = 'https://' . $host . '/obs/';
+    }
+}
+
 AppConfig::$isStaging = false;
 AppConfig::$phpBinary = 'php';
 


### PR DESCRIPTION
## 概要
Codespaces環境対応の設定をsecrets.phpからlocal-secrets.phpに移動

## 変更内容
- post-create-command.shでのsecrets.php生成処理を削除
- local-secrets.phpにCodespaces環境判定とLINE画像URL対応を追加
- docker-compose.ymlにポート環境変数を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)