### PR TITLE
[PROD] feat: PR の OGP 画像を取得して X 投稿に添付（URL なしで視覚情報を担保）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,6 +251,26 @@ jobs:
             accessSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
           });
 
+          // GitHub PR ページから OGP 画像 URL を抽出
+          async function fetchOgImageUrl(pageUrl) {
+            const res = await fetch(pageUrl, {
+              headers: { 'User-Agent': 'Mozilla/5.0 (compatible; OpenChatGraphBot)' },
+            });
+            if (!res.ok) return null;
+            const html = await res.text();
+            const m = html.match(/<meta\s+property="og:image"\s+content="([^"]+)"/i);
+            return m ? m[1] : null;
+          }
+
+          // OGP 画像をダウンロード (Buffer + MIME)
+          async function downloadImage(url) {
+            const res = await fetch(url);
+            if (!res.ok) throw new Error('image download failed: ' + res.status);
+            const mimeType = (res.headers.get('content-type') || 'image/png').split(';')[0];
+            const buffer = Buffer.from(await res.arrayBuffer());
+            return { buffer, mimeType };
+          }
+
           async function postTweet() {
             try {
               const prNumber = process.env.PR_NUMBER;
@@ -262,8 +282,24 @@ jobs:
               const includeUrls = process.env.INCLUDE_URLS === 'true';
 
               // X API: URL を含む post は $0.20 / 含まない場合 $0.015。
-              // デフォルトは URL なし。PR に `url-post` ラベルが付いている場合のみ
-              // サイト URL と PR URL を載せる（重要な PR で広く拡散したい用途想定）。
+              // デフォルトは URL なし & OGP 画像添付 (PR の社内カード画像をビジュアル代替)。
+              // `url-post` ラベル付き PR の場合は URL を本文に載せる ($0.20)、X 側で
+              // URL 埋め込みカードが付くので OGP 添付は不要。
+              let mediaIds;
+              if (!includeUrls) {
+                try {
+                  const ogImageUrl = await fetchOgImageUrl(prUrl);
+                  if (ogImageUrl) {
+                    const { buffer, mimeType } = await downloadImage(ogImageUrl);
+                    const mediaId = await client.v1.uploadMedia(buffer, { mimeType });
+                    mediaIds = [mediaId];
+                    console.log('OGP image attached: ' + ogImageUrl);
+                  }
+                } catch (e) {
+                  console.error('OGP image skipped:', e.message);
+                }
+              }
+
               const tail = includeUrls
                 ? '#オプチャグラフ ' + siteUrl + '\n\n' + prUrl
                 : '#オプチャグラフ';
@@ -273,7 +309,10 @@ jobs:
                 'By ' + prAuthor + '\n\n' +
                 tail;
 
-              const tweet = await client.v2.tweet(message);
+              const tweetOpts = mediaIds && mediaIds.length
+                ? { media: { media_ids: mediaIds } }
+                : undefined;
+              const tweet = await client.v2.tweet(message, tweetOpts);
               console.log('Tweet posted: ' + tweet.data.id);
 
             } catch (error) {


### PR DESCRIPTION
## 概要

通常モード (`url-post` ラベル無し) の X 投稿に PR の OGP 画像を添付する。
URL を本文に入れない (= $0.015/post 維持) ままで、視覚的に PR の存在を訴求できる。

## 動作

| 条件 | post 内容 | 単価 |
|---|---|---|
| ラベル無し (デフォルト) | テキスト + **OGP 画像添付** | $0.015 |
| `url-post` ラベル付き | テキスト + 本文 URL (X 側で URL カード自動展開) | $0.20 |

## 実装

- `fetchOgImageUrl()`: PR ページから `<meta property="og:image" content="...">` を抽出
- `downloadImage()`: 抽出 URL から Buffer + Content-Type を取得
- `client.v1.uploadMedia()`: X v1.1 メディアアップロード
- `client.v2.tweet(text, { media: { media_ids } })`: 添付つき post

OGP 取得失敗時 (ネットワーク断 / GitHub の HTML 変更等) は画像なしテキストのみで継続。

stg 側: #245