### PR TITLE
[PROD] fix: 削除済みオープンチャットURLを 410 Gone で返してGoogleインデックス除外を加速

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,17 +328,21 @@ jobs:
                 }
               }
 
-              // PR 本文末尾の "🤖 Generated with..." / "Co-Authored-By:" は除外。
+              // PR 本文末尾の "🤖 Generated with..." / "Co-Authored-By:" は除外し、
+              // markdown ヘッダ (#, ##, ### …) の直下の空行のみ詰める。
+              // 段落間の空行は読みやすさのため残す。
               const prBody = (process.env.PR_BODY || '')
                 .replace(/\n*🤖[\s\S]*$/, '')
                 .replace(/\n*Co-Authored-By:[\s\S]*$/, '')
+                .replace(/^(#{1,6} .*)\n\n+/gm, '$1\n')
                 .trim();
 
               // X Premium tweet 上限は 25,000 文字。それを超える場合だけ事前に切り詰める。
               const MAX_TWEET = 25000;
-              const head = '🚀 ' + tweetMsg + '#オプチャグラフ\n\n' +
-                '#' + prNumber + ': ' + prTitle + '\n' +
-                'By ' + prAuthor;
+              // head: 「🚀 メッセージ#オプチャグラフ\n#番号: タイトル」の 2 行のみ。
+              // (アバター画像から作者は分かるので By {author} は省く)
+              const head = '🚀 ' + tweetMsg + '#オプチャグラフ\n' +
+                '#' + prNumber + ': ' + prTitle;
               const urlSuffix = includeUrls ? '\n\n' + siteUrl + '\n\n' + prUrl : '';
               const separator = '\n---\n';
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
               echo "ssh_host=${{ vars.STG_SSH_HOST }}"
               echo "ssh_path=${{ vars.STG_SSH_PATH }}"
               echo "mysql_dbs=${{ vars.STG_MYSQL_DB_COMMENT }} ${{ vars.STG_MYSQL_DB_COMMENT_TW }} ${{ vars.STG_MYSQL_DB_COMMENT_TH }}"
-              echo "tweet_msg=開発環境に反映されました"
+              echo "tweet_msg=開発環境が更新されました。以下のPRがマージされました。"
               echo "tweet_url=https://openchat-review-dev.me"
             } >> "$GITHUB_OUTPUT"
           else
@@ -76,7 +76,7 @@ jobs:
               echo "ssh_host=${{ vars.SSH_HOST }}"
               echo "ssh_path=${{ vars.SSH_PATH }}"
               echo "mysql_dbs=${{ vars.MYSQL_DB_COMMENT }} ${{ vars.MYSQL_DB_COMMENT_TW }} ${{ vars.MYSQL_DB_COMMENT_TH }}"
-              echo "tweet_msg=サイトに反映されました"
+              echo "tweet_msg=サイトが更新されました。以下のPRがマージされました。"
               echo "tweet_url=https://openchat-review.me"
             } >> "$GITHUB_OUTPUT"
           fi
@@ -255,22 +255,48 @@ jobs:
           // ブラウザ風 UA で取得する。
           const BROWSER_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
-          // GitHub PR ページから OGP 画像 URL を抽出
-          async function fetchOgImageUrl(pageUrl) {
-            const res = await fetch(pageUrl, { headers: { 'User-Agent': BROWSER_UA } });
-            if (!res.ok) return null;
-            const html = await res.text();
-            const m = html.match(/<meta\s+property="og:image"\s+content="([^"]+)"/i);
-            return m ? m[1] : null;
+          const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+          // GitHub PR ページから OGP 画像 URL を抽出。
+          // opengraph.githubassets.com の生成キュー詰まりや GitHub 側キャッシュ伝播遅延で
+          // 初回 fetch が失敗 / og:image meta 未反映のことがあるため、指数バックオフで
+          // 最大 5 回 (合計 ~45 秒) リトライする。
+          async function fetchOgImageUrl(pageUrl, retries = 5) {
+            for (let i = 0; i < retries; i++) {
+              try {
+                const res = await fetch(pageUrl, { headers: { 'User-Agent': BROWSER_UA } });
+                if (res.ok) {
+                  const html = await res.text();
+                  const m = html.match(/<meta\s+property="og:image"\s+content="([^"]+)"/i);
+                  if (m) return m[1];
+                }
+                console.log('fetchOgImageUrl attempt ' + (i + 1) + ' / ' + retries + ' failed (status=' + res.status + ')');
+              } catch (e) {
+                console.log('fetchOgImageUrl attempt ' + (i + 1) + ' / ' + retries + ' error: ' + e.message);
+              }
+              if (i < retries - 1) await sleep(3000 * (i + 1));
+            }
+            return null;
           }
 
-          // OGP 画像をダウンロード (Buffer + MIME)
-          async function downloadImage(url) {
-            const res = await fetch(url, { headers: { 'User-Agent': BROWSER_UA } });
-            if (!res.ok) throw new Error('image download failed: ' + res.status);
-            const mimeType = (res.headers.get('content-type') || 'image/png').split(';')[0];
-            const buffer = Buffer.from(await res.arrayBuffer());
-            return { buffer, mimeType };
+          // OGP 画像をダウンロード (Buffer + MIME)。
+          // opengraph.githubassets.com が 5xx / 429 を返すことがあるためリトライする。
+          async function downloadImage(url, retries = 5) {
+            for (let i = 0; i < retries; i++) {
+              try {
+                const res = await fetch(url, { headers: { 'User-Agent': BROWSER_UA } });
+                if (res.ok) {
+                  const mimeType = (res.headers.get('content-type') || 'image/png').split(';')[0];
+                  const buffer = Buffer.from(await res.arrayBuffer());
+                  return { buffer, mimeType };
+                }
+                console.log('downloadImage attempt ' + (i + 1) + ' / ' + retries + ' failed (status=' + res.status + ')');
+              } catch (e) {
+                console.log('downloadImage attempt ' + (i + 1) + ' / ' + retries + ' error: ' + e.message);
+              }
+              if (i < retries - 1) await sleep(3000 * (i + 1));
+            }
+            throw new Error('image download failed after ' + retries + ' retries');
           }
 
           async function postTweet() {
@@ -302,19 +328,56 @@ jobs:
                 }
               }
 
-              const tail = includeUrls
-                ? '#オプチャグラフ ' + siteUrl + '\n\n' + prUrl
-                : '#オプチャグラフ';
+              // PR 本文末尾の "🤖 Generated with..." / "Co-Authored-By:" は除外。
+              const prBody = (process.env.PR_BODY || '')
+                .replace(/\n*🤖[\s\S]*$/, '')
+                .replace(/\n*Co-Authored-By:[\s\S]*$/, '')
+                .trim();
 
-              const message = '🚀 プルリクエストがマージされ、' + tweetMsg + '\n\n' +
+              // X Premium tweet 上限は 25,000 文字。それを超える場合だけ事前に切り詰める。
+              const MAX_TWEET = 25000;
+              const head = '🚀 ' + tweetMsg + '#オプチャグラフ\n\n' +
                 '#' + prNumber + ': ' + prTitle + '\n' +
-                'By ' + prAuthor + '\n\n' +
-                tail;
+                'By ' + prAuthor;
+              const urlSuffix = includeUrls ? '\n\n' + siteUrl + '\n\n' + prUrl : '';
+              const separator = '\n---\n';
+
+              let bodySection = '';
+              if (prBody) {
+                const overhead = head.length + separator.length + urlSuffix.length;
+                const remaining = MAX_TWEET - overhead;
+                if (remaining > 5) {
+                  const body = prBody.length > remaining
+                    ? prBody.slice(0, remaining - 1) + '…'
+                    : prBody;
+                  bodySection = separator + body;
+                }
+              }
+
+              const message = head + bodySection + urlSuffix;
 
               const tweetOpts = mediaIds && mediaIds.length
                 ? { media: { media_ids: mediaIds } }
                 : undefined;
-              const tweet = await client.v2.tweet(message, tweetOpts);
+
+              // X Premium 前提でフル本文を送信。文字数超過で X に拒否された場合のみ
+              // head + 区切り + 切り詰め本文 で再送する。
+              let tweet;
+              try {
+                tweet = await client.v2.tweet(message, tweetOpts);
+              } catch (err) {
+                const errCodes = (err && err.data && err.data.errors) ? err.data.errors.map(e => e.code) : [];
+                const tooLong = errCodes.includes(186) || /too long|character limit/i.test((err && err.message) || '');
+                if (!tooLong) throw err;
+
+                console.log('Tweet rejected as too long (' + message.length + ' chars). Retrying with truncated body.');
+                const tail = bodySection ? '\n---\n' : '';
+                const baseLen = head.length + tail.length + urlSuffix.length;
+                const limit = 280; // X 拒否時のフォールバック上限
+                const truncatedBody = prBody.slice(0, Math.max(0, limit - baseLen - 1)) + '…';
+                const fallback = head + (truncatedBody.length > 1 ? '\n---\n' + truncatedBody : '') + urlSuffix;
+                tweet = await client.v2.tweet(fallback, tweetOpts);
+              }
               console.log('Tweet posted: ' + tweet.data.id);
 
             } catch (error) {
@@ -340,6 +403,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
           TWEET_MSG: ${{ steps.config.outputs.tweet_msg }}
           SITE_URL: ${{ steps.config.outputs.tweet_url }}
           INCLUDE_URLS: ${{ contains(github.event.pull_request.labels.*.name, 'url-post') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,12 +328,18 @@ jobs:
                 }
               }
 
-              // PR 本文末尾の "🤖 Generated with..." / "Co-Authored-By:" は除外し、
-              // markdown ヘッダ (#, ##, ### …) の直下の空行のみ詰める。
-              // 段落間の空行は読みやすさのため残す。
+              // PR 本文の整形:
+              //  1. 末尾の "🤖 Generated with..." / "Co-Authored-By:" を除外
+              //  2. URL を全部除去 (X API は URL 含むツイートで $0.20、無しで $0.015 と
+              //     13 倍コスト差。本文中のリンク経由で URL が混入するのを防ぐ)
+              //  3. markdown ヘッダ (#, ##, ### …) の直下の空行のみ詰める
+              //     (段落間の空行は読みやすさのため残す)
               const prBody = (process.env.PR_BODY || '')
                 .replace(/\n*🤖[\s\S]*$/, '')
                 .replace(/\n*Co-Authored-By:[\s\S]*$/, '')
+                .replace(/\[([^\]]+)\]\(https?:\/\/[^)]+\)/g, '$1')
+                .replace(/<https?:\/\/[^>]+>/g, '')
+                .replace(/https?:\/\/\S+/g, '')
                 .replace(/^(#{1,6} .*)\n\n+/gm, '$1\n')
                 .trim();
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ setup/local-setup.sh
 # バッチ処理
 batch/sh/*.key
 batch/sh/sqldump
-batch/sh/prod-sync/secrets/*
+batch/sh/prod-sync/secrets/
 !batch/sh/prod-sync/secrets-example/**
 
 # サイトマップ

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -214,32 +214,28 @@ class OpenChatPageController
     ) {
         http_response_code(410);
 
+        // TW/TH: oc_error.php は JP 本文ハードコードのため framework error.php へ
         if (MimimalCmsConfig::$urlRoot !== '') {
-            return view('errors/error', [
-                'httpCode' => 410,
-                'httpStatusMessage' => 'Gone',
-                'detailsMessage' => '',
-            ]);
+            return view('errors/error', ['httpCode' => 410]);
         }
 
         /** @var RecommendRankingRepository $repo */
         $repo = app(RecommendRankingRepository::class);
         $tag = $repo->getRecommendTag($open_chat_id);
-        if (!$tag) {
-            return view('errors/error', [
-                'httpCode' => 410,
-                'httpStatusMessage' => 'Gone',
-                'detailsMessage' => '',
-            ]);
-        }
 
-        $_meta = meta()->setTitle("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
-            ->setDescription("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
-            ->setOgpDescription("「{$tag}」タグのオープンチャット ID:{$open_chat_id} （オプチャグラフから削除済み）");
+        $titlePrefix = $tag
+            ? "「{$tag}」タグ ID:{$open_chat_id}"
+            : "ID:{$open_chat_id}";
+        $_meta = meta()->setTitle("{$titlePrefix} （オプチャグラフから削除済み）")
+            ->setDescription("{$titlePrefix} （オプチャグラフから削除済み）")
+            ->setOgpDescription(($tag ? "「{$tag}」タグのオープンチャット" : 'オープンチャット') . " ID:{$open_chat_id} （オプチャグラフから削除済み）");
         $_css = ['room_list', 'site_header', 'site_footer', 'recommend_list'];
 
-        [$tag2, $tag3] = $repo->getTags($open_chat_id);
-        $recommend = $recommendGenarator->getRecommend($tag, $tag2 ?: null, $tag3 ?: null, null);
+        $recommend = [];
+        if ($tag) {
+            [$tag2, $tag3] = $repo->getTags($open_chat_id);
+            $recommend = $recommendGenarator->getRecommend($tag, $tag2 ?: null, $tag3 ?: null, null);
+        }
 
         return view('errors/oc_error', compact('_meta', '_css', 'recommend', 'open_chat_id', 'topPageDto'));
     }

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -54,14 +54,22 @@ class OpenChatPageController
 
         if (MimimalCmsConfig::$urlRoot === '') {
             $oc = $ocRepo->getOpenChatByIdWithTag($open_chat_id);
-            if (!$oc)
+            if (!$oc) {
+                if (isset($isAdminPage) || !$ocRepo->isWithinIdRange($open_chat_id)) {
+                    return false;
+                }
                 return $this->deletedResponse($recommendGenarator, $open_chat_id, $topPageDto);
+            }
 
             $recommend = $recommendGenarator->getRecommend($oc['tag1'], $oc['tag2'], $oc['tag3'], $oc['category']);
         } else {
             $oc = $ocRepo->getOpenChatById($open_chat_id);
-            if (!$oc)
-                return false;
+            if (!$oc) {
+                if (!$ocRepo->isWithinIdRange($open_chat_id)) {
+                    return false;
+                }
+                return $this->deletedResponse($recommendGenarator, $open_chat_id, $topPageDto);
+            }
 
             /** @var RecommendRankingRepository $recommendRankingRepository */
             $recommendRankingRepository = app(RecommendRankingRepository::class);
@@ -187,16 +195,43 @@ class OpenChatPageController
         return $officialPageList->getListDto($emblem);
     }
 
+    /**
+     * 過去に発番されていた範囲の id への !$oc アクセス時に呼ばれる削除済みレスポンス。
+     *
+     * - HTTP 410 Gone を返す (Google の再クロールキューから速やかに外す目的;
+     *   元の 404 だと数ヶ月〜年単位で再クロールされ続ける)
+     * - JP & recommend タグあり: errors/oc_error.php (リッチ UI: 「削除されました」+ recommend)
+     * - JP & タグなし / TW / TH: errors/error.php (汎用、TW/TH は翻訳済み)
+     *   ※ oc_error.php は本文が JP ハードコードのため他言語では使えない
+     *
+     * 範囲外 (=過去にも一度も発番されていない適当な id) の場合はこの関数は呼ばれず、
+     * 呼び出し側で return false → framework デフォルト 404 が走る。
+     */
     private function deletedResponse(
         RecommendGenarator $recommendGenarator,
         int $open_chat_id,
         StaticTopPageDto $topPageDto
     ) {
+        http_response_code(410);
+
+        if (MimimalCmsConfig::$urlRoot !== '') {
+            return view('errors/error', [
+                'httpCode' => 410,
+                'httpStatusMessage' => 'Gone',
+                'detailsMessage' => '',
+            ]);
+        }
+
         /** @var RecommendRankingRepository $repo */
         $repo = app(RecommendRankingRepository::class);
         $tag = $repo->getRecommendTag($open_chat_id);
-        if (!$tag)
-            return false;
+        if (!$tag) {
+            return view('errors/error', [
+                'httpCode' => 410,
+                'httpStatusMessage' => 'Gone',
+                'detailsMessage' => '',
+            ]);
+        }
 
         $_meta = meta()->setTitle("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
             ->setDescription("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
@@ -206,7 +241,6 @@ class OpenChatPageController
         [$tag2, $tag3] = $repo->getTags($open_chat_id);
         $recommend = $recommendGenarator->getRecommend($tag, $tag2 ?: null, $tag3 ?: null, null);
 
-        http_response_code(404);
         return view('errors/oc_error', compact('_meta', '_css', 'recommend', 'open_chat_id', 'topPageDto'));
     }
 

--- a/app/Models/Repositories/OpenChatPageRepository.php
+++ b/app/Models/Repositories/OpenChatPageRepository.php
@@ -95,6 +95,12 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
         return !!DB::fetchColumn($query, ['id' => $id]);
     }
 
+    public function isWithinIdRange(int $id): bool
+    {
+        $max = (int) DB::fetchColumn("SELECT MAX(id) FROM open_chat");
+        return $id <= $max;
+    }
+
     public function getOpenChatNamesByIds(array $ids): array
     {
         if (empty($ids)) {

--- a/app/Models/Repositories/OpenChatPageRepositoryInterface.php
+++ b/app/Models/Repositories/OpenChatPageRepositoryInterface.php
@@ -12,6 +12,12 @@ interface OpenChatPageRepositoryInterface
 
     public function isExistsOpenChat(int $id): bool;
 
+    /**
+     * 指定した id が「過去に発番されていてもおかしくない範囲」内か。
+     * MAX(open_chat.id) 以下なら true (= 過去存在していた / 現在削除済みの可能性あり)。
+     */
+    public function isWithinIdRange(int $id): bool;
+
     /** @param int[] $ids
      *  @return array<int, string> [id => name] */
     public function getOpenChatNamesByIds(array $ids): array;

--- a/app/Views/errors/error.php
+++ b/app/Views/errors/error.php
@@ -252,9 +252,14 @@ if (class_exists($config) && isset($config::$urlRoot)) {
 }
 
 
-$_meta = meta()->setTitle("{$httpCode} {$httpStatusMessage}")
-    ->setDescription($message)
-    ->setOgpDescription($message);
+// /oc/* の 404 / 410 はユーザ向けにエラーコードを出さず削除済みメッセージで統一
+$isOcDeletedPage = ($httpCode == 404 || $httpCode == 410) && strpos(path(), 'oc/');
+$titleText = $isOcDeletedPage ? $message2 : "{$httpCode} {$httpStatusMessage}";
+$descText = $isOcDeletedPage ? $message2 : $message;
+
+$_meta = meta()->setTitle($titleText)
+    ->setDescription($descText)
+    ->setOgpDescription($descText);
 
 $_css = ['room_list', 'site_header', 'site_footer'];
 
@@ -305,7 +310,7 @@ try {
             <?php viewComponent('site_header') ?>
         </div>
         <header style="padding: 0;">
-            <?php if ($httpCode != 404 || !strpos(path(), 'oc/')) : ?>
+            <?php if (($httpCode != 404 && $httpCode != 410) || !strpos(path(), 'oc/')) : ?>
                 <h1><?php echo $httpCode ?? '' ?></h1>
                 <h2><?php echo $httpStatusMessage ?? '' ?></h2>
                 <br>
@@ -354,7 +359,7 @@ try {
             <p></p>
         <?php endif ?>
     </main>
-    <?php if ($httpCode == 404) : ?>
+    <?php if ($httpCode == 404 || $httpCode == 410) : ?>
         <?php /** @var NotFoundPageController $c */
         try {
             $c = app(NotFoundPageController::class);

--- a/app/Views/errors/error.php
+++ b/app/Views/errors/error.php
@@ -252,8 +252,9 @@ if (class_exists($config) && isset($config::$urlRoot)) {
 }
 
 
-// /oc/* の 404 / 410 はユーザ向けにエラーコードを出さず削除済みメッセージで統一
-$isOcDeletedPage = ($httpCode == 404 || $httpCode == 410) && strpos(path(), 'oc/');
+// /oc/* の 410 (削除済み確定) のみエラーコードを出さず削除済みメッセージに切り替え。
+// 404 (範囲外 / 未登録 id) は通常の "404 Not Found" + 汎用メッセージで返す。
+$isOcDeletedPage = $httpCode == 410 && strpos(path(), 'oc/');
 $titleText = $isOcDeletedPage ? $message2 : "{$httpCode} {$httpStatusMessage}";
 $descText = $isOcDeletedPage ? $message2 : $message;
 
@@ -310,7 +311,7 @@ try {
             <?php viewComponent('site_header') ?>
         </div>
         <header style="padding: 0;">
-            <?php if (($httpCode != 404 && $httpCode != 410) || !strpos(path(), 'oc/')) : ?>
+            <?php if ($httpCode != 410 || !strpos(path(), 'oc/')) : ?>
                 <h1><?php echo $httpCode ?? '' ?></h1>
                 <h2><?php echo $httpStatusMessage ?? '' ?></h2>
                 <br>


### PR DESCRIPTION
詳細は STG にマージ済みの以下 PR を参照:
- #254: fix: X 投稿の OGP 画像取得をリトライ付きに変更
- #256: fix: 削除済みオプチャ (410) と未存在オプチャ (404) のエラーページ振り分け修正