### PR TITLE
[PROD] fix: OGP 画像取得の UA を修正（429 回避）+ フッター URL を新 org に追従

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,11 +251,13 @@ jobs:
             accessSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
           });
 
+          // opengraph.githubassets.com は bot 風 UA に対し 429 を返すため、
+          // ブラウザ風 UA で取得する。
+          const BROWSER_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
           // GitHub PR ページから OGP 画像 URL を抽出
           async function fetchOgImageUrl(pageUrl) {
-            const res = await fetch(pageUrl, {
-              headers: { 'User-Agent': 'Mozilla/5.0 (compatible; OpenChatGraphBot)' },
-            });
+            const res = await fetch(pageUrl, { headers: { 'User-Agent': BROWSER_UA } });
             if (!res.ok) return null;
             const html = await res.text();
             const m = html.match(/<meta\s+property="og:image"\s+content="([^"]+)"/i);
@@ -264,7 +266,7 @@ jobs:
 
           // OGP 画像をダウンロード (Buffer + MIME)
           async function downloadImage(url) {
-            const res = await fetch(url);
+            const res = await fetch(url, { headers: { 'User-Agent': BROWSER_UA } });
             if (!res.ok) throw new Error('image download failed: ' + res.status);
             const mimeType = (res.headers.get('content-type') || 'image/png').split(';')[0];
             const buffer = Buffer.from(await res.arrayBuffer());

--- a/app/Views/components/footer_inner.php
+++ b/app/Views/components/footer_inner.php
@@ -29,6 +29,6 @@
                 <span class="text"><?php echo t('LINEアプリをダウンロード（LINE公式）') ?><span class="line-link-icon777"></span></span>
             </a>
         </aside>
-        <div class="copyright">© <?php echo t('オプチャグラフ') ?><span><a class="unset" style="cursor: pointer;" href="https://github.com/mimimiku778" target="_blank">Project on GitHub @mimimiku778</a><span class="line-link-icon777"></span></span></div>
+        <div class="copyright">© <?php echo t('オプチャグラフ') ?><span><a class="unset" style="cursor: pointer;" href="https://github.com/Open-Chat-Graph" target="_blank">Project on GitHub @Open-Chat-Graph</a><span class="line-link-icon777"></span></span></div>
     </nav>
 </footer>


### PR DESCRIPTION
## 内容

- OGP 画像取得を browser-like UA に変更（`opengraph.githubassets.com` の 429 回避、curl で 200 を実測）
- フッター copyright のリンク (`@mimimiku778` → `@Open-Chat-Graph`)

stg 側: #249

skip-post 付与（X post 消費しない、次の通常 PR でOGP添付を確認）