### PR TITLE
[PROD] feat: PR に url-post ラベルを付けると X 投稿に URL を含めるオプション追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -255,15 +255,23 @@ jobs:
             try {
               const prNumber = process.env.PR_NUMBER;
               const prTitle = process.env.PR_TITLE;
+              const prUrl = process.env.PR_URL;
               const prAuthor = process.env.PR_AUTHOR;
               const tweetMsg = process.env.TWEET_MSG;
+              const siteUrl = process.env.SITE_URL;
+              const includeUrls = process.env.INCLUDE_URLS === 'true';
 
-              // X API は URL を含む post が $0.20 / URL 無しは $0.015。
-              // 単価を 13x 下げるため URL (siteUrl / prUrl) は載せない。
+              // X API: URL を含む post は $0.20 / 含まない場合 $0.015。
+              // デフォルトは URL なし。PR に `url-post` ラベルが付いている場合のみ
+              // サイト URL と PR URL を載せる（重要な PR で広く拡散したい用途想定）。
+              const tail = includeUrls
+                ? '#オプチャグラフ ' + siteUrl + '\n\n' + prUrl
+                : '#オプチャグラフ';
+
               const message = '🚀 プルリクエストがマージされ、' + tweetMsg + '\n\n' +
                 '#' + prNumber + ': ' + prTitle + '\n' +
                 'By ' + prAuthor + '\n\n' +
-                '#オプチャグラフ';
+                tail;
 
               const tweet = await client.v2.tweet(message);
               console.log('Tweet posted: ' + tweet.data.id);
@@ -293,6 +301,7 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           TWEET_MSG: ${{ steps.config.outputs.tweet_msg }}
           SITE_URL: ${{ steps.config.outputs.tweet_url }}
+          INCLUDE_URLS: ${{ contains(github.event.pull_request.labels.*.name, 'url-post') }}
         run: node post-pr-merge.js
 
       - name: Notify Discord (deploy failure)


### PR DESCRIPTION
## 概要

通常 (label 無し): URL 無し post で **$0.015/post**
`url-post` ラベル付き: 旧形式の URL 入り post で **$0.20/post** (重要 PR で広く拡散したい用途)

判定は `contains(github.event.pull_request.labels.*.name, 'url-post')` で行い、`INCLUDE_URLS` env として JS に渡す。

## post フォーマット

**通常 (label 無し):**
```
🚀 プルリクエストがマージされ、...
#XXX: <title>
By <author>

#オプチャグラフ
```

**`url-post` ラベル付き:**
```
🚀 プルリクエストがマージされ、...
#XXX: <title>
By <author>

#オプチャグラフ https://openchat-review.me

https://github.com/.../pull/XXX
```

stg 側: #243