### PR TITLE
[PROD] skip-ci: Cloudflareキャッシュパージの成功判定を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,7 @@ jobs:
             -H "Authorization: Bearer ${API_KEY}" \
             -H "Content-Type: application/json" \
             --data '{"purge_everything":true}')
-          if echo "$RESPONSE" | grep -q '"success":true'; then
+          if echo "$RESPONSE" | grep -q '"success":\s*true'; then
             echo "Cache purged successfully."
           else
             echo "::error::Cache purge failed: $RESPONSE"


### PR DESCRIPTION
## 問題

デプロイ時のCloudflareキャッシュパージが常に失敗扱いになっていた。

APIレスポンスの `"success": true`（コロン後にスペースあり）に対して、grepパターンが `"success":true`（スペースなし）で検索していたためマッチしなかった。

## 対処

grepパターンを `"success":\s*true` に変更し、スペースの有無に関わらずマッチするようにした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)