### PR TITLE
[STG] skip-ci: PC幅でコメント日時をインライン表示・日付フォーマット改善

### DIFF
--- a/app/Views/components/open_chat_list_ranking_comment2.php
+++ b/app/Views/components/open_chat_list_ranking_comment2.php
@@ -31,18 +31,18 @@ use App\Views\Ads\GoogleAdsense as GAd;
             </div>
 
             <?php if ($oc['member']) : ?>
-              <div class="comment-member-count" style="margin-left: 3px;">
+              <div class="comment-member-count">
                 <span>(<?php echo  formatMember($oc['member']) ?>)</span>
               </div>
             <?php endif ?>
-
+            <!-- JSのapplyTimeElapsedString()で表示フォーマット変換 -->
+            <div class="comment-time"><span><?php echo $oc['time'] ?></span></div>
           </a>
         </h3>
         <footer class="comment-footer">
           <?php if (mb_strlen($oc['description']) > 0) : ?>
             <div class="comment-user"><span><?php echo $oc['user'] ?></span></div>
           <?php endif ?>
-          <div class="comment-time"><span><?php echo $oc['time'] ?></span></div>
         </footer>
         <?php if (mb_strlen($oc['description']) > 0) : ?>
           <p class="openchat-item-desc unset"><?php echo truncateDescription($oc['description'], 80) ?></p>

--- a/public/js/fetchComment.js
+++ b/public/js/fetchComment.js
@@ -1,56 +1,60 @@
 let lastList = ''
 
+// 表示ルール:
+// 今日 & 15分以内       → "たった今"
+// 今日 & 1〜23時間前    → "3時間前"
+// 今日 & 16〜59分前     → "30分前"
+// 今日 & 15分超〜1分未満 → "45秒前"
+// 昨日以前 & 同年 (モバイル) → "2/23"
+// 昨日以前 & 同年 (PC)      → "2月23日"
+// 昨日以前 & 前年以前 (モバイル) → "2025/12/1"
+// 昨日以前 & 前年以前 (PC)      → "2025年12月1日"
 export function timeElapsedString(datetime, thresholdMinutes = 15) {
   const now = new Date()
-  const targetDatetime = new Date(datetime.replace(/-/g, '/')) // 日付形式を修正してDateオブジェクトを作成
+  const targetDatetime = new Date(datetime.replace(/-/g, '/'))
 
-  const diffMs = now - targetDatetime // ミリ秒単位の差を計算
-  const totalMinutes = diffMs / 1000 / 60 // ミリ秒を分に変換
+  const diffMs = now - targetDatetime
+  const totalMinutes = diffMs / 1000 / 60
 
   if (totalMinutes <= thresholdMinutes) {
-    return ['たった今', '#4d73ff']
+    return 'たった今'
   }
 
   const diffDate = new Date(diffMs)
-  const years = diffDate.getUTCFullYear() - 1970 // 1970年からの年数を計算
-  const months = diffDate.getUTCMonth()
-  const days = diffDate.getUTCDate() - 1 // 月初からの日数
   const hours = diffDate.getUTCHours()
   const minutes = diffDate.getUTCMinutes()
   const seconds = diffDate.getUTCSeconds()
 
-  const formattedTime = `${targetDatetime.getHours()}:${String(targetDatetime.getMinutes()).padStart(2, '0')}`
+  const isToday = now.getFullYear() === targetDatetime.getFullYear()
+    && now.getMonth() === targetDatetime.getMonth()
+    && now.getDate() === targetDatetime.getDate()
+
+  if (isToday) {
+    if (hours > 0) {
+      return hours + '時間前'
+    } else if (minutes > 0) {
+      return minutes + '分前'
+    } else {
+      return seconds + '秒前'
+    }
+  }
+
+  const isPC = window.matchMedia('(min-width: 512px)').matches
+  const m = targetDatetime.getMonth() + 1
+  const d = targetDatetime.getDate()
 
   if (now.getFullYear() > targetDatetime.getFullYear()) {
-    return [
-      `${targetDatetime.getFullYear()}年${targetDatetime.getMonth() + 1}月${targetDatetime.getDate()}日 ${formattedTime}`,
-      '#777',
-    ]
-  } else if (months > 0) {
-    return [
-      `${targetDatetime.getMonth() + 1}月${targetDatetime.getDate()}日 ${formattedTime}`,
-      '#777',
-    ]
-  } else if (days > 0) {
-    return [
-      `${targetDatetime.getMonth() + 1}月${targetDatetime.getDate()}日 ${formattedTime}`,
-      '#777',
-    ]
-  } else if (hours > 0) {
-    return [hours + '時間前', '#4d73ff']
-  } else if (minutes > 0) {
-    return [minutes + '分前', '#4d73ff']
-  } else {
-    return [seconds + '秒前', '#4d73ff']
+    const y = targetDatetime.getFullYear()
+    return isPC ? `${y}年${m}月${d}日` : `${y}/${m}/${d}`
   }
+
+  return isPC ? `${m}月${d}日` : `${m}/${d}`
 }
 
 export function applyTimeElapsedString() {
   const commentTime = document.querySelectorAll('.comment-time span')
   commentTime.forEach((time) => {
-    const [formattedTime, color] = timeElapsedString(time.textContent)
-    time.textContent = formattedTime
-    time.style.color = color
+    time.textContent = timeElapsedString(time.textContent)
   })
 }
 

--- a/public/style/room_list.css
+++ b/public/style/room_list.css
@@ -575,11 +575,11 @@
 .recent-comment-list .openchat-item-desc {
   color: #111;
   font-weight: normal;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 150%;
   -webkit-line-clamp: 2;
   line-clamp: 2;
-  margin-top: 6px;
+  margin-top: 2px;
 }
 
 .comment-images {
@@ -609,7 +609,9 @@
 
 .recent-comment-list .openchat-item-title {
   display: flex;
-  font-size: 13px;
+  flex-wrap: nowrap;
+  overflow: visible;
+  padding-right: 2.2rem;
 }
 
 .top-ranking .openchat-item-title {
@@ -618,14 +620,15 @@
 }
 
 .comment-user {
-  color: #111;
-  font-size: 14px;
-  display: block;
+  color: #777;
+  font-size: 11px;
   font-weight: bold;
+  display: block;
   position: relative;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  margin-top: 2px;
 }
 
 .openchat-item-title .comment-name {
@@ -634,14 +637,12 @@
   white-space: nowrap;
   overflow: hidden;
   color: #111;
-  font-weight: normal;
-  max-width: 70%;
+  font-weight: 500;
+  font-size: 14px;
 }
 
 .recent-comment-list .openchat-item-title .comment-name {
-  flex: 1 1 0;
   min-width: 0;
-  max-width: max-content;
 }
 
 .openchat-item-title .comment-member-count {
@@ -650,7 +651,9 @@
 }
 
 .recent-comment-list .openchat-item-title .comment-member-count {
-  flex: 0 0 auto;
+  flex: 1 0 0;
+  font-size: 14px;
+  margin-left: 2px;
 }
 
 .recent-comment-list .openchat-item-title .comment-user {
@@ -671,10 +674,10 @@
 
 .comment-footer {
   all: unset;
-  display: flex;
   gap: 6px;
+  margin-top: 0px;
   align-items: center;
-  margin-top: 3px;
+  display: flex;
   flex-wrap: nowrap;
 }
 
@@ -685,9 +688,11 @@
 
 .comment-time {
   font-weight: normal;
-  position: relative;
-  color: #777;
-  font-size: 13px;
+  position: absolute;
+  right: -1.5rem;
+  top: -1px;
+  color: #555;
+  font-size: 11px;
   flex-shrink: 0;
 }
 
@@ -1267,7 +1272,7 @@
 
   .recent-comment-list .openchat-item-desc {
     margin-top: 3px;
-    font-size: 15px;
+    font-size: 13px;
     font-weight: normal;
   }
 
@@ -1287,6 +1292,22 @@
   .recent-comment-list .openchat-item-title {
     font-size: 13px;
     font-weight: 500;
+    padding-right: 0;
+  }
+
+  .recent-comment-list .openchat-item-title .comment-member-count {
+    flex: 0 0 auto;
+  }
+
+  .comment-time {
+    position: static;
+    font-size: 14px;
+    flex: 0 0 auto;
+  }
+
+  .comment-time::before {
+    content: '・';
+    color: inherit;
   }
 
   .refresh-time span {


### PR DESCRIPTION
## Summary
- PC幅(512px以上)でコメント日時を絶対配置からインライン表示に変更し、メンバー数の右に中点（・）区切りで配置
- 日付フォーマットをPC: `◯月◯日`、モバイル: `M/D` に変更し、過去日付の時間表示を削除
- 「たった今」等の青色表示を廃止し、全てグレーに統一

## Test plan
- [x] PC幅でコメント日時がメンバー数の右に中点付きで表示される
- [x] モバイル幅でコメント日時が従来通り絶対配置で表示される
- [x] 過去日付に時間が表示されない
- [x] 「たった今」が青くならずグレーのまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)