### PR TITLE
[STG] refactor: GitHub リポジトリ URL を新 org に追従

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ Note: Database configuration is loaded from `local-secrets.php`
 ### User Agent
 
 ```
-Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/mimimiku778/Open-Chat-Graph)
+Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/Open-Chat-Graph/Open-Chat-Graph)
 ```
 
 ## Frontend Components

--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ ci-test: _check-data-protection ## ローカルでCIテストを実行（Mock環
 # 機密ファイルは batch/sh/prod-sync/secrets/ にプライベートリポを clone する形で取得する。
 # アクセス権がない場合は git clone 自体が失敗するため、必然的に sync は使えない。
 
-PROD_SYNC_CONFIG_URL ?= git@github.com:mimimiku778/Open-Chat-Graph-Config.git
+PROD_SYNC_CONFIG_URL ?= git@github.com:Open-Chat-Graph/Open-Chat-Graph-Config.git
 
 _ensure-prod-sync-secrets:
 	@SECRETS_DIR=batch/sh/prod-sync/secrets; \

--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -158,7 +158,7 @@ class AppConfig
     static bool $enableCloudflare = false;
 
     /** GitHubリポジトリ（ログのソースコードリンク用） */
-    static string $githubRepo = 'mimimiku778/Open-Chat-Graph';
+    static string $githubRepo = 'Open-Chat-Graph/Open-Chat-Graph';
     static string $githubBranch = 'main';
     static bool $disableAdTags = true;
 

--- a/app/Services/Crawler/Config/MockOpenChatCrawlerConfig.php
+++ b/app/Services/Crawler/Config/MockOpenChatCrawlerConfig.php
@@ -15,7 +15,7 @@ class MockOpenChatCrawlerConfig implements OpenChatCrawlerConfigInterface
 
     const LINE_INTERNAL_URL = 'http://line-mock-api/ti/g2/';
 
-    const USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot-Mock; +https://github.com/mimimiku778/Open-Chat-Graph)';
+    const USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot-Mock; +https://github.com/Open-Chat-Graph/Open-Chat-Graph)';
 
     public const LINE_URL_MATCH_PATTERN = [
         '' =>    '{(?<=https:\/\/line-mock-api\/jp\/cover\/).+?(?=\?|$)}',

--- a/app/Services/Crawler/Config/OpenChatCrawlerConfig.php
+++ b/app/Services/Crawler/Config/OpenChatCrawlerConfig.php
@@ -6,7 +6,7 @@ class OpenChatCrawlerConfig implements OpenChatCrawlerConfigInterface
 {
     protected const LINE_INTERNAL_URL = 'https://line.me/ti/g2/';
 
-    protected const USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/mimimiku778/Open-Chat-Graph)';
+    protected const USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/Open-Chat-Graph/Open-Chat-Graph)';
 
     public const LINE_URL_MATCH_PATTERN = [
         '' =>    '{(?<=https:\/\/openchat\.line\.me\/jp\/cover\/).+?(?=\?|$)}',

--- a/app/Services/OpenChat/Crawler/OpenChatCrawler.php
+++ b/app/Services/OpenChat/Crawler/OpenChatCrawler.php
@@ -31,7 +31,7 @@ class OpenChatCrawler
 
         /**
          *  @var string $ua クローリング用のユーザーエージェント
-         *                  Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/mimimiku778/Open-Chat-Graph)
+         *                  Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/Open-Chat-Graph/Open-Chat-Graph)
          */
         $ua = $this->config->getUserAgent();
 

--- a/app/Views/policy_content.php
+++ b/app/Views/policy_content.php
@@ -18,7 +18,7 @@ viewComponent('policy_head', compact('_css', '_meta')) ?>
             <?php if (\Shared\MimimalCmsConfig::$urlRoot === ''): ?>
                 <h1 style="letter-spacing: 0px;">オプチャグラフとは？</h1>
                 <p>オプチャグラフはLINEオープンチャットの成長傾向をグラフやランキングで比較できるWEBサイトです。</p>
-                <p>LINE非公式の<a href="https://github.com/mimimiku778/Open-Chat-Graph" target="_blank">オープンソースプロジェクト</a>により運営されています。 </p>
+                <p>LINE非公式の<a href="https://github.com/Open-Chat-Graph/Open-Chat-Graph" target="_blank">オープンソースプロジェクト</a>により運営されています。 </p>
                 <h2>サイトの目的</h2>
                 <p>・ユーザーがオープンチャットを見つけて参加する機会を作る</p>
                 <p>・オープンチャットの管理者が成長傾向を把握し、比較できる事で運営に役立つ</p>
@@ -185,7 +185,7 @@ viewComponent('policy_head', compact('_css', '_meta')) ?>
             <?php elseif (\Shared\MimimalCmsConfig::$urlRoot === '/tw') : ?>
                 <h1 style="letter-spacing: 0px;">關於LINE社群流量統計</h1>
                 <p>LINE社群流量統計是一個幫助使用者發現開放聊天室，並透過圖表和排名比較成長趨勢的網站。</p>
-                <p>這是一個由 <a href="https://github.com/mimimiku778/Open-Chat-Graph" target="_blank">開源專案</a> （LINE非官方）營運。</p>
+                <p>這是一個由 <a href="https://github.com/Open-Chat-Graph/Open-Chat-Graph" target="_blank">開源專案</a> （LINE非官方）營運。</p>
                 <h2>網站的目標</h2>
                 <p>・為使用者提供機會找到並加入開放聊天室</p>
                 <p>・協助開放聊天室的管理員掌握成長趨勢並進行比較，對管理運營有所幫助</p>
@@ -238,7 +238,7 @@ viewComponent('policy_head', compact('_css', '_meta')) ?>
             <?php elseif (\Shared\MimimalCmsConfig::$urlRoot === '/th') : ?>
                 <h1 style="letter-spacing: 0px;">เกี่ยวกับ LINE OPENCHAT สถิติการเข้าชม</h1>
                 <p>LINE OPENCHAT สถิติการเข้าชม เป็นเว็บไซต์ที่ช่วยให้ผู้ใช้ค้นหา โอเพนแชท และเปรียบเทียบแนวโน้มการเติบโตผ่านกราฟและการจัดอันดับ</p>
-                <p>ดำเนินการโดย<a href="https://github.com/mimimiku778/Open-Chat-Graph" target="_blank">โครงการโอเพนซอร์ส</a> (ไม่ใช่ทางการของ LINE)</p>
+                <p>ดำเนินการโดย<a href="https://github.com/Open-Chat-Graph/Open-Chat-Graph" target="_blank">โครงการโอเพนซอร์ส</a> (ไม่ใช่ทางการของ LINE)</p>
                 <h2>เป้าหมายของเว็บไซต์</h2>
                 <p>・สร้างโอกาสให้ผู้ใช้ค้นหาและเข้าร่วม โอเพนแชท</p>
                 <p>・ช่วยให้ผู้ดูแล โอเพนแชท เข้าใจแนวโน้มการเติบโตและเปรียบเทียบข้อมูลเพื่อสนับสนุนการจัดการ</p>

--- a/shared/MimimalCmsConfig.php
+++ b/shared/MimimalCmsConfig.php
@@ -146,5 +146,5 @@ class MimimalCmsConfig
      * This constant is used to specify the GitHub URL for displaying the source code in the exception error trace.
      * The path name after the DOCUMENT_ROOT_NAME constant is concatenated with this URL.
      */
-    public static string $errorPageGitHubUrl = 'https://github.com/mimimiku778/Open-Chat-Graph/blob/main/';
+    public static string $errorPageGitHubUrl = 'https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/main/';
 }


### PR DESCRIPTION
## 概要

リポジトリを Open-Chat-Graph org に transfer したのに伴い、コード内に固定値で書かれていた GitHub URL 参照を新 org URL に更新。

## 更新箇所

- `app/Config/AppConfig.php` — `$githubRepo` (ソースコードリンク用)
- `shared/MimimalCmsConfig.php` — `$errorPageGitHubUrl` (エラーページの "view on GitHub" 先)
- `app/Services/Crawler/Config/{,Mock}OpenChatCrawlerConfig.php` — クローラ User-Agent 内 URL
- `app/Services/OpenChat/Crawler/OpenChatCrawler.php` — docstring
- `app/Views/policy_content.php` — ja/zh-tw/th フッターリンク 3 箇所
- `Makefile` — `PROD_SYNC_CONFIG_URL` (機密リポ URL)
- `CLAUDE.md` — User-Agent 例

## 副次的検証

このPR の merge をもって以下を実機で確認する:
- X 投稿の OGP 画像が新 org `Open-Chat-Graph` のアバターを含むかどうか
- post 本文に URL が出ないかどうか ($0.015/post 課金維持)

## 不変

- Frontend / Frontend-Stats-Graph / Comments の 3 リポは未移行 (アーカイブ予定) のため該当 URL は据え置き
- author 表記 (LICENSE/composer.json/MimimalCMS ヘッダ) は org 化と無関係