### PR TITLE
[STG] skip-ci: 管理APIの安全化・一括操作・Discord通知拡張

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init init-y init-y-n _init up down restart rebuild ssh up-mock cron cron-stop show cert ci-test phpstan build-frontend build-frontend\:ranking build-frontend\:comments build-frontend\:graph build-frontend\:all-room-stats _build-one-frontend _wait-mysql _is-mock _check-data-protection
+.PHONY: help init init-y init-y-n _init up down restart rebuild ssh up-mock cron cron-stop show cert ci-test phpstan build-frontend build-frontend\:ranking build-frontend\:oc-app build-frontend\:all-room-stats _build-one-frontend _wait-mysql _is-mock _check-data-protection
 
 # .envファイルを読み込み（存在しない場合はスキップ）
 -include .env
@@ -60,8 +60,7 @@ help: ## ヘルプを表示
 	@echo "$(YELLOW)フロントエンド:$(NC)"
 	@echo "  $(GREEN)make build-frontend$(NC)          - フロントエンドを全てビルド"
 	@echo "  $(GREEN)make build-frontend:ranking$(NC)  - ランキングのみビルド"
-	@echo "  $(GREEN)make build-frontend:comments$(NC) - コメントのみビルド"
-	@echo "  $(GREEN)make build-frontend:graph$(NC)    - グラフのみビルド"
+	@echo "  $(GREEN)make build-frontend:oc-app$(NC)   - コメント・グラフ等のみビルド"
 	@echo "  $(GREEN)make build-frontend:all-room-stats$(NC) - 全体統計のみビルド"
 	@echo ""
 	@echo "$(YELLOW)静的解析:$(NC)"
@@ -155,15 +154,10 @@ build-frontend\:ranking: ## ランキングのみビルド
 	@$(MAKE) _build-one-frontend DIR=frontend/ranking
 	@echo "$(GREEN)ranking ビルド完了$(NC)"
 
-build-frontend\:comments: ## コメントのみビルド
-	@echo "$(GREEN)comments をビルドしています...$(NC)"
-	@$(MAKE) _build-one-frontend DIR=frontend/comments
-	@echo "$(GREEN)comments ビルド完了$(NC)"
-
-build-frontend\:graph: ## グラフのみビルド
-	@echo "$(GREEN)graph をビルドしています...$(NC)"
-	@$(MAKE) _build-one-frontend DIR=frontend/stats-graph
-	@echo "$(GREEN)graph ビルド完了$(NC)"
+build-frontend\:oc-app: ## コメント・グラフ等をビルド
+	@echo "$(GREEN)oc-app をビルドしています...$(NC)"
+	@$(MAKE) _build-one-frontend DIR=frontend/oc-app
+	@echo "$(GREEN)oc-app ビルド完了$(NC)"
 
 build-frontend\:all-room-stats: ## 全体統計のみビルド
 	@echo "$(GREEN)all-room-stats をビルドしています...$(NC)"

--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -162,6 +162,9 @@ class AppConfig
     static string $githubBranch = 'main';
     static bool $disableAdTags = true;
 
+    // 重複通報の受付をスキップ（管理者が既に対応している通報をさらに通報されるのを防止）
+    static bool $skipDuplicateReport = false;
+
     /** @var array<string,int> */
     static array $developmentEnvUpdateLimit = [
         'OpenChatHourlyInvitationTicketUpdater' => 10,

--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -551,7 +551,7 @@ Route::path(
     ->matchNum('flag', min: 0, max: 5);
 
 Route::path(
-    'admin-api/deleteuser@post',
+    'admin-api/deleteuser@post@get',
     [AdminEndPointController::class, 'deleteuser']
 )
     ->matchNum('id')
@@ -559,8 +559,15 @@ Route::path(
     ->matchNum('commentId');
 
 Route::path(
-    'admin-api/commentbanroom@post',
+    'admin-api/commentbanroom@post@get',
     [AdminEndPointController::class, 'commentbanroom']
+)
+    ->match(fn() => MimimalCmsConfig::$urlRoot === '')
+    ->matchNum('id');
+
+Route::path(
+    'admin-api/commentunbanroom@post@get',
+    [AdminEndPointController::class, 'commentunbanroom']
 )
     ->match(fn() => MimimalCmsConfig::$urlRoot === '')
     ->matchNum('id');
@@ -569,28 +576,42 @@ Route::path('admin-api/commentimagestorage@post', [AdminEndPointController::clas
     ->match(fn() => MimimalCmsConfig::$urlRoot === '');
 
 Route::path(
-    'admin-api/deletecommentimage@post',
+    'admin-api/deletecommentimage@post@get',
     [AdminEndPointController::class, 'deleteCommentImage']
 )
     ->match(fn() => MimimalCmsConfig::$urlRoot === '')
     ->matchNum('imageId');
 
 Route::path(
-    'admin-api/deletedcommentimages@post',
+    'admin-api/deletedcommentimages@post@get',
     [AdminEndPointController::class, 'deleteDeletedCommentImages']
 )
     ->match(fn() => MimimalCmsConfig::$urlRoot === '');
 
 Route::path(
-    'admin-api/deletecommentsall@post',
+    'admin-api/deletecommentsall@post@get',
     [AdminEndPointController::class, 'deletecommentsall']
 )
     ->match(fn() => MimimalCmsConfig::$urlRoot === '')
     ->matchNum('id');
 
 Route::path(
-    'admin-api/restorecommentsall@post',
+    'admin-api/restorecommentsall@post@get',
     [AdminEndPointController::class, 'restorecommentsall']
+)
+    ->match(fn() => MimimalCmsConfig::$urlRoot === '')
+    ->matchNum('id');
+
+Route::path(
+    'admin-api/harddeletecommentsall@post@get',
+    [AdminEndPointController::class, 'harddeletecommentsall']
+)
+    ->match(fn() => MimimalCmsConfig::$urlRoot === '')
+    ->matchNum('id');
+
+Route::path(
+    'admin-api/bulkshadowban@post@get',
+    [AdminEndPointController::class, 'bulkshadowban']
 )
     ->match(fn() => MimimalCmsConfig::$urlRoot === '')
     ->matchNum('id');

--- a/app/Controllers/Api/AdminEndPointController.php
+++ b/app/Controllers/Api/AdminEndPointController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controllers\Api;
 
+use App\Config\AppConfig;
 use App\Models\CommentRepositories\CommentImageRepositoryInterface;
 use App\Models\CommentRepositories\CommentLogRepositoryInterface;
 use App\Models\CommentRepositories\CommentPostRepositoryInterface;
@@ -24,6 +25,21 @@ class AdminEndPointController
         if (!$adminAuthService->auth()) {
             throw new NotFoundException;
         }
+    }
+
+    private function requireConfirmation(string $title, string $description, string $action, array $params, ?string $cancelUrl = null)
+    {
+        if (!empty($_REQUEST['confirmed'])) {
+            return null;
+        }
+
+        return view('admin/admin_confirm_page', [
+            'title' => $title,
+            'description' => $description,
+            'action' => url($action),
+            'params' => $params,
+            'cancelUrl' => $cancelUrl ?? '/',
+        ]);
     }
 
     function index(string $type, string $id, AdminEndPoint $adminEndPoint)
@@ -56,6 +72,16 @@ class AdminEndPointController
         CommentImageServiceInterface $commentImageService,
         CommentLogRepositoryInterface $commentLogRepository
     ) {
+        $flagLabel = AppConfig::COMMENT_FLAG_LABELS[$flag] ?? "flag={$flag}";
+        $confirm = $this->requireConfirmation(
+            "コメントのフラグ変更確認",
+            "コメント #{$commentId} を「{$flagLabel}」に変更します。",
+            'admin-api/deletecomment',
+            ['id' => $id, 'commentId' => $commentId, 'flag' => $flag],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
+
         // ログ用にcomment_idを事前取得
         $comment_id = $deleteCommentRepository->getCommentId($id, $commentId);
 
@@ -116,6 +142,15 @@ class AdminEndPointController
         DeleteCommentRepositoryInterface $deleteCommentRepository,
         CommentLogRepositoryInterface $commentLogRepository
     ) {
+        $confirm = $this->requireConfirmation(
+            "ユーザーシャドウバン確認",
+            "コメント #{$commentId} の投稿者をシャドウバンします。\n該当ユーザーの全コメントがシャドウ削除されます。",
+            'admin-api/deleteuser',
+            ['id' => $id, 'commentId' => $commentId],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
+
         $comment_id = $deleteCommentRepository->getCommentId($id, $commentId);
         if (!$comment_id) {
             return view('admin/admin_message_page', ['title' => 'ユーザー削除', 'message' => 'ユーザーがいません']);
@@ -148,10 +183,35 @@ class AdminEndPointController
 
     function commentbanroom(int $id, CommentPostRepositoryInterface $commentPostRepo)
     {
+        $confirm = $this->requireConfirmation(
+            "コメント禁止確認",
+            "このオープンチャットのコメントを1週間禁止します。",
+            'admin-api/commentbanroom',
+            ['id' => $id],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
+
         $result = $commentPostRepo->addBanRoom($id);
         if (!$result) {
             return view('admin/admin_message_page', ['title' => '存在しない部屋です', 'message' => '存在しない部屋です']);
         }
+
+        return redirect("oc/{$id}/admin");
+    }
+
+    function commentunbanroom(int $id, CommentPostRepositoryInterface $commentPostRepo)
+    {
+        $confirm = $this->requireConfirmation(
+            "コメント禁止解除確認",
+            "このオープンチャットのコメント禁止を解除します。",
+            'admin-api/commentunbanroom',
+            ['id' => $id],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
+
+        $commentPostRepo->removeBanRoom($id);
 
         return redirect("oc/{$id}/admin");
     }
@@ -163,8 +223,17 @@ class AdminEndPointController
         CommentImageServiceInterface $commentImageService,
         CommentLogRepositoryInterface $commentLogRepository
     ) {
-        // ログ用に影響するcomment_idを事前取得（flag=1,2,4は除外 = softDeleteAllCommentsと同じ条件）
-        $affectedIds = $deleteCommentRepository->getCommentIdsByOpenChatId($id, [1, 2, 4]);
+        $confirm = $this->requireConfirmation(
+            "全コメント通常削除確認",
+            "このオープンチャットの全コメントを通常削除（flag=5）します。",
+            'admin-api/deletecommentsall',
+            ['id' => $id],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
+
+        // ログ用に影響するcomment_idを事前取得（flag=2,4,5は除外 = softDeleteAllCommentsと同じ条件）
+        $affectedIds = $deleteCommentRepository->getCommentIdsByOpenChatId($id, [2, 4, 5]);
 
         $filenames = $deleteCommentRepository->getCommentImageFilenames($id);
         $count = $deleteCommentRepository->softDeleteAllComments($id);
@@ -198,12 +267,21 @@ class AdminEndPointController
         CommentImageServiceInterface $commentImageService,
         CommentLogRepositoryInterface $commentLogRepository
     ) {
-        // ログ用にflag=5のcomment_idを事前取得
-        $affectedIds = $deleteCommentRepository->getSoftDeletedCommentIds($id);
+        $confirm = $this->requireConfirmation(
+            "全コメント復元確認",
+            "削除されたコメント（シャドウ削除・通常削除）を全て復元します。",
+            'admin-api/restorecommentsall',
+            ['id' => $id],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
 
-        // flag=5のコメントに紐づく画像を復元
-        $filenames = $deleteCommentRepository->getSoftDeletedCommentImageFilenames($id);
-        $count = $deleteCommentRepository->restoreSoftDeletedComments($id);
+        // ログ用にflag=1,5のcomment_idを事前取得
+        $affectedIds = $deleteCommentRepository->getDeletedCommentIds($id);
+
+        // flag=1,5のコメントに紐づく画像を復元
+        $filenames = $deleteCommentRepository->getDeletedCommentImageFilenames($id);
+        $count = $deleteCommentRepository->restoreDeletedComments($id);
 
         // 管理者操作ログ記録
         if (!empty($affectedIds)) {
@@ -232,6 +310,14 @@ class AdminEndPointController
         CommentImageRepositoryInterface $commentImageRepository,
         CommentImageServiceInterface $commentImageService
     ) {
+        $confirm = $this->requireConfirmation(
+            "画像削除確認",
+            "画像ID: {$imageId} を完全削除します。",
+            'admin-api/deletecommentimage',
+            ['imageId' => $imageId],
+        );
+        if ($confirm) return $confirm;
+
         $filename = $commentImageRepository->deleteImageById($imageId);
         if (!$filename) {
             return view('admin/admin_message_page', ['title' => '画像削除', 'message' => '画像が見つかりません']);
@@ -256,6 +342,14 @@ class AdminEndPointController
         CommentImageRepositoryInterface $commentImageRepository,
         CommentImageServiceInterface $commentImageService
     ) {
+        $confirm = $this->requireConfirmation(
+            "削除済み画像一括削除確認",
+            "削除済みコメントに紐づく画像ファイルを全て物理削除します。",
+            'admin-api/deletedcommentimages',
+            [],
+        );
+        if ($confirm) return $confirm;
+
         $images = $commentImageRepository->getDeletedCommentImages(999999);
         if (empty($images)) {
             return view('admin/admin_message_page', ['title' => '画像一括削除', 'message' => '削除対象の画像はありません']);
@@ -269,6 +363,98 @@ class AdminEndPointController
 
         $count = count($filenames);
         return view('admin/admin_message_page', ['title' => '画像一括削除', 'message' => "{$count}件の画像を削除しました"]);
+    }
+
+    function harddeletecommentsall(
+        int $id,
+        DeleteCommentRepositoryInterface $deleteCommentRepository,
+        CommentImageServiceInterface $commentImageService,
+        CommentLogRepositoryInterface $commentLogRepository
+    ) {
+        $confirm = $this->requireConfirmation(
+            "全コメント完全削除確認",
+            "このオープンチャットの全コメント・画像を完全削除します。\nこの操作は元に戻せません。",
+            'admin-api/harddeletecommentsall',
+            ['id' => $id],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
+
+        // ログ用に全comment_idを事前取得
+        $affectedIds = $deleteCommentRepository->getCommentIdsByOpenChatId($id, []);
+
+        $filenames = $deleteCommentRepository->deleteCommentsAll($id);
+
+        // 管理者操作ログ記録
+        if (!empty($affectedIds)) {
+            $commentLogRepository->addAdminLogs($affectedIds, CommentLogType::AdminBulkDelete);
+        }
+
+        if (!empty($filenames)) {
+            $commentImageService->deleteImages($filenames);
+        }
+
+        try {
+            purgeCacheCloudFlare(files: [
+                url('recent-comment-api'),
+                url('comments-timeline'),
+            ]);
+        } catch (\RuntimeException $e) {
+            AdminTool::sendDiscordNotify($e->getMessage());
+            ExceptionHandler::errorLog($e);
+        }
+
+        return redirect("oc/{$id}/admin");
+    }
+
+    function bulkshadowban(
+        int $id,
+        CommentPostRepositoryInterface $commentPostRepo,
+        DeleteCommentRepositoryInterface $deleteCommentRepository,
+        CommentImageRepositoryInterface $commentImageRepository,
+        CommentImageServiceInterface $commentImageService,
+        CommentLogRepositoryInterface $commentLogRepository
+    ) {
+        $confirm = $this->requireConfirmation(
+            "一斉シャドウバン確認",
+            "このオープンチャットの全投稿者をBANし、全コメントをシャドウ削除します。\n画像はhiddenに移動されます。",
+            'admin-api/bulkshadowban',
+            ['id' => $id],
+            url("oc/{$id}/admin")
+        );
+        if ($confirm) return $confirm;
+
+        // 全投稿者BAN
+        $commentPostRepo->addBanUsersInRoom($id);
+
+        // ログ用に影響するcomment_idを事前取得（flag=1,2,4は除外 = shadowDeleteAllCommentsと同じ条件）
+        $affectedIds = $deleteCommentRepository->getCommentIdsByOpenChatId($id, [1, 2, 4]);
+
+        // 全コメントシャドウ削除
+        $deleteCommentRepository->shadowDeleteAllComments($id);
+
+        // 管理者操作ログ記録
+        if (!empty($affectedIds)) {
+            $commentLogRepository->addAdminLogs($affectedIds, CommentLogType::AdminBulkBanUsers);
+        }
+
+        // 画像をhiddenに移動
+        $filenames = $deleteCommentRepository->getCommentImageFilenames($id);
+        if (!empty($filenames)) {
+            $commentImageService->hideImages($filenames);
+        }
+
+        try {
+            purgeCacheCloudFlare(files: [
+                url('recent-comment-api'),
+                url('comments-timeline'),
+            ]);
+        } catch (\RuntimeException $e) {
+            AdminTool::sendDiscordNotify($e->getMessage());
+            ExceptionHandler::errorLog($e);
+        }
+
+        return redirect("oc/{$id}/admin");
     }
 
     /**

--- a/app/Controllers/Api/CommentReportApiController.php
+++ b/app/Controllers/Api/CommentReportApiController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controllers\Api;
 
+use App\Config\AppConfig;
 use App\Models\CommentRepositories\CommentImageRepositoryInterface;
 use App\Models\CommentRepositories\CommentListRepositoryInterface;
 use App\Models\CommentRepositories\CommentLogRepositoryInterface;
@@ -33,37 +34,7 @@ class CommentReportApiController
         $comment = $this->commentListRepository->findCommentById($comment_id);
         if (!$comment) return false;
 
-        if ($this->isDuplicateReport($comment_id, CommentLogType::Report, $reportUserId)) {
-            return response(['success' => false]);
-        }
-
-        $this->commentLogRepository->addLog(
-            $comment_id, CommentLogType::Report, getIP(), getUA(),
-            json_encode(['report_user_id' => $reportUserId])
-        );
-
-        $id = $comment['id'];
-        $ocId = $comment['open_chat_id'];
-        $reporter = $this->buildReporterInfo($reportUserId);
-        $poster = $this->buildPosterInfo($comment);
-        $roomInfo = $this->buildRoomInfo($ocId);
-
-        $deleteUrl = url("admin-api/deletecomment?openExternalBrowser=1&id={$ocId}&commentId={$id}&flag=2");
-        $roomUrl = url("oc/{$ocId}/admin?openExternalBrowser=1");
-        $logUrl = url("admin/log/admin-action?openExternalBrowser=1");
-
-        AdminTool::sendDiscordNotify(
-            "📢 **コメント通報**\n"
-            . "\n**ルーム**\n{$roomInfo}\n"
-            . "\n**コメント #{$id}**\n{$comment['text']}\n"
-            . $this->formatPosterSection($poster)
-            . $this->formatReporterSection($reporter)
-            . "\n> 🗑️ [削除する]({$deleteUrl})\n"
-            . "> 🏠 [ルーム管理]({$roomUrl})\n"
-            . "> 📋 [操作ログ]({$logUrl})"
-        );
-
-        return response(['success' => true]);
+        return $this->handleReport($comment_id, CommentLogType::Report, $reportUserId, $comment);
     }
 
     function reportImage(
@@ -74,67 +45,68 @@ class CommentReportApiController
         $reportUserId = $this->validateReporter($token);
         if ($reportUserId === false) return response(['success' => false]);
 
-        if ($this->isDuplicateReport($image_id, CommentLogType::ImageReport, $reportUserId)) {
-            return response(['success' => false]);
-        }
+        $commentId = $commentImageRepository->getCommentIdByImageId($image_id);
+        if ($commentId === false) return false;
 
-        $this->commentLogRepository->addLog(
-            $image_id, CommentLogType::ImageReport, getIP(), getUA(),
-            json_encode(['report_user_id' => $reportUserId])
-        );
-
-        $reporter = $this->buildReporterInfo($reportUserId);
+        $comment = $this->commentListRepository->findCommentById($commentId);
+        if (!$comment) return false;
 
         $imageFilename = $commentImageRepository->getFilenameByImageId($image_id);
         $imageUrl = $imageFilename
             ? url('comment-img/' . substr($imageFilename, 0, 2) . '/' . $imageFilename)
             : '';
 
-        $commentId = $commentImageRepository->getCommentIdByImageId($image_id);
-        $comment = $commentId !== false ? $this->commentListRepository->findCommentById($commentId) : false;
+        return $this->handleReport($image_id, CommentLogType::ImageReport, $reportUserId, $comment, $imageUrl);
+    }
 
-        if ($comment) {
-            $id = $comment['id'];
-            $ocId = $comment['open_chat_id'];
-            $poster = $this->buildPosterInfo($comment);
-            $roomInfo = $this->buildRoomInfo($ocId);
-
-            $deleteImageUrl = url("admin-api/deletecomment?openExternalBrowser=1&id={$ocId}&commentId={$id}&flag=4");
-            $deleteCommentUrl = url("admin-api/deletecomment?openExternalBrowser=1&id={$ocId}&commentId={$id}&flag=2");
-            $roomUrl = url("oc/{$ocId}/admin?openExternalBrowser=1");
-            $logUrl = url("admin/log/admin-action?openExternalBrowser=1");
-
-            AdminTool::sendDiscordNotify(
-                "🖼️ **画像通報**\n"
-                . "\n**ルーム**\n{$roomInfo}\n"
-                . "\n**コメント #{$id}**\n{$comment['text']}\n"
-                . $this->formatPosterSection($poster)
-                . $this->formatReporterSection($reporter)
-                . "\n> 🖼️ [画像削除]({$deleteImageUrl})\n"
-                . "> 🗑️ [コメント削除]({$deleteCommentUrl})\n"
-                . "> 🏠 [ルーム管理]({$roomUrl})\n"
-                . "> 📋 [操作ログ]({$logUrl})"
-                . ($imageUrl ? "\n{$imageUrl}" : '')
-            );
-        } else {
-            $deleteImageUrl = url("admin-api/deletecommentimage?openExternalBrowser=1&imageId={$image_id}");
-
-            AdminTool::sendDiscordNotify(
-                "🖼️ **画像通報**\n"
-                . "\n**画像ID**: {$image_id}\n"
-                . $this->formatReporterSection($reporter)
-                . "\n> 🗑️ [画像削除]({$deleteImageUrl})"
-                . ($imageUrl ? "\n{$imageUrl}" : '')
-            );
+    private function handleReport(
+        int $entityId,
+        CommentLogType $logType,
+        string $reportUserId,
+        array $comment,
+        string $imageUrl = '',
+    ) {
+        if ($this->isDuplicateReport($entityId, $logType, $reportUserId)) {
+            return response(['success' => false]);
         }
+
+        $this->commentLogRepository->addLog(
+            $entityId, $logType, getIP(), getUA(),
+            json_encode(['report_user_id' => $reportUserId])
+        );
+
+        $id = $comment['id'];
+        $ocId = $comment['open_chat_id'];
+        $reporter = $this->buildUserInfo($reportUserId);
+        $poster = $this->buildPosterInfo($comment);
+        $roomInfo = $this->buildRoomInfo($ocId);
+
+        $base = "admin-api/deletecomment?openExternalBrowser=1&id={$ocId}&commentId={$id}";
+        $isImage = $logType === CommentLogType::ImageReport;
+
+        $deleteImageLine = $isImage
+            ? "> 🖼️ [画像のみ削除](" . url("{$base}&flag=4") . ")\n"
+            : '';
+
+        AdminTool::sendDiscordNotify(
+            ($isImage ? "🖼️ **画像通報**" : "📢 **コメント通報**") . "\n"
+            . "\n**ルーム**\n{$roomInfo}\n"
+            . "\n**コメント #{$id}**\n{$comment['text']}\n"
+            . $this->formatPosterSection($poster)
+            . $this->formatReporterSection($reporter)
+            . "\n{$deleteImageLine}"
+            . "> 🔇 [シャドウ削除](" . url("{$base}&flag=1") . ")\n"
+            . "> 🗑️ [通常削除](" . url("{$base}&flag=5") . ")\n"
+            . "> ❌ [完全削除](" . url("{$base}&flag=3") . ")\n"
+            . "> 🚫 [ユーザーシャドウバン](" . url("admin-api/deleteuser?openExternalBrowser=1&id={$ocId}&commentId={$id}") . ")\n"
+            . "> 🏠 [ルーム管理](" . url("oc/{$ocId}/admin?openExternalBrowser=1") . ")\n"
+            . "> 📋 [操作ログ](" . url("admin/log/admin-action?openExternalBrowser=1") . ")"
+            . ($imageUrl ? "\n{$imageUrl}" : '')
+        );
 
         return response(['success' => true]);
     }
 
-    /**
-     * reCAPTCHA検証 + BAN判定
-     * @return string|false report_user_id or false
-     */
     private function validateReporter(string $token): string|false
     {
         $this->googleReCaptcha->validate($token, 0.5);
@@ -149,29 +121,31 @@ class CommentReportApiController
 
     private function isDuplicateReport(int $entityId, CommentLogType $type, string $reportUserId): bool
     {
+        if (!AppConfig::$skipDuplicateReport) {
+            return false;
+        }
+
         return $this->commentLogRepository->findReportLog(
             $entityId, $type, json_encode(['report_user_id' => $reportUserId])
         );
     }
 
-    /** @return array{ hash: string, ip: string, ua: string, ipHash: string, uaHash: string, nameStr: string } */
-    private function buildReporterInfo(string $reportUserId): array
+    private function buildUserInfo(string $userId): array
     {
         $ip = getIP();
         $ua = getUA();
-        $names = $this->commentLogRepository->findRecentNamesByUserIdOrIp($reportUserId, $ip);
+        $names = $this->commentLogRepository->findRecentNamesByUserIdOrIp($userId, $ip);
 
         return [
-            'hash' => substr(hash('sha256', $reportUserId), 0, 7),
-            'ip' => $ip,
-            'ua' => $ua,
+            'hash' => substr(hash('sha256', $userId), 0, 7),
             'ipHash' => substr(hash('sha256', $ip), 0, 7),
             'uaHash' => substr(hash('sha256', $ua), 0, 7),
+            'ip' => $ip,
+            'ua' => $ua,
             'nameStr' => !empty($names) ? implode(', ', $names) : '',
         ];
     }
 
-    /** @return array{ hash: string, ip: string, ua: string, ipHash: string, uaHash: string, nameStr: string } */
     private function buildPosterInfo(array $comment): array
     {
         $posterLog = $this->commentLogRepository->findAddCommentLog($comment['comment_id']);
@@ -188,10 +162,10 @@ class CommentReportApiController
 
         return [
             'hash' => substr(hash('sha256', $userId), 0, 7),
-            'ip' => $ip,
-            'ua' => $ua,
             'ipHash' => substr(hash('sha256', $ip), 0, 7),
             'uaHash' => substr(hash('sha256', $ua), 0, 7),
+            'ip' => $ip,
+            'ua' => $ua,
             'nameStr' => $nameStr,
         ];
     }
@@ -204,25 +178,25 @@ class CommentReportApiController
             : "ID: {$ocId}";
     }
 
-    private function formatPosterSection(array $poster): string
+    private function formatPosterSection(array $info): string
     {
         return "\n**投稿者**\n"
-            . "- 名前: {$poster['nameStr']}\n"
-            . "- ID: {$poster['hash']}\n"
-            . "- IP-hash: {$poster['ipHash']}\n"
-            . "  - IP: {$poster['ip']}\n"
-            . "- UA-hash: {$poster['uaHash']}\n"
-            . "  - UA: {$poster['ua']}\n";
+            . "- 名前: {$info['nameStr']}\n"
+            . "- ID: {$info['hash']}\n"
+            . "- IP-hash: {$info['ipHash']}\n"
+            . "  - IP: {$info['ip']}\n"
+            . "- UA-hash: {$info['uaHash']}\n"
+            . "  - UA: {$info['ua']}\n";
     }
 
-    private function formatReporterSection(array $reporter): string
+    private function formatReporterSection(array $info): string
     {
         return "\n**通報者**\n"
-            . ($reporter['nameStr'] ? "- 名前: {$reporter['nameStr']}\n" : '')
-            . "- ID: {$reporter['hash']}\n"
-            . "- IP-hash: {$reporter['ipHash']}\n"
-            . "  - IP: {$reporter['ip']}\n"
-            . "- UA-hash: {$reporter['uaHash']}\n"
-            . "  - UA: {$reporter['ua']}\n";
+            . ($info['nameStr'] ? "- 名前: {$info['nameStr']}\n" : '')
+            . "- ID: {$info['hash']}\n"
+            . "- IP-hash: {$info['ipHash']}\n"
+            . "  - IP: {$info['ip']}\n"
+            . "- UA-hash: {$info['uaHash']}\n"
+            . "  - UA: {$info['ua']}\n";
     }
 }

--- a/app/Models/CommentRepositories/Api/ApiCommentPostRepository.php
+++ b/app/Models/CommentRepositories/Api/ApiCommentPostRepository.php
@@ -60,4 +60,24 @@ class ApiCommentPostRepository implements CommentPostRepositoryInterface
 
         return SQLiteOcgraphSqlapi::fetchColumn($query, compact('user_id', 'ip'));
     }
+
+    function addBanUsersInRoom(int $open_chat_id): int
+    {
+        throw new \RuntimeException('Write operation not supported in API repository');
+    }
+
+    function removeBanRoom(int $open_chat_id): bool
+    {
+        throw new \RuntimeException('Write operation not supported in API repository');
+    }
+
+    function getBanRoomExpiry(int $open_chat_id): string|false
+    {
+        return SQLiteOcgraphSqlapi::fetchColumn(
+            "SELECT created_at FROM ban_room
+             WHERE open_chat_id = :open_chat_id AND created_at >= datetime('now', '-7 days')
+             ORDER BY created_at DESC LIMIT 1",
+            compact('open_chat_id')
+        );
+    }
 }

--- a/app/Models/CommentRepositories/CommentPostRepository.php
+++ b/app/Models/CommentRepositories/CommentPostRepository.php
@@ -96,16 +96,67 @@ class CommentPostRepository implements CommentPostRepositoryInterface
     function getBanUser(string $user_id, string $ip): string|false
     {
         $query =
-            "SELECT 
+            "SELECT
                 user_id
-            FROM 
-                ban_user 
-            WHERE 
-                user_id = :user_id 
+            FROM
+                ban_user
+            WHERE
+                user_id = :user_id
                 OR ip = :ip
             LIMIT
                 1";
 
         return CommentDB::fetchColumn($query, compact('user_id', 'ip'));
+    }
+
+    function addBanUsersInRoom(int $open_chat_id): int
+    {
+        $query =
+            "SELECT DISTINCT
+                t1.user_id,
+                t2.ip
+            FROM
+                comment AS t1
+                JOIN log AS t2 ON t1.comment_id = t2.entity_id AND t2.type = 'AddComment'
+            WHERE
+                t1.open_chat_id = :open_chat_id
+                AND t1.user_id != ''";
+
+        $users = CommentDB::fetchAll($query, compact('open_chat_id'));
+        $count = 0;
+
+        foreach ($users as $user) {
+            $existing = CommentDB::fetchColumn(
+                "SELECT user_id FROM ban_user WHERE user_id = :user_id AND ip = :ip LIMIT 1",
+                $user
+            );
+            if ($existing) continue;
+
+            CommentDB::execute(
+                "INSERT INTO ban_user (user_id, ip) VALUES (:user_id, :ip)",
+                $user
+            );
+            $count++;
+        }
+
+        return $count;
+    }
+
+    function removeBanRoom(int $open_chat_id): bool
+    {
+        return CommentDB::executeAndCheckResult(
+            "DELETE FROM ban_room WHERE open_chat_id = :open_chat_id AND created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)",
+            compact('open_chat_id')
+        );
+    }
+
+    function getBanRoomExpiry(int $open_chat_id): string|false
+    {
+        return CommentDB::fetchColumn(
+            "SELECT created_at FROM ban_room
+             WHERE open_chat_id = :open_chat_id AND created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+             ORDER BY created_at DESC LIMIT 1",
+            compact('open_chat_id')
+        );
     }
 }

--- a/app/Models/CommentRepositories/CommentPostRepositoryInterface.php
+++ b/app/Models/CommentRepositories/CommentPostRepositoryInterface.php
@@ -12,4 +12,7 @@ interface CommentPostRepositoryInterface
     /** @return array{ user_id:string,ip:string }|false */
     function addBanUser(int $comment_id): array|false;
     function getBanUser(string $user_id, string $ip): string|false;
+    function addBanUsersInRoom(int $open_chat_id): int;
+    function removeBanRoom(int $open_chat_id): bool;
+    function getBanRoomExpiry(int $open_chat_id): string|false;
 }

--- a/app/Models/CommentRepositories/DeleteCommentRepository.php
+++ b/app/Models/CommentRepositories/DeleteCommentRepository.php
@@ -125,9 +125,9 @@ class DeleteCommentRepository implements DeleteCommentRepositoryInterface
             $id
         );
 
-        // 全コメントをflag=5に更新
+        // 全コメントをflag=5に更新（flag=2通報,4画像削除は除外、flag=5は既に対象状態）
         return CommentDB::execute(
-            "UPDATE comment SET flag = 5 WHERE open_chat_id = :open_chat_id AND flag NOT IN (1, 2, 4)",
+            "UPDATE comment SET flag = 5 WHERE open_chat_id = :open_chat_id AND flag NOT IN (2, 4, 5)",
             $id
         )->rowCount();
     }
@@ -140,6 +140,14 @@ class DeleteCommentRepository implements DeleteCommentRepositoryInterface
         )->rowCount();
     }
 
+    function restoreDeletedComments(int $open_chat_id): int
+    {
+        return CommentDB::execute(
+            "UPDATE comment SET flag = 0 WHERE open_chat_id = :open_chat_id AND flag IN (1, 5)",
+            compact('open_chat_id')
+        )->rowCount();
+    }
+
     function getSoftDeletedCommentImageFilenames(int $open_chat_id): array
     {
         return array_column(
@@ -147,6 +155,19 @@ class DeleteCommentRepository implements DeleteCommentRepositoryInterface
                 "SELECT ci.filename FROM comment_image AS ci
                  JOIN comment AS c ON ci.comment_id = c.comment_id
                  WHERE c.open_chat_id = :open_chat_id AND c.flag = 5",
+                compact('open_chat_id')
+            ),
+            'filename'
+        );
+    }
+
+    function getDeletedCommentImageFilenames(int $open_chat_id): array
+    {
+        return array_column(
+            CommentDB::fetchAll(
+                "SELECT ci.filename FROM comment_image AS ci
+                 JOIN comment AS c ON ci.comment_id = c.comment_id
+                 WHERE c.open_chat_id = :open_chat_id AND c.flag IN (1, 5)",
                 compact('open_chat_id')
             ),
             'filename'
@@ -180,15 +201,19 @@ class DeleteCommentRepository implements DeleteCommentRepositoryInterface
     function getCommentIdsByOpenChatId(int $openChatId, array $excludeFlags): array
     {
         $params = ['openChatId' => $openChatId];
-        $placeholders = [];
-        foreach (array_values($excludeFlags) as $i => $flag) {
-            $key = "flag{$i}";
-            $placeholders[] = ":{$key}";
-            $params[$key] = $flag;
-        }
 
-        $in = implode(',', $placeholders);
-        $query = "SELECT comment_id FROM comment WHERE open_chat_id = :openChatId AND flag NOT IN ({$in})";
+        if (empty($excludeFlags)) {
+            $query = "SELECT comment_id FROM comment WHERE open_chat_id = :openChatId";
+        } else {
+            $placeholders = [];
+            foreach (array_values($excludeFlags) as $i => $flag) {
+                $key = "flag{$i}";
+                $placeholders[] = ":{$key}";
+                $params[$key] = $flag;
+            }
+            $in = implode(',', $placeholders);
+            $query = "SELECT comment_id FROM comment WHERE open_chat_id = :openChatId AND flag NOT IN ({$in})";
+        }
 
         return array_column(
             CommentDB::fetchAll($query, $params),
@@ -206,6 +231,37 @@ class DeleteCommentRepository implements DeleteCommentRepositoryInterface
             ),
             'comment_id'
         );
+    }
+
+    /** @return int[] */
+    function getDeletedCommentIds(int $openChatId): array
+    {
+        return array_column(
+            CommentDB::fetchAll(
+                "SELECT comment_id FROM comment WHERE open_chat_id = :openChatId AND flag IN (1, 5)",
+                compact('openChatId')
+            ),
+            'comment_id'
+        );
+    }
+
+    function shadowDeleteAllComments(int $open_chat_id): int
+    {
+        $id = compact('open_chat_id');
+
+        // いいね削除
+        CommentDB::execute(
+            "DELETE FROM `like` WHERE comment_id IN (
+                SELECT comment_id FROM comment WHERE open_chat_id = :open_chat_id
+            )",
+            $id
+        );
+
+        // 全コメントをflag=1に更新（flag=2通報,4画像削除は除外、flag=1は既に対象状態）
+        return CommentDB::execute(
+            "UPDATE comment SET flag = 1 WHERE open_chat_id = :open_chat_id AND flag NOT IN (1, 2, 4)",
+            $id
+        )->rowCount();
     }
 
     function deleteCommentByUserIdAndIpAll(string $user_id, string $ip): void

--- a/app/Models/CommentRepositories/DeleteCommentRepositoryInterface.php
+++ b/app/Models/CommentRepositories/DeleteCommentRepositoryInterface.php
@@ -14,8 +14,11 @@ interface DeleteCommentRepositoryInterface
     function deleteCommentsAll(int $open_chat_id): array;
     function softDeleteAllComments(int $open_chat_id): int;
     function restoreSoftDeletedComments(int $open_chat_id): int;
+    function restoreDeletedComments(int $open_chat_id): int;
     /** @return string[] image filenames associated with flag=5 comments */
     function getSoftDeletedCommentImageFilenames(int $open_chat_id): array;
+    /** @return string[] image filenames associated with flag=1 or flag=5 comments */
+    function getDeletedCommentImageFilenames(int $open_chat_id): array;
     function deleteLikeByUserIdAndIp(int $open_chat_id, string $user_id, string $ip): int;
     function deleteCommentByUserIdAndIpAll(string $user_id, string $ip): void;
     function getCommentId(int $open_chat_id, int $id): int|false;
@@ -25,4 +28,8 @@ interface DeleteCommentRepositoryInterface
 
     /** @return int[] comment_ids with flag=5 */
     function getSoftDeletedCommentIds(int $openChatId): array;
+    /** @return int[] comment_ids with flag=1 or flag=5 */
+    function getDeletedCommentIds(int $openChatId): array;
+
+    function shadowDeleteAllComments(int $open_chat_id): int;
 }

--- a/app/Models/CommentRepositories/Enum/CommentLogType.php
+++ b/app/Models/CommentRepositories/Enum/CommentLogType.php
@@ -16,13 +16,14 @@ enum CommentLogType: string
     case AdminBanUser = 'AdminBanUser';
     case AdminBulkDelete = 'AdminBulkDelete';
     case AdminBulkRestore = 'AdminBulkRestore';
+    case AdminBulkBanUsers = 'AdminBulkBanUsers';
 
     /** admin系typeかどうか */
     public function isAdmin(): bool
     {
         return match ($this) {
             self::AdminDelete, self::AdminRestore, self::AdminBanUser,
-            self::AdminBulkDelete, self::AdminBulkRestore => true,
+            self::AdminBulkDelete, self::AdminBulkRestore, self::AdminBulkBanUsers => true,
             default => false,
         };
     }
@@ -36,6 +37,7 @@ enum CommentLogType: string
             self::AdminBanUser->value,
             self::AdminBulkDelete->value,
             self::AdminBulkRestore->value,
+            self::AdminBulkBanUsers->value,
         ];
     }
 
@@ -47,6 +49,7 @@ enum CommentLogType: string
             self::AdminBanUser => 'シャドウバン',
             self::AdminBulkDelete => '一括削除',
             self::AdminBulkRestore => '一括復元',
+            self::AdminBulkBanUsers => '一斉シャドウバン',
             default => $this->value,
         };
     }

--- a/app/Services/OpenChatAdmin/AdminOpenChat.php
+++ b/app/Services/OpenChatAdmin/AdminOpenChat.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\OpenChatAdmin;
 
 use App\Models\CommentRepositories\CommentListRepositoryInterface;
+use App\Models\CommentRepositories\CommentPostRepositoryInterface;
 use App\Models\RecommendRepositories\RecommendRankingRepository;
 use App\Services\OpenChatAdmin\Dto\AdminOpenChatDto;
 use App\Models\Repositories\DB;
@@ -14,6 +15,7 @@ class AdminOpenChat
     function __construct(
         private RecommendRankingRepository $recommendRankingRepository,
         private CommentListRepositoryInterface $commentListRepository,
+        private CommentPostRepositoryInterface $commentPostRepository,
     ) {
     }
 
@@ -22,8 +24,16 @@ class AdminOpenChat
         $dto = new AdminOpenChatDto;
         $dto->id = $id;
         $dto->recommendTag = $this->recommendRankingRepository->getRecommendTag($id);
-        $dto->modifyTag = DB::fetchColumn("SELECT tag FROM modify_recommend WHERE id = {$id}");;
+        $dto->modifyTag = DB::fetchColumn("SELECT tag FROM modify_recommend WHERE id = {$id}");
         $dto->commentIdArray = $this->commentListRepository->getCommentIdArrayByOpenChatId($id);
+
+        $banCreatedAt = $this->commentPostRepository->getBanRoomExpiry($id);
+        if ($banCreatedAt !== false) {
+            $expiry = (new \DateTime($banCreatedAt))->modify('+7 days');
+            $now = new \DateTime();
+            $diff = $now->diff($expiry);
+            $dto->commentBanRemainingDays = $diff->invert ? 0 : $diff->days + ($diff->h > 0 || $diff->i > 0 ? 1 : 0);
+        }
 
         return $dto;
     }

--- a/app/Services/OpenChatAdmin/Dto/AdminOpenChatDto.php
+++ b/app/Services/OpenChatAdmin/Dto/AdminOpenChatDto.php
@@ -11,4 +11,5 @@ class AdminOpenChatDto
     public string|false $modifyTag;
     /** @var int[] $commentIdArray */
     public array $commentIdArray;
+    public ?int $commentBanRemainingDays = null;
 }

--- a/app/Views/admin/admin_confirm_page.php
+++ b/app/Views/admin/admin_confirm_page.php
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="jp">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="<?php echo fileUrl("style/mvp.css", urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl("style/site_header.css", urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl("style/site_footer.css", urlRoot: '') ?>">
+    <title><?php echo $title ?? '確認' ?></title>
+</head>
+
+<body>
+    <?php viewComponent('site_header') ?>
+    <main>
+        <h2><?php echo $title ?></h2>
+        <p><?php echo nl2br($description ?? '') ?></p>
+        <form method="POST" action="<?php echo $action ?>">
+            <input type="hidden" name="confirmed" value="1">
+            <?php foreach ($params as $key => $value): ?>
+                <input type="hidden" name="<?php echo htmlspecialchars($key) ?>" value="<?php echo htmlspecialchars((string)$value) ?>">
+            <?php endforeach ?>
+            <div style="display: flex; gap: 1rem; margin-top: 1.5rem;">
+                <button type="submit" style="background-color: #d32f2f; color: white; border: none; padding: 0.75rem 1.5rem; border-radius: 4px; cursor: pointer; font-size: 1rem;">実行する</button>
+                <a href="<?php echo $cancelUrl ?? '/' ?>" style="display: inline-flex; align-items: center; padding: 0.75rem 1.5rem; border-radius: 4px; text-decoration: none; background: #e0e0e0; color: #333; font-size: 1rem;">キャンセル</a>
+            </div>
+        </form>
+    </main>
+    <footer>
+        <?php viewComponent('footer_inner') ?>
+    </footer>
+    <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
+</body>
+
+</html>

--- a/app/Views/components/oc_content_admin.php
+++ b/app/Views/components/oc_content_admin.php
@@ -3,7 +3,7 @@
 /** @var \App\Services\OpenChatAdmin\Dto\AdminOpenChatDto $_adminDto */
 ?>
 <div style="padding: 0 1rem;">
-    <form onsubmit="return confirm('変更しますか？')" action="/admin-api" method="POST" style="margin: 1rem 0;">
+    <form action="/admin-api" method="POST" style="margin: 1rem 0;">
         <b>タグ: <?php echo $_adminDto->recommendTag ?: '無し' ?></b>
         <label>タグ変更</label>
         <input type="text" name="tag">
@@ -11,14 +11,14 @@
         <input type="hidden" name="type" value="modifyTag">
         <input type="submit">
     </form>
-    <form onsubmit="return confirm('削除しますか？')" action="/admin-api" method="POST" style="margin: 1rem 0;">
+    <form action="/admin-api" method="POST" style="margin: 1rem 0;">
         <b>Modifyタグ: <?php echo $_adminDto->modifyTag !== false ? ($_adminDto->modifyTag ?: '空文字') : '無し' ?></b>
         <label>タグを削除</label>
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
         <input type="hidden" name="type" value="deleteModifyTag">
         <input type="submit">
     </form>
-    <form onsubmit="return confirm('コメントのフラグを変更しますか？')" action="/admin-api/deletecomment" method="POST" style="margin: 1rem 0;">
+    <form action="/admin-api/deletecomment" method="POST" style="margin: 1rem 0;">
         <label for="comments-delete">コメントのフラグを変更</label>
         <select name="commentId" id="comments-delete" style="width: 5rem; font-size:1rem">
             <?php foreach ($_adminDto->commentIdArray as $commentId) : ?>
@@ -35,7 +35,7 @@
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
         <input type="submit">
     </form>
-    <form onsubmit="return confirm('ユーザーをシャドウバンしますか？')" action="/admin-api/deleteuser" method="POST" style="margin: 1rem 0;">
+    <form action="/admin-api/deleteuser" method="POST" style="margin: 1rem 0;">
         <label for="user-delete">ユーザーをシャドウバン</label>
         <select name="commentId" id="user-delete" style="width: 5rem; font-size:1rem">
             <?php foreach ($_adminDto->commentIdArray as $commentId) : ?>
@@ -45,18 +45,33 @@
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
         <input type="submit">
     </form>
-    <form onsubmit="return confirm('このオープンチャットの全コメントを削除しますか？')" action="/admin-api/deletecommentsall" method="POST" style="margin: 1rem 0;">
+    <form action="/admin-api/deletecommentsall" method="POST" style="margin: 1rem 0;">
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
         <input type="submit" value="全コメントを削除（通常削除）">
     </form>
-    <form onsubmit="return confirm('通常削除されたコメントを全て復元しますか？')" action="/admin-api/restorecommentsall" method="POST" style="margin: 1rem 0;">
+    <form action="/admin-api/restorecommentsall" method="POST" style="margin: 1rem 0;">
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
-        <input type="submit" value="通常削除を一斉復元">
+        <input type="submit" value="削除を一斉復元（シャドウ削除・通常削除）">
     </form>
-    <form onsubmit="return confirm('コメントを１週間禁止しますか？')" action="/admin-api/commentbanroom" method="POST" style="margin: 1rem 0;">
+    <form action="/admin-api/harddeletecommentsall" method="POST" style="margin: 1rem 0;">
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
-        <input type="submit" value="コメントを1週間禁止">
+        <input type="submit" value="全コメントを完全削除">
     </form>
+    <form action="/admin-api/bulkshadowban" method="POST" style="margin: 1rem 0;">
+        <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
+        <input type="submit" value="一斉シャドウバン（全投稿者BAN + 全コメントシャドウ削除）">
+    </form>
+    <?php if ($_adminDto->commentBanRemainingDays !== null): ?>
+        <form action="/admin-api/commentunbanroom" method="POST" style="margin: 1rem 0;">
+            <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
+            <input type="submit" value="コメント禁止を解除（残り<?php echo $_adminDto->commentBanRemainingDays ?>日）">
+        </form>
+    <?php else: ?>
+        <form action="/admin-api/commentbanroom" method="POST" style="margin: 1rem 0;">
+            <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
+            <input type="submit" value="コメントを1週間禁止">
+        </form>
+    <?php endif ?>
     <div style="margin: 1rem 0;">
         <a href="<?php echo url('admin/log/admin-action') ?>" target="_blank">操作ログ</a>
     </div>

--- a/app/Views/components/oc_content_admin.php
+++ b/app/Views/components/oc_content_admin.php
@@ -47,11 +47,11 @@
     </form>
     <form action="/admin-api/deletecommentsall" method="POST" style="margin: 1rem 0;">
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
-        <input type="submit" value="全コメントを削除（通常削除）">
+        <button type="submit" style="text-align: left;">全コメントを削除<br>（通常削除）</button>
     </form>
     <form action="/admin-api/restorecommentsall" method="POST" style="margin: 1rem 0;">
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
-        <input type="submit" value="削除を一斉復元（シャドウ削除・通常削除）">
+        <button type="submit" style="text-align: left;">削除を一斉復元<br>（シャドウ削除・通常削除）</button>
     </form>
     <form action="/admin-api/harddeletecommentsall" method="POST" style="margin: 1rem 0;">
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
@@ -59,7 +59,7 @@
     </form>
     <form action="/admin-api/bulkshadowban" method="POST" style="margin: 1rem 0;">
         <input type="hidden" name="id" value="<?php echo $_adminDto->id ?>">
-        <input type="submit" value="一斉シャドウバン（全投稿者BAN + 全コメントシャドウ削除）">
+        <button type="submit" style="text-align: left;">一斉シャドウバン<br>（全投稿者BAN + 全コメントシャドウ削除）</button>
     </form>
     <?php if ($_adminDto->commentBanRemainingDays !== null): ?>
         <form action="/admin-api/commentunbanroom" method="POST" style="margin: 1rem 0;">

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -140,8 +140,9 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
           </span>
         </aside>
 
-        <div style="display: flex; flex-direction: column; width: 100%; margin: auto 0;">
-          <section class="open-btn sp-btn" style="width: 100%; margin: 0; padding: 0;">
+        <div style="display: flex; gap: 8px; width: 100%; margin: auto 0;">
+          <a id="admin-gear-btn" href="<?php echo url('oc', $oc['id'], 'admin') ?>" style="display: none; align-items: center; justify-content: center; padding: 0 14px; background: linear-gradient(135deg, #ffa751, #e85d04); border-radius: 8px; color: white; text-decoration: none; font-size: 18px;">⚙</a>
+          <section class="open-btn sp-btn" style="flex: 1; margin: 0; padding: 0;">
             <?php if ($oc['url']) : ?>
               <a href="<?php echo MimimalCmsConfig::$urlRoot === '' ? url('oc', $oc['id'], 'jump') : lineAppUrl($oc) ?>" class="openchat_link" style="font-size: 16px;">
                 <div style="display: flex; align-items: center; justify-content: center;">

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -141,7 +141,11 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
         </aside>
 
         <div style="display: flex; gap: 8px; width: 100%; margin: auto 0;">
-          <a id="admin-gear-btn" href="<?php echo url('oc', $oc['id'], 'admin') ?>" style="display: none; align-items: center; justify-content: center; padding: 0 14px; background: linear-gradient(135deg, #ffa751, #e85d04); border-radius: 8px; color: white; text-decoration: none; font-size: 18px;">⚙</a>
+          <?php if (isset($_adminDto)) : ?>
+            <a href="<?php echo url('oc', $oc['id']) ?>" style="display: flex; align-items: center; justify-content: center; padding: 0 14px; background: linear-gradient(135deg, #7eb8ff, #3a7bd5); border-radius: 8px; color: white; text-decoration: none; font-size: 18px;">✕</a>
+          <?php else : ?>
+            <a id="admin-gear-btn" href="<?php echo url('oc', $oc['id'], 'admin') ?>" style="display: none; align-items: center; justify-content: center; padding: 0 14px; background: linear-gradient(135deg, #ffa751, #e85d04); border-radius: 8px; color: white; text-decoration: none; font-size: 18px;">⚙</a>
+          <?php endif ?>
           <section class="open-btn sp-btn" style="flex: 1; margin: 0; padding: 0;">
             <?php if ($oc['url']) : ?>
               <a href="<?php echo MimimalCmsConfig::$urlRoot === '' ? url('oc', $oc['id'], 'jump') : lineAppUrl($oc) ?>" class="openchat_link" style="font-size: 16px;">

--- a/frontend/oc-app/package-lock.json
+++ b/frontend/oc-app/package-lock.json
@@ -2239,17 +2239,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
-      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/type-utils": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -2262,7 +2262,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.0",
+        "@typescript-eslint/parser": "^8.56.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -2278,16 +2278,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
-      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2303,14 +2303,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
-      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.0",
-        "@typescript-eslint/types": "^8.56.0",
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2325,14 +2325,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
-      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0"
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2343,9 +2343,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
-      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2360,15 +2360,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
-      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -2385,9 +2385,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
-      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2399,18 +2399,18 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
-      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.0",
-        "@typescript-eslint/tsconfig-utils": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.4.0"
@@ -2424,22 +2424,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -2456,16 +2440,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
-      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0"
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2480,13 +2464,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
-      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/types": "8.56.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4733,16 +4717,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
-      "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.56.0",
-        "@typescript-eslint/parser": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0"
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/frontend/oc-app/src/comments/components/Dialog/ImageReportDialog.tsx
+++ b/frontend/oc-app/src/comments/components/Dialog/ImageReportDialog.tsx
@@ -55,7 +55,7 @@ export default function ImageReportDialog() {
       {state.result === 'unsent' && (
         <DialogParagraph>削除すべき不適切な画像として通報しますか？</DialogParagraph>
       )}
-      {state.result === 'done' && <DialogParagraph>通報しました</DialogParagraph>}
+      {state.result === 'done' && <DialogParagraph>通報情報が管理者の端末に送信されました<br />（管理者個人のスマートフォンのDiscordに通知済み）</DialogParagraph>}
       {state.result === 'fail' && (
         <DialogParagraph>
           サーバーとの通信に失敗しました。連続アクセスを防止しているため、しばらく待ってから再度お試しください。

--- a/frontend/oc-app/src/comments/components/Dialog/ReportDialogUi.tsx
+++ b/frontend/oc-app/src/comments/components/Dialog/ReportDialogUi.tsx
@@ -28,7 +28,7 @@ export default function ReportDialogUi({
       {result === 'unsent' && (
         <DialogParagraph>削除すべき不適切なコメントとして通報しますか？</DialogParagraph>
       )}
-      {result === 'done' && <DialogParagraph>通報しました</DialogParagraph>}
+      {result === 'done' && <DialogParagraph>通報情報が管理者の端末に送信されました<br />（管理者個人のスマートフォンのDiscordに通知済み）</DialogParagraph>}
       {result === 'fail' && (
         <DialogParagraph>
           サーバーとの通信に失敗しました。連続アクセスを防止しているため、しばらく待ってから再度お試しください。

--- a/public/js/security.js
+++ b/public/js/security.js
@@ -71,6 +71,11 @@ const admin = document.cookie
   ?.split('=')[1]
 admin && console.log('admin:', admin)
 
+if (admin) {
+  const gearBtn = document.getElementById('admin-gear-btn')
+  if (gearBtn) gearBtn.style.display = 'flex'
+}
+
 if (typeof admin === 'undefined' || !admin) blockblock()
 
 function detectAdBlock() {


### PR DESCRIPTION
## Summary

- 全管理APIにサーバーサイド確認ページを追加し、Discord直リンクからの誤操作を防止
- Discord通報通知リンクをシャドウ削除/通常削除/完全削除/ユーザーBANの4種に拡張
- 全コメント完全削除・一斉シャドウバン等の一括操作を追加
- コメント禁止の残り日数表示と解除トグルを実装
- CommentReportApiControllerのreportComment/reportImage共通処理を統合
- 管理者用ギアアイコン、通報ダイアログのメッセージ改善、Makefileビルドターゲット更新

## Test plan

- [ ] Discord通知リンクをブラウザで直接開き、確認ページが表示されることを確認
- [ ] 確認ページで「実行する」→アクション実行、「キャンセル」→管理ページに戻ることを確認
- [ ] 管理画面の各フォーム送信が確認ページ経由で動作することを確認
- [ ] 一括操作（全コメント完全削除、一斉シャドウバン）の動作確認
- [ ] コメント禁止トグル（禁止/解除）の動作確認
- [ ] 通報ダイアログのメッセージ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)