### PR TITLE
[STG] fix: 410 ページ UI を oc_error.php に集約 + 404 と分離

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -214,32 +214,28 @@ class OpenChatPageController
     ) {
         http_response_code(410);
 
+        // TW/TH: oc_error.php は JP 本文ハードコードのため framework error.php へ
         if (MimimalCmsConfig::$urlRoot !== '') {
-            return view('errors/error', [
-                'httpCode' => 410,
-                'httpStatusMessage' => 'Gone',
-                'detailsMessage' => '',
-            ]);
+            return view('errors/error', ['httpCode' => 410]);
         }
 
         /** @var RecommendRankingRepository $repo */
         $repo = app(RecommendRankingRepository::class);
         $tag = $repo->getRecommendTag($open_chat_id);
-        if (!$tag) {
-            return view('errors/error', [
-                'httpCode' => 410,
-                'httpStatusMessage' => 'Gone',
-                'detailsMessage' => '',
-            ]);
-        }
 
-        $_meta = meta()->setTitle("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
-            ->setDescription("「{$tag}」タグ ID:{$open_chat_id} （オプチャグラフから削除済み）")
-            ->setOgpDescription("「{$tag}」タグのオープンチャット ID:{$open_chat_id} （オプチャグラフから削除済み）");
+        $titlePrefix = $tag
+            ? "「{$tag}」タグ ID:{$open_chat_id}"
+            : "ID:{$open_chat_id}";
+        $_meta = meta()->setTitle("{$titlePrefix} （オプチャグラフから削除済み）")
+            ->setDescription("{$titlePrefix} （オプチャグラフから削除済み）")
+            ->setOgpDescription(($tag ? "「{$tag}」タグのオープンチャット" : 'オープンチャット') . " ID:{$open_chat_id} （オプチャグラフから削除済み）");
         $_css = ['room_list', 'site_header', 'site_footer', 'recommend_list'];
 
-        [$tag2, $tag3] = $repo->getTags($open_chat_id);
-        $recommend = $recommendGenarator->getRecommend($tag, $tag2 ?: null, $tag3 ?: null, null);
+        $recommend = [];
+        if ($tag) {
+            [$tag2, $tag3] = $repo->getTags($open_chat_id);
+            $recommend = $recommendGenarator->getRecommend($tag, $tag2 ?: null, $tag3 ?: null, null);
+        }
 
         return view('errors/oc_error', compact('_meta', '_css', 'recommend', 'open_chat_id', 'topPageDto'));
     }

--- a/app/Views/errors/error.php
+++ b/app/Views/errors/error.php
@@ -252,9 +252,14 @@ if (class_exists($config) && isset($config::$urlRoot)) {
 }
 
 
-$_meta = meta()->setTitle("{$httpCode} {$httpStatusMessage}")
-    ->setDescription($message)
-    ->setOgpDescription($message);
+// /oc/* の 404 / 410 はユーザ向けにエラーコードを出さず削除済みメッセージで統一
+$isOcDeletedPage = ($httpCode == 404 || $httpCode == 410) && strpos(path(), 'oc/');
+$titleText = $isOcDeletedPage ? $message2 : "{$httpCode} {$httpStatusMessage}";
+$descText = $isOcDeletedPage ? $message2 : $message;
+
+$_meta = meta()->setTitle($titleText)
+    ->setDescription($descText)
+    ->setOgpDescription($descText);
 
 $_css = ['room_list', 'site_header', 'site_footer'];
 
@@ -305,7 +310,7 @@ try {
             <?php viewComponent('site_header') ?>
         </div>
         <header style="padding: 0;">
-            <?php if ($httpCode != 404 || !strpos(path(), 'oc/')) : ?>
+            <?php if (($httpCode != 404 && $httpCode != 410) || !strpos(path(), 'oc/')) : ?>
                 <h1><?php echo $httpCode ?? '' ?></h1>
                 <h2><?php echo $httpStatusMessage ?? '' ?></h2>
                 <br>
@@ -354,7 +359,7 @@ try {
             <p></p>
         <?php endif ?>
     </main>
-    <?php if ($httpCode == 404) : ?>
+    <?php if ($httpCode == 404 || $httpCode == 410) : ?>
         <?php /** @var NotFoundPageController $c */
         try {
             $c = app(NotFoundPageController::class);

--- a/app/Views/errors/error.php
+++ b/app/Views/errors/error.php
@@ -252,8 +252,9 @@ if (class_exists($config) && isset($config::$urlRoot)) {
 }
 
 
-// /oc/* の 404 / 410 はユーザ向けにエラーコードを出さず削除済みメッセージで統一
-$isOcDeletedPage = ($httpCode == 404 || $httpCode == 410) && strpos(path(), 'oc/');
+// /oc/* の 410 (削除済み確定) のみエラーコードを出さず削除済みメッセージに切り替え。
+// 404 (範囲外 / 未登録 id) は通常の "404 Not Found" + 汎用メッセージで返す。
+$isOcDeletedPage = $httpCode == 410 && strpos(path(), 'oc/');
 $titleText = $isOcDeletedPage ? $message2 : "{$httpCode} {$httpStatusMessage}";
 $descText = $isOcDeletedPage ? $message2 : $message;
 
@@ -310,7 +311,7 @@ try {
             <?php viewComponent('site_header') ?>
         </div>
         <header style="padding: 0;">
-            <?php if (($httpCode != 404 && $httpCode != 410) || !strpos(path(), 'oc/')) : ?>
+            <?php if ($httpCode != 410 || !strpos(path(), 'oc/')) : ?>
                 <h1><?php echo $httpCode ?? '' ?></h1>
                 <h2><?php echo $httpStatusMessage ?? '' ?></h2>
                 <br>


### PR DESCRIPTION
## 目的
Google インデックスから削除済みオプチャを速く除外させる施策 (#251 で 410 化済) の続編。本 PR は **410 と 404 のページ表示が両方とも「削除されました」になっていてユーザにも検索エンジンにも誤解を与えていた問題** を解消する。

## 何をしたか

「削除済みオプチャ (HTTP 410)」と「そもそも存在しない id (HTTP 404)」で表示するエラーページを別物に修正。未発番 id にアクセスしたユーザに対しても「削除済み」と誤って伝えていたのを通常の "404 Not Found" に戻す。

加えて、JP の 410 ページで recommend タグが取れないケースが `errors/error.php` 経由になり UI が崩れていたのも修正 (`oc_error.php` で recommend 空配列を許容)。

## 修正後の振り分け

| 状況 | テンプレート | 表示メッセージ |
|---|---|---|
| JP 410 (削除済み) | `oc_error.php` | 「このオープンチャットはオプチャグラフから削除されました」 |
| TW/TH 410 (削除済み) | `error.php` | 「此聊天室未注册或已删除」/「ห้องสนทนานี้ไม่ได้ลงทะเบียนหรือถูกลบ」 |
| 全言語 404 (未存在) | `error.php` | 「404 Not Found」+「お探しのページは...」(翻訳済み) |

`NotFoundPageController::index()` のおすすめページ表示も 410 で有効化。

## 動作確認 (local docker)

| パス | 結果 |
|---|---|
| `/oc/298` (JP 削除済み・タグあり) | 410 + oc_error |
| `/oc/100` (JP 削除済み・タグなし) | 410 + oc_error (recommend 空) |
| `/oc/137722222` (JP 未存在) | 404 + error.php 通常 |
| `/tw/oc/99999999` (TW 未存在) | 404 + error.php 通常 (TW 翻訳) |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)