### PR TITLE
refactor: マイリストAPIのキャッシュ制御を最適化

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -177,10 +177,11 @@ Route::path('ranking-position/{user}/oc/{open_chat_id}/position_hour')
     });
 
 Route::path('mylist-api', [MyListApiController::class, 'index'])
-    ->match(function (FileStorageInterface $fileStorage) {
+    ->match(function () {
         if (MimimalCmsConfig::$urlRoot !== '')
             return false;
-        checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
+
+        noStore();
     });
 
 Route::path('recent-comment-api', [RecentCommentApiController::class, 'index'])

--- a/app/Controllers/Api/MyListApiController.php
+++ b/app/Controllers/Api/MyListApiController.php
@@ -23,7 +23,6 @@ class MyListApiController
             return false;
         }
 
-        sessionStart();
         [$expires, $myListIdArray, $myList] = $myOpenChatList->init();
         if (!$expires)
             return false;


### PR DESCRIPTION
## 変更内容

マイリストAPIで不要な処理を削除し、キャッシュ制御を適切に設定

### 変更点

- 不要な`sessionStart()`呼び出しを削除（マイリストはCookieベースで動作）
- キャッシュ制御を`noStore()`に変更（ユーザー固有データのため）