### PR TITLE
[PROD] fix: 削除済みオープンチャットURLを 410 Gone で返してGoogleインデックス除外を加速

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -54,14 +54,22 @@ class OpenChatPageController
 
         if (MimimalCmsConfig::$urlRoot === '') {
             $oc = $ocRepo->getOpenChatByIdWithTag($open_chat_id);
-            if (!$oc)
+            if (!$oc) {
+                if (isset($isAdminPage) || !$ocRepo->isWithinIdRange($open_chat_id)) {
+                    return false;
+                }
                 return $this->deletedResponse($recommendGenarator, $open_chat_id, $topPageDto);
+            }
 
             $recommend = $recommendGenarator->getRecommend($oc['tag1'], $oc['tag2'], $oc['tag3'], $oc['category']);
         } else {
             $oc = $ocRepo->getOpenChatById($open_chat_id);
-            if (!$oc)
-                return false;
+            if (!$oc) {
+                if (!$ocRepo->isWithinIdRange($open_chat_id)) {
+                    return false;
+                }
+                return $this->deletedResponse($recommendGenarator, $open_chat_id, $topPageDto);
+            }
 
             /** @var RecommendRankingRepository $recommendRankingRepository */
             $recommendRankingRepository = app(RecommendRankingRepository::class);
@@ -187,16 +195,43 @@ class OpenChatPageController
         return $officialPageList->getListDto($emblem);
     }
 
+    /**
+     * 過去に発番されていた範囲の id への !$oc アクセス時に呼ばれる削除済みレスポンス。
+     *
+     * - HTTP 410 Gone を返す (Google の再クロールキューから速やかに外す目的;
+     *   元の 404 だと数ヶ月〜年単位で再クロールされ続ける)
+     * - JP & recommend タグあり: errors/oc_error.php (リッチ UI: 「削除されました」+ recommend)
+     * - JP & タグなし / TW / TH: errors/error.php (汎用、TW/TH は翻訳済み)
+     *   ※ oc_error.php は本文が JP ハードコードのため他言語では使えない
+     *
+     * 範囲外 (=過去にも一度も発番されていない適当な id) の場合はこの関数は呼ばれず、
+     * 呼び出し側で return false → framework デフォルト 404 が走る。
+     */
     private function deletedResponse(
         RecommendGenarator $recommendGenarator,
         int $open_chat_id,
         StaticTopPageDto $topPageDto
     ) {
+        http_response_code(410);
+
+        if (MimimalCmsConfig::$urlRoot !== '') {
+            return view('errors/error', [
+                'httpCode' => 410,
+                'httpStatusMessage' => 'Gone',
+                'detailsMessage' => '',
+            ]);
+        }
+
         /** @var RecommendRankingRepository $repo */
         $repo = app(RecommendRankingRepository::class);
         $tag = $repo->getRecommendTag($open_chat_id);
-        if (!$tag)
-            return false;
+        if (!$tag) {
+            return view('errors/error', [
+                'httpCode' => 410,
+                'httpStatusMessage' => 'Gone',
+                'detailsMessage' => '',
+            ]);
+        }
 
         $_meta = meta()->setTitle("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
             ->setDescription("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
@@ -206,7 +241,6 @@ class OpenChatPageController
         [$tag2, $tag3] = $repo->getTags($open_chat_id);
         $recommend = $recommendGenarator->getRecommend($tag, $tag2 ?: null, $tag3 ?: null, null);
 
-        http_response_code(404);
         return view('errors/oc_error', compact('_meta', '_css', 'recommend', 'open_chat_id', 'topPageDto'));
     }
 

--- a/app/Models/Repositories/OpenChatPageRepository.php
+++ b/app/Models/Repositories/OpenChatPageRepository.php
@@ -95,6 +95,12 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
         return !!DB::fetchColumn($query, ['id' => $id]);
     }
 
+    public function isWithinIdRange(int $id): bool
+    {
+        $max = (int) DB::fetchColumn("SELECT MAX(id) FROM open_chat");
+        return $id <= $max;
+    }
+
     public function getOpenChatNamesByIds(array $ids): array
     {
         if (empty($ids)) {

--- a/app/Models/Repositories/OpenChatPageRepositoryInterface.php
+++ b/app/Models/Repositories/OpenChatPageRepositoryInterface.php
@@ -12,6 +12,12 @@ interface OpenChatPageRepositoryInterface
 
     public function isExistsOpenChat(int $id): bool;
 
+    /**
+     * 指定した id が「過去に発番されていてもおかしくない範囲」内か。
+     * MAX(open_chat.id) 以下なら true (= 過去存在していた / 現在削除済みの可能性あり)。
+     */
+    public function isWithinIdRange(int $id): bool;
+
     /** @param int[] $ids
      *  @return array<int, string> [id => name] */
     public function getOpenChatNamesByIds(array $ids): array;


### PR DESCRIPTION
## 問題の概要

LINE で削除されたオープンチャットの URL に対し現状 HTTP 404 を返している。Google Search Console 上で「見つかりませんでした (404)」が **22万件以上**累積しており、これは過去に LINE で削除されたルームの累積。

### 具体的な問題

- 404 = "今は無いが将来戻るかも" として Google は数ヶ月〜年単位で再クロールを継続
- クロールバジェットを浪費し、本来インデックスすべきページの発見が遅れる
- LINE OpenChat の仕様上、削除された ID が将来戻ることはなく、404 は実態と乖離

## 対処内容

過去に発番された範囲内 (`MAX(open_chat.id)` 以下) の id に対し `!$oc` だった場合は **HTTP 410 Gone**（永続的に消滅）を返す。Google は 410 を見るとクロールキューから速やかに除外する。範囲外の id (= 過去にも一度も発番されていない、ランダムスキャナ等) は従来通り 404。

### ビュー振り分け (deletedResponse 内)

- **JP & recommend タグあり**: `errors/oc_error.php` (リッチ UI: 「削除されました」+ recommend リスト)
- **JP & タグなし / TW / TH**: `errors/error.php` (汎用、TW/TH は翻訳済み)
  - `oc_error.php` は本文が JP ハードコードのため他言語では使えない

### その他

- `OpenChatPageRepository` に `isWithinIdRange()` を追加 (MAX(id) 判定)
- `/oc/{id}/admin` (`$isAdminPage` あり) は 404 のまま維持 (管理 UI の確認用)

## テスト方法

### 手動テスト (デプロイ後の本番)

削除済み・範囲内 → **410** + 「削除されました」UI:
```bash
curl -sI https://openchat-review.me/oc/298 | head -1   # 期待: HTTP/2 410
```

範囲外 → **404** のまま:
```bash
curl -sI https://openchat-review.me/oc/137722222 | head -1   # 期待: HTTP/2 404
```

正常な ID → **200**:
```bash
curl -sI https://openchat-review.me/oc/3 | head -1   # 期待: HTTP/2 200
```

TW/TH も同様 (範囲内 → 410 + 翻訳付き error.php、範囲外 → 404)。

### 中長期検証

1〜3 ヶ月後に Google Search Console「ページのインデックス登録 > 見つかりませんでした (404)」の件数（現在 228,171）が減少傾向か確認。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)