### PR TITLE
[STG] cost: X 投稿の URL を削除して post 単価を13x 下げる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -255,16 +255,15 @@ jobs:
             try {
               const prNumber = process.env.PR_NUMBER;
               const prTitle = process.env.PR_TITLE;
-              const prUrl = process.env.PR_URL;
               const prAuthor = process.env.PR_AUTHOR;
               const tweetMsg = process.env.TWEET_MSG;
-              const siteUrl = process.env.SITE_URL;
 
+              // X API は URL を含む post が $0.20 / URL 無しは $0.015。
+              // 単価を 13x 下げるため URL (siteUrl / prUrl) は載せない。
               const message = '🚀 プルリクエストがマージされ、' + tweetMsg + '\n\n' +
                 '#' + prNumber + ': ' + prTitle + '\n' +
                 'By ' + prAuthor + '\n\n' +
-                '#オプチャグラフ ' + siteUrl + '\n\n' +
-                prUrl;
+                '#オプチャグラフ';
 
               const tweet = await client.v2.tweet(message);
               console.log('Tweet posted: ' + tweet.data.id);


### PR DESCRIPTION
## 動機

X API 2026/04 改定で:
- URL を含む post: **$0.20 / post**
- URL を含まない post: **$0.015 / post** (13x 安い)

旧 deploy.yml は post 本文に `siteUrl` と `prUrl` を載せていたため、自動 post 1件あたり $0.20 課金されていた。

## 変更後の post フォーマット

```
🚀 プルリクエストがマージされ、サイトに反映されました

#240: <PR タイトル>
By <author>

#オプチャグラフ
```

## 影響

- 月 100 PR で $20 → $1.50 に圧縮
- PR 番号は post 本文に残るので URL 無しでも GitHub 上で検索容易