### PR TITLE
[STG] fix: 週次更新ルームの翌日確認クロールが動作しない問題を修正

### DIFF
--- a/app/Models/Repositories/test/MemberChangeFilterCacheRepositoryTest.php
+++ b/app/Models/Repositories/test/MemberChangeFilterCacheRepositoryTest.php
@@ -7,7 +7,7 @@
  * docker compose exec app ./vendor/bin/phpunit app/Models/Repositories/test/MemberChangeFilterCacheRepositoryTest.php
  *
  * テスト内容:
- * - 実際のSQLiteデータベースを使用（1000件以上のテストデータ）
+ * - 実際のSQLiteデータベースを使用（1200件以上のテストデータ）
  * - キャッシュの読み書き動作
  * - hourly/dailyの使い分け
  * - キーごとに独立した日付検証
@@ -24,8 +24,6 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 {
     private MemberChangeFilterCacheRepository $repository;
     private FileStorageInterface $fileStorage;
-    private string $tempDbFile = '';
-    private string $today;
 
     private string $filterMemberChangePath;
     private string $filterNewRoomsPath;
@@ -36,24 +34,25 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     private ?string $originalWeeklyUpdate = null;
 
     /**
-     * テストデータの期待値（insertTestDataで生成されるデータに基づく）
+     * テストデータの期待値（クラス全体で共有）
      */
-    private array $expectedMemberChange = [];
-    private array $expectedNewRooms = [];
-    private array $expectedWeeklyUpdate = [];
+    private static string $today;
+    private static string $tempDbFile = '';
+    private static array $expectedMemberChange = [];
+    private static array $expectedNewRooms = [];
+    private static array $expectedWeeklyUpdate = [];
 
-    protected function setUp(): void
+    /**
+     * クラス全体で1回だけDB作成（テスト高速化）
+     */
+    public static function setUpBeforeClass(): void
     {
-        $this->today = date('Y-m-d');
+        self::$today = date('Y-m-d');
+        self::$tempDbFile = sys_get_temp_dir() . '/test_filter_cache_' . uniqid() . '.db';
 
-        // 一時的なテスト用SQLiteファイルを作成
-        $this->tempDbFile = sys_get_temp_dir() . '/test_filter_cache_' . uniqid() . '.db';
-
-        // テスト用PDOインスタンスを作成してSQLiteStatistics::$pdoにセット
-        SQLiteStatistics::$pdo = new \PDO('sqlite:' . $this->tempDbFile);
+        SQLiteStatistics::$pdo = new \PDO('sqlite:' . self::$tempDbFile);
         SQLiteStatistics::$pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
-        // テーブル作成
         SQLiteStatistics::$pdo->exec("
             CREATE TABLE statistics (
                 open_chat_id INTEGER NOT NULL,
@@ -63,10 +62,22 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
             )
         ");
 
-        // テストデータ挿入（1000件以上）
-        $this->insertTestData();
+        self::insertTestData();
+    }
 
-        // 実際のリポジトリを使用
+    public static function tearDownAfterClass(): void
+    {
+        if (file_exists(self::$tempDbFile)) {
+            unlink(self::$tempDbFile);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        // PDOを再セット（他のテストで変わっている可能性）
+        SQLiteStatistics::$pdo = new \PDO('sqlite:' . self::$tempDbFile);
+        SQLiteStatistics::$pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
         $statisticsRepository = app(SqliteStatisticsRepository::class);
         $this->fileStorage = app(FileStorageInterface::class);
         $this->repository = new MemberChangeFilterCacheRepository(
@@ -74,17 +85,14 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
             $this->fileStorage
         );
 
-        // キャッシュファイルパス
         $this->filterMemberChangePath = $this->fileStorage->getStorageFilePath('filterMemberChange');
         $this->filterNewRoomsPath = $this->fileStorage->getStorageFilePath('filterNewRooms');
         $this->filterWeeklyUpdatePath = $this->fileStorage->getStorageFilePath('filterWeeklyUpdate');
 
-        // 既存のファイルをバックアップ
         $this->backupFile($this->filterMemberChangePath, $this->originalMemberChange);
         $this->backupFile($this->filterNewRoomsPath, $this->originalNewRooms);
         $this->backupFile($this->filterWeeklyUpdatePath, $this->originalWeeklyUpdate);
 
-        // キャッシュをクリア
         $this->clearAllCaches();
     }
 
@@ -97,12 +105,6 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     protected function tearDown(): void
     {
-        // テスト用SQLiteファイルを削除
-        if (file_exists($this->tempDbFile)) {
-            unlink($this->tempDbFile);
-        }
-
-        // 既存のファイルを復元
         $this->restoreFile($this->filterMemberChangePath, $this->originalMemberChange);
         $this->restoreFile($this->filterNewRoomsPath, $this->originalNewRooms);
         $this->restoreFile($this->filterWeeklyUpdatePath, $this->originalWeeklyUpdate);
@@ -142,7 +144,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     }
 
     /**
-     * テストデータを挿入（1000件以上）
+     * テストデータを挿入（1200件以上）
      *
      * データパターン:
      * - ID 1-200: メンバー変動あり（過去8日間で変動）→ expectedMemberChange
@@ -150,8 +152,9 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
      * - ID 401-600: 週次更新対象（最終レコードが1週間以上前）→ expectedWeeklyUpdate
      * - ID 601-800: 通常部屋（対象外）
      * - ID 801-1000: メンバー変動あり + 新規部屋（両方に該当）
+     * - ID 1001-1200: 確認クロール対象（8日以上のギャップ後に復帰）→ expectedWeeklyUpdate
      */
-    private function insertTestData(): void
+    private static function insertTestData(): void
     {
         $stmt = SQLiteStatistics::$pdo->prepare(
             "INSERT INTO statistics (open_chat_id, member, date) VALUES (?, ?, ?)"
@@ -167,7 +170,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
                 $member = $baseMember + (8 - $day) * 5;
                 $stmt->execute([$id, $member, $date]);
             }
-            $this->expectedMemberChange[] = $id;
+            self::$expectedMemberChange[] = $id;
         }
 
         // パターン2: 新規部屋（ID 201-400）
@@ -178,7 +181,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
                 $date = date('Y-m-d', strtotime("-{$day} days"));
                 $stmt->execute([$id, $baseMember, $date]);
             }
-            $this->expectedNewRooms[] = $id;
+            self::$expectedNewRooms[] = $id;
         }
 
         // パターン3: 週次更新対象（ID 401-600）
@@ -190,7 +193,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
                 $member = $baseMember + (15 - $day) * 3;
                 $stmt->execute([$id, $member, $date]);
             }
-            $this->expectedWeeklyUpdate[] = $id;
+            self::$expectedWeeklyUpdate[] = $id;
         }
 
         // パターン4: 通常部屋（ID 601-800）
@@ -213,14 +216,28 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
                 $member = $baseMember + (4 - $day) * 2; // 変動あり
                 $stmt->execute([$id, $member, $date]);
             }
-            $this->expectedMemberChange[] = $id;
-            $this->expectedNewRooms[] = $id;
+            self::$expectedMemberChange[] = $id;
+            self::$expectedNewRooms[] = $id;
+        }
+
+        // パターン6: 確認クロール対象（ID 1001-1200）
+        // 古いレコード8件（15〜22日前） + 昨日のレコード1件
+        // 直近8日間のレコードは昨日の1件のみ → 8日以上のギャップ後の復帰 → 確認クロール対象
+        // レコード数9件 ≥ 8 → getNewRoomsWithLessThan8Records には該当しない
+        for ($id = 1001; $id <= 1200; $id++) {
+            $baseMember = 700 + ($id - 1000);
+            for ($day = 22; $day >= 15; $day--) {
+                $date = date('Y-m-d', strtotime("-{$day} days"));
+                $stmt->execute([$id, $baseMember, $date]);
+            }
+            $stmt->execute([$id, $baseMember + 10, date('Y-m-d', strtotime('-1 days'))]);
+            self::$expectedWeeklyUpdate[] = $id;
         }
 
         // 期待値をソート
-        sort($this->expectedMemberChange);
-        sort($this->expectedNewRooms);
-        sort($this->expectedWeeklyUpdate);
+        sort(self::$expectedMemberChange);
+        sort(self::$expectedNewRooms);
+        sort(self::$expectedWeeklyUpdate);
     }
 
     // ========================================
@@ -242,7 +259,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
         );
         $count = (int) $stmt->fetchColumn();
 
-        $this->assertSame(1000, $count, '部屋数は1000件であること');
+        $this->assertSame(1200, $count, '部屋数は1200件であること');
     }
 
     // ========================================
@@ -251,13 +268,13 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForHourly_returns_memberChange_and_newRooms(): void
     {
-        $result = $this->repository->getForHourly($this->today);
+        $result = $this->repository->getForHourly(self::$today);
         sort($result);
 
         // メンバー変動 + 新規部屋（重複除去）
         $expected = array_unique(array_merge(
-            $this->expectedMemberChange,
-            $this->expectedNewRooms
+            self::$expectedMemberChange,
+            self::$expectedNewRooms
         ));
         sort($expected);
 
@@ -266,7 +283,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForHourly_creates_cache_files(): void
     {
-        $this->repository->getForHourly($this->today);
+        $this->repository->getForHourly(self::$today);
 
         // キャッシュファイルが作成される
         $this->assertFileExists($this->filterMemberChangePath);
@@ -276,17 +293,17 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     public function test_getForHourly_uses_cache_for_memberChange(): void
     {
         // 1回目: DBから取得してキャッシュ
-        $this->repository->getForHourly($this->today);
+        $this->repository->getForHourly(self::$today);
 
         // キャッシュを手動で変更（新形式で日付を埋め込み）
-        $this->writeCacheFile('filterMemberChange', $this->today, [9999]);
+        $this->writeCacheFile('filterMemberChange', self::$today, [9999]);
 
         // 2回目: memberChangeはキャッシュから、newRoomsはリアルタイム
-        $result2 = $this->repository->getForHourly($this->today);
+        $result2 = $this->repository->getForHourly(self::$today);
         sort($result2);
 
         // キャッシュ[9999] + 新規部屋（リアルタイム）
-        $expected = array_unique(array_merge([9999], $this->expectedNewRooms));
+        $expected = array_unique(array_merge([9999], self::$expectedNewRooms));
         sort($expected);
 
         $this->assertSame($expected, $result2);
@@ -294,10 +311,10 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForHourly_does_not_include_weekly_update(): void
     {
-        $result = $this->repository->getForHourly($this->today);
+        $result = $this->repository->getForHourly(self::$today);
 
         // 週次更新部屋は含まれない
-        foreach ($this->expectedWeeklyUpdate as $id) {
+        foreach (self::$expectedWeeklyUpdate as $id) {
             $this->assertNotContains(
                 $id,
                 $result,
@@ -312,14 +329,14 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForDaily_returns_all_three_data(): void
     {
-        $result = $this->repository->getForDaily($this->today);
+        $result = $this->repository->getForDaily(self::$today);
         sort($result);
 
         // メンバー変動 + 新規部屋 + 週次更新（重複除去）
         $expected = array_unique(array_merge(
-            $this->expectedMemberChange,
-            $this->expectedNewRooms,
-            $this->expectedWeeklyUpdate
+            self::$expectedMemberChange,
+            self::$expectedNewRooms,
+            self::$expectedWeeklyUpdate
         ));
         sort($expected);
 
@@ -328,7 +345,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForDaily_creates_all_cache_files(): void
     {
-        $this->repository->getForDaily($this->today);
+        $this->repository->getForDaily(self::$today);
 
         // 全てのキャッシュファイルが作成される
         $this->assertFileExists($this->filterMemberChangePath);
@@ -339,15 +356,15 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     public function test_getForDaily_uses_all_caches_on_second_call(): void
     {
         // 1回目: DBから取得してキャッシュ
-        $this->repository->getForDaily($this->today);
+        $this->repository->getForDaily(self::$today);
 
         // 全てのキャッシュを手動で変更（新形式）
-        $this->writeCacheFile('filterMemberChange', $this->today, [1]);
-        $this->writeCacheFile('filterNewRooms', $this->today, [2]);
-        $this->writeCacheFile('filterWeeklyUpdate', $this->today, [3]);
+        $this->writeCacheFile('filterMemberChange', self::$today, [1]);
+        $this->writeCacheFile('filterNewRooms', self::$today, [2]);
+        $this->writeCacheFile('filterWeeklyUpdate', self::$today, [3]);
 
         // 2回目: 全てキャッシュから
-        $result = $this->repository->getForDaily($this->today);
+        $result = $this->repository->getForDaily(self::$today);
         sort($result);
 
         $this->assertSame([1, 2, 3], $result);
@@ -359,14 +376,14 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
         $this->writeCacheFile('filterMemberChange', '2020-01-01', [9999]);
 
         // 異なる日付でgetForDaily
-        $result = $this->repository->getForDaily($this->today);
+        $result = $this->repository->getForDaily(self::$today);
         sort($result);
 
         // DBから再取得した値が返される
         $expected = array_unique(array_merge(
-            $this->expectedMemberChange,
-            $this->expectedNewRooms,
-            $this->expectedWeeklyUpdate
+            self::$expectedMemberChange,
+            self::$expectedNewRooms,
+            self::$expectedWeeklyUpdate
         ));
         sort($expected);
 
@@ -375,10 +392,10 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForDaily_includes_weekly_update(): void
     {
-        $result = $this->repository->getForDaily($this->today);
+        $result = $this->repository->getForDaily(self::$today);
 
         // 週次更新部屋が含まれる
-        foreach ($this->expectedWeeklyUpdate as $id) {
+        foreach (self::$expectedWeeklyUpdate as $id) {
             $this->assertContains(
                 $id,
                 $result,
@@ -394,16 +411,16 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     public function test_hourly_cache_does_not_validate_weekly_cache(): void
     {
         // hourlyタスクがfilterMemberChangeとfilterNewRoomsのキャッシュを今日の日付で保存
-        $this->repository->getForHourly($this->today);
+        $this->repository->getForHourly(self::$today);
 
         // filterWeeklyUpdateに古い日付のキャッシュを手動作成
         $this->writeCacheFile('filterWeeklyUpdate', '2020-01-01', [9999]);
 
         // getForDailyを呼ぶ → filterWeeklyUpdateの日付が不一致なのでDBから再取得すべき
-        $result = $this->repository->getForDaily($this->today);
+        $result = $this->repository->getForDaily(self::$today);
 
         // 古い[9999]ではなく、DBから取得した正しい週次更新部屋が含まれること
-        foreach ($this->expectedWeeklyUpdate as $id) {
+        foreach (self::$expectedWeeklyUpdate as $id) {
             $this->assertContains(
                 $id,
                 $result,
@@ -419,12 +436,12 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
         saveSerializedFile($this->filterMemberChangePath, [9999]);
 
         // 旧形式はキャッシュ無効として扱われ、DBから再取得される
-        $result = $this->repository->getForHourly($this->today);
+        $result = $this->repository->getForHourly(self::$today);
         sort($result);
 
         $expected = array_unique(array_merge(
-            $this->expectedMemberChange,
-            $this->expectedNewRooms
+            self::$expectedMemberChange,
+            self::$expectedNewRooms
         ));
         sort($expected);
 
@@ -454,7 +471,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForHourly_returns_unique_values(): void
     {
-        $result = $this->repository->getForHourly($this->today);
+        $result = $this->repository->getForHourly(self::$today);
 
         // 重複がないことを確認
         $this->assertCount(count(array_unique($result)), $result);
@@ -462,7 +479,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
 
     public function test_getForDaily_returns_unique_values(): void
     {
-        $result = $this->repository->getForDaily($this->today);
+        $result = $this->repository->getForDaily(self::$today);
 
         // 重複がないことを確認
         $this->assertCount(count(array_unique($result)), $result);
@@ -475,7 +492,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     public function test_getForHourly_performance(): void
     {
         $start = microtime(true);
-        $this->repository->getForHourly($this->today);
+        $this->repository->getForHourly(self::$today);
         $elapsed = microtime(true) - $start;
 
         // 1秒以内に完了すること
@@ -485,7 +502,7 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     public function test_getForDaily_performance(): void
     {
         $start = microtime(true);
-        $this->repository->getForDaily($this->today);
+        $this->repository->getForDaily(self::$today);
         $elapsed = microtime(true) - $start;
 
         // 1秒以内に完了すること
@@ -496,12 +513,12 @@ class MemberChangeFilterCacheRepositoryTest extends TestCase
     {
         // 1回目: DBから取得
         $start1 = microtime(true);
-        $this->repository->getForDaily($this->today);
+        $this->repository->getForDaily(self::$today);
         $elapsed1 = microtime(true) - $start1;
 
         // 2回目: キャッシュから取得
         $start2 = microtime(true);
-        $this->repository->getForDaily($this->today);
+        $this->repository->getForDaily(self::$today);
         $elapsed2 = microtime(true) - $start2;
 
         // キャッシュからの取得は初回より速いこと

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
@@ -71,9 +71,9 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
     public function getWeeklyUpdateRooms(string $date): array
     {
         // 1. 最後のレコードが1週間以上前の部屋（週次更新用）
-        // 2. 昨日8日以上ぶりにクロールされた部屋（確認クロール用）
-        //    → 確認クロール後、getMemberChangeWithinLastWeekの8日間ウィンドウで
-        //      メンバー変動を検知し、変動があれば日次サイクルに復帰する
+        // 2. 昨日8日以上ぶりにクロールされ、かつメンバー数が変動した部屋（確認クロール用）
+        //    前の週と同じ人数なら確認不要（引き続き週次）。
+        //    変動があった場合のみ翌日の確認クロールで日次復帰を判定する。
         $query =
             "SELECT open_chat_id
             FROM statistics
@@ -83,10 +83,20 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
             UNION
 
             SELECT open_chat_id
-            FROM statistics
-            GROUP BY open_chat_id
-            HAVING MAX(`date`) = DATE(:curDate, '-1 day')
-               AND COUNT(CASE WHEN `date` >= DATE(:curDate, '-8 days') THEN 1 END) = 1";
+            FROM statistics AS s_new
+            WHERE s_new.`date` = DATE(:curDate, '-1 day')
+              AND (
+                  SELECT COUNT(*) FROM statistics s_count
+                  WHERE s_count.open_chat_id = s_new.open_chat_id
+                    AND s_count.`date` >= DATE(:curDate, '-8 days')
+              ) = 1
+              AND s_new.member != (
+                  SELECT s_old.member FROM statistics s_old
+                  WHERE s_old.open_chat_id = s_new.open_chat_id
+                    AND s_old.`date` < DATE(:curDate, '-8 days')
+                  ORDER BY s_old.`date` DESC
+                  LIMIT 1
+              )";
 
         $mode = [\PDO::FETCH_COLUMN, 0];
         return SQLiteStatistics::fetchAll($query, ['curDate' => $date], $mode);

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
@@ -70,12 +70,23 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
 
     public function getWeeklyUpdateRooms(string $date): array
     {
-        // 最後のレコードが1週間以上前の部屋（週次更新用）
+        // 1. 最後のレコードが1週間以上前の部屋（週次更新用）
+        // 2. 昨日8日以上ぶりにクロールされた部屋（確認クロール用）
+        //    → 確認クロール後、getMemberChangeWithinLastWeekの8日間ウィンドウで
+        //      メンバー変動を検知し、変動があれば日次サイクルに復帰する
         $query =
             "SELECT open_chat_id
             FROM statistics
             GROUP BY open_chat_id
-            HAVING MAX(`date`) <= DATE(:curDate, '-7 days')";
+            HAVING MAX(`date`) <= DATE(:curDate, '-7 days')
+
+            UNION
+
+            SELECT open_chat_id
+            FROM statistics
+            GROUP BY open_chat_id
+            HAVING MAX(`date`) = DATE(:curDate, '-1 day')
+               AND COUNT(CASE WHEN `date` >= DATE(:curDate, '-8 days') THEN 1 END) = 1";
 
         $mode = [\PDO::FETCH_COLUMN, 0];
         return SQLiteStatistics::fetchAll($query, ['curDate' => $date], $mode);

--- a/app/Models/SQLite/Repositories/Statistics/test/SqliteStatisticsRepositoryTest.php
+++ b/app/Models/SQLite/Repositories/Statistics/test/SqliteStatisticsRepositoryTest.php
@@ -135,6 +135,24 @@ class SqliteStatisticsRepositoryTest extends TestCase
             [1006, 600, date('Y-m-d', strtotime('-2 days'))],
             [1006, 610, date('Y-m-d', strtotime('-1 days'))],
             [1006, 610, $this->today],
+
+            // パターン7: 確認クロール対象 - メンバー変動あり（ID: 1007）
+            // 15日前のレコード + 昨日のレコード（8日以上のギャップ後に復帰）
+            // メンバー数が変わっている → 確認クロール対象
+            [1007, 100, date('Y-m-d', strtotime('-15 days'))],
+            [1007, 120, date('Y-m-d', strtotime('-1 days'))],
+
+            // パターン8: 確認クロール対象 - メンバー変動なし（ID: 1008）
+            // 15日前のレコード + 昨日のレコード（8日以上のギャップ後に復帰）
+            // メンバー数は同じ → それでも確認クロール対象（翌日のデータで判定するため）
+            [1008, 200, date('Y-m-d', strtotime('-15 days'))],
+            [1008, 200, date('Y-m-d', strtotime('-1 days'))],
+
+            // パターン9: 非対象 - 通常の日次サイクル（ID: 1009）
+            // 昨日と一昨日にレコードあり（8日間に2レコード）→ 確認クロール対象外
+            [1009, 300, date('Y-m-d', strtotime('-15 days'))],
+            [1009, 300, date('Y-m-d', strtotime('-2 days'))],
+            [1009, 310, date('Y-m-d', strtotime('-1 days'))],
         ];
 
         $stmt = SQLiteStatistics::$pdo->prepare(
@@ -158,12 +176,12 @@ class SqliteStatisticsRepositoryTest extends TestCase
         $result = $this->repository->getNewRoomsWithLessThan8Records();
         sort($result);
 
-        $expected = [1003];
+        $expected = [1003, 1007, 1008, 1009];
 
         $this->assertSame(
             $expected,
             $result,
-            'レコード数が8以下の新規部屋（ID: 1003）のみを取得すること'
+            'レコード数が8未満の部屋を取得すること'
         );
     }
 
@@ -182,7 +200,8 @@ class SqliteStatisticsRepositoryTest extends TestCase
         $result = $this->repository->getMemberChangeWithinLastWeek($this->today);
         sort($result);
 
-        $expected = [1001, 1003, 1006];
+        // 1009: -2日(300) → -1日(310) で変動あり
+        $expected = [1001, 1003, 1006, 1009];
 
         $this->assertSame(
             $expected,
@@ -196,20 +215,42 @@ class SqliteStatisticsRepositoryTest extends TestCase
      *
      * 期待される動作:
      * - 最後のレコードが1週間以上前の部屋を取得
-     * - ID 1004のみが該当
+     * - 昨日8日以上ぶりにクロールされた部屋（確認クロール対象）も取得
+     * - ID 1004, 1007, 1008が該当
+     * - ID 1009は非該当（直近8日間に2レコードあるため確認クロール不要）
      */
     public function testGetWeeklyUpdateRooms(): void
     {
         $result = $this->repository->getWeeklyUpdateRooms($this->today);
         sort($result);
 
-        $expected = [1004];
+        $expected = [1004, 1007, 1008];
 
         $this->assertSame(
             $expected,
             $result,
-            '最後のレコードが1週間以上前の部屋（ID: 1004）のみを取得すること'
+            '週次更新対象 + 確認クロール対象の部屋を取得すること'
         );
+    }
+
+    /**
+     * テスト: 確認クロール対象の詳細検証
+     *
+     * 8日以上のギャップから復帰した部屋は、メンバー変動の有無に関わらず
+     * 確認クロール対象に含まれること
+     */
+    public function testWeeklyUpdateIncludesConfirmationCrawlRooms(): void
+    {
+        $result = $this->repository->getWeeklyUpdateRooms($this->today);
+
+        // メンバー変動あり（100→120）の確認クロール対象
+        $this->assertContains(1007, $result, '8日以上ギャップ後の復帰（変動あり）が含まれること');
+
+        // メンバー変動なし（200→200）の確認クロール対象
+        $this->assertContains(1008, $result, '8日以上ギャップ後の復帰（変動なし）が含まれること');
+
+        // 通常の日次サイクル（直近8日間に2レコード）は含まれない
+        $this->assertNotContains(1009, $result, '通常の日次サイクル部屋は含まれないこと');
     }
 
     /**
@@ -217,7 +258,8 @@ class SqliteStatisticsRepositoryTest extends TestCase
      *
      * 期待される動作:
      * - getMemberChangeWithinLastWeek + getNewRoomsWithLessThan8Records + getWeeklyUpdateRooms
-     * - = ID 1001, 1003, 1004, 1006
+     * - = ID 1001, 1003, 1004, 1006, 1007, 1008, 1009
+     *   - 1009は getMemberChangeWithinLastWeek で取得（昨日メンバー変動あり）
      */
     public function testCombinedMethods(): void
     {
@@ -228,7 +270,7 @@ class SqliteStatisticsRepositoryTest extends TestCase
         $combined = array_unique(array_merge($memberChange, $newRooms, $weeklyUpdate));
         sort($combined);
 
-        $expected = [1001, 1003, 1004, 1006];
+        $expected = [1001, 1003, 1004, 1006, 1007, 1008, 1009];
 
         $this->assertSame(
             $expected,
@@ -259,6 +301,9 @@ class SqliteStatisticsRepositoryTest extends TestCase
         $this->assertSame(8, $counts[1004], '部屋1004は8件のレコードを持つこと');
         $this->assertSame(9, $counts[1005], '部屋1005は9件のレコードを持つこと');
         $this->assertSame(9, $counts[1006], '部屋1006は9件のレコードを持つこと');
+        $this->assertSame(2, $counts[1007], '部屋1007は2件のレコードを持つこと（確認クロール対象・変動あり）');
+        $this->assertSame(2, $counts[1008], '部屋1008は2件のレコードを持つこと（確認クロール対象・変動なし）');
+        $this->assertSame(3, $counts[1009], '部屋1009は3件のレコードを持つこと（通常の日次サイクル）');
     }
 
     /**
@@ -285,6 +330,9 @@ class SqliteStatisticsRepositoryTest extends TestCase
         $this->assertGreaterThan(1, $changes[1004], '部屋1004はメンバー数が変動していること');
         $this->assertSame(1, $changes[1005], '部屋1005はメンバー数が変動していないこと');
         $this->assertGreaterThan(1, $changes[1006], '部屋1006はメンバー数が変動していること');
+        $this->assertGreaterThan(1, $changes[1007], '部屋1007はメンバー数が変動していること');
+        $this->assertSame(1, $changes[1008], '部屋1008はメンバー数が変動していないこと');
+        $this->assertGreaterThan(1, $changes[1009], '部屋1009はメンバー数が変動していること');
     }
 
     /**

--- a/app/Models/SQLite/Repositories/Statistics/test/SqliteStatisticsRepositoryTest.php
+++ b/app/Models/SQLite/Repositories/Statistics/test/SqliteStatisticsRepositoryTest.php
@@ -215,8 +215,9 @@ class SqliteStatisticsRepositoryTest extends TestCase
      *
      * 期待される動作:
      * - 最後のレコードが1週間以上前の部屋を取得
-     * - 昨日8日以上ぶりにクロールされた部屋（確認クロール対象）も取得
-     * - ID 1004, 1007, 1008が該当
+     * - 昨日8日以上ぶりにクロールされ、メンバー数が変動した部屋（確認クロール対象）も取得
+     * - ID 1004, 1007が該当
+     * - ID 1008は非該当（メンバー数変動なし → 確認クロール不要、引き続き週次）
      * - ID 1009は非該当（直近8日間に2レコードあるため確認クロール不要）
      */
     public function testGetWeeklyUpdateRooms(): void
@@ -224,30 +225,31 @@ class SqliteStatisticsRepositoryTest extends TestCase
         $result = $this->repository->getWeeklyUpdateRooms($this->today);
         sort($result);
 
-        $expected = [1004, 1007, 1008];
+        $expected = [1004, 1007];
 
         $this->assertSame(
             $expected,
             $result,
-            '週次更新対象 + 確認クロール対象の部屋を取得すること'
+            '週次更新対象 + 確認クロール対象（変動あり）の部屋を取得すること'
         );
     }
 
     /**
      * テスト: 確認クロール対象の詳細検証
      *
-     * 8日以上のギャップから復帰した部屋は、メンバー変動の有無に関わらず
-     * 確認クロール対象に含まれること
+     * - メンバー変動あり → 確認クロール対象（翌日も確認し、日次復帰を判定）
+     * - メンバー変動なし → 引き続き週次（確認クロール不要）
+     * - 通常の日次サイクル → 対象外
      */
     public function testWeeklyUpdateIncludesConfirmationCrawlRooms(): void
     {
         $result = $this->repository->getWeeklyUpdateRooms($this->today);
 
-        // メンバー変動あり（100→120）の確認クロール対象
+        // メンバー変動あり（100→120）→ 確認クロール対象
         $this->assertContains(1007, $result, '8日以上ギャップ後の復帰（変動あり）が含まれること');
 
-        // メンバー変動なし（200→200）の確認クロール対象
-        $this->assertContains(1008, $result, '8日以上ギャップ後の復帰（変動なし）が含まれること');
+        // メンバー変動なし（200→200）→ 引き続き週次、確認クロール不要
+        $this->assertNotContains(1008, $result, '変動なしの部屋は確認クロール不要で含まれないこと');
 
         // 通常の日次サイクル（直近8日間に2レコード）は含まれない
         $this->assertNotContains(1009, $result, '通常の日次サイクル部屋は含まれないこと');
@@ -259,7 +261,9 @@ class SqliteStatisticsRepositoryTest extends TestCase
      * 期待される動作:
      * - getMemberChangeWithinLastWeek + getNewRoomsWithLessThan8Records + getWeeklyUpdateRooms
      * - = ID 1001, 1003, 1004, 1006, 1007, 1008, 1009
-     *   - 1009は getMemberChangeWithinLastWeek で取得（昨日メンバー変動あり）
+     *   - 1007: getWeeklyUpdateRooms（確認クロール） + getNewRoomsWithLessThan8Records
+     *   - 1008: getNewRoomsWithLessThan8Records のみ（変動なし→週次のまま）
+     *   - 1009: getMemberChangeWithinLastWeek + getNewRoomsWithLessThan8Records
      */
     public function testCombinedMethods(): void
     {


### PR DESCRIPTION
## 問題の概要

週次更新ルーム（ランキング未掲載かつメンバー数変動なし）のクロール後、メンバー数が変わっていても翌日の確認クロールが行われない。

[`58f4849b`](https://github.com/mimimiku778/Open-Chat-Graph/commit/58f4849b)（2024-02-09）のバッチフィルター化リファクタで、旧 `OpenChatUpdaterDtoFinalizer` にあったクロール後の再評価ロジックが失われていた。

### 元の仕様

| 状況 | 動作 |
|------|------|
| 前の週と同じ人数 | 引き続き週次。翌日チェックしない |
| 前の週と違う人数 | 翌日もクロールする |
| 翌日の人数が前日と同じ | また週次に戻す |
| 翌日の人数が前日と違う | 日次サイクルへ復帰 |

非アクティブなルームを週次にして節約しつつ、微小な変動（数名の出入り）を吸収する設計。

### なぜ動かなくなっていたか

`getMemberChangeWithinLastWeek` は直近8日間のウィンドウでメンバー変動を検知する。正常な7日サイクルでは7日前のレコードがウィンドウ内に収まるため問題ないが、**8日以上のギャップ**（初回リカバリ等）では古いレコードがウィンドウ外に落ち、変動があっても検知できず、翌日どのフィルターにも拾われなかった。

## 対処内容

[`getWeeklyUpdateRooms()`](https://github.com/mimimiku778/Open-Chat-Graph/blob/fix/weekly-update-confirmation-crawl/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php#L71-L97) にUNION条件を追加。「昨日8日以上ぶりにクロールされ、**かつメンバー数が変動した**ルーム」のみを確認クロール対象に含める。

```sql
UNION

SELECT open_chat_id
FROM statistics AS s_new
WHERE s_new.date = DATE(:curDate, '-1 day')
  -- 直近8日間のレコードが昨日の1件のみ（= 8日以上のギャップ後の復帰）
  AND (SELECT COUNT(*) FROM statistics s_count
       WHERE s_count.open_chat_id = s_new.open_chat_id
         AND s_count.date >= DATE(:curDate, '-8 days')) = 1
  -- 昨日のメンバー数がギャップ前の最新レコードと異なる
  AND s_new.member != (SELECT s_old.member FROM statistics s_old
       WHERE s_old.open_chat_id = s_new.open_chat_id
         AND s_old.date < DATE(:curDate, '-8 days')
       ORDER BY s_old.date DESC LIMIT 1)
```

### 確認クロール後のフロー

| ケース | D日（週次クロール） | D+1 | D+2以降 |
|--------|---------------------|-----|---------|
| 前週と同じ（11→11） | 記録。変動なし | クロールなし | 7日後に再クロール |
| 前週と違う→安定（11→12→12） | 記録。変動あり | 確認クロール。前日と同じ | 週次に戻る |
| 前週と違う→さらに変動（11→12→13） | 記録。変動あり | 確認クロール。前日と違う | `getMemberChangeWithinLastWeek` → 日次へ |

## テスト結果

```
OK (28 tests, 1249 assertions) — 22秒
```

<details>
<summary>テスト詳細</summary>

```
Member Change Filter Cache Repository
 ✔ Database has over 1000 records
 ✔ Database has expected room count
 ✔ GetForHourly returns memberChange and newRooms
 ✔ GetForHourly creates cache files
 ✔ GetForHourly uses cache for memberChange
 ✔ GetForHourly does not include weekly update
 ✔ GetForDaily returns all three data
 ✔ GetForDaily creates all cache files
 ✔ GetForDaily uses all caches on second call
 ✔ GetForDaily refetches when date mismatch
 ✔ GetForDaily includes weekly update
 ✔ Hourly cache does not validate weekly cache
 ✔ Old format cache is treated as invalid
 ✔ Implements interface
 ✔ Di creates instance
 ✔ GetForHourly returns unique values
 ✔ GetForDaily returns unique values
 ✔ GetForHourly performance
 ✔ GetForDaily performance
 ✔ Cached call is faster

Sqlite Statistics Repository
 ✔ Get new rooms with less than 8 records
 ✔ Get member change within last week
 ✔ Get weekly update rooms
 ✔ Weekly update includes confirmation crawl rooms
 ✔ Combined methods
 ✔ Record counts
 ✔ Member changes
 ✔ Empty database
```

</details>

### 追加テストケース

| ID | パターン | `getWeeklyUpdateRooms` |
|----|---------|----------------------|
| 1007 | 確認クロール対象（変動あり: 100→120） | ✓ 含まれる |
| 1008 | 変動なし（200→200）→ 引き続き週次 | ✗ 含まれない |
| 1009 | 通常の日次サイクル（直近8日間に2レコード） | ✗ 含まれない |

### その他

`MemberChangeFilterCacheRepositoryTest` のDB作成を `setUpBeforeClass` に変更（20分→22秒）

🤖 Generated with [Claude Code](https://claude.com/claude-code)