### PR TITLE
[STG] chore: マージ通知ツイートの余白を削って情報密度を上げる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,17 +328,21 @@ jobs:
                 }
               }
 
-              // PR 本文末尾の "🤖 Generated with..." / "Co-Authored-By:" は除外。
+              // PR 本文末尾の "🤖 Generated with..." / "Co-Authored-By:" は除外し、
+              // markdown ヘッダ (#, ##, ### …) の直下の空行のみ詰める。
+              // 段落間の空行は読みやすさのため残す。
               const prBody = (process.env.PR_BODY || '')
                 .replace(/\n*🤖[\s\S]*$/, '')
                 .replace(/\n*Co-Authored-By:[\s\S]*$/, '')
+                .replace(/^(#{1,6} .*)\n\n+/gm, '$1\n')
                 .trim();
 
               // X Premium tweet 上限は 25,000 文字。それを超える場合だけ事前に切り詰める。
               const MAX_TWEET = 25000;
-              const head = '🚀 ' + tweetMsg + '#オプチャグラフ\n\n' +
-                '#' + prNumber + ': ' + prTitle + '\n' +
-                'By ' + prAuthor;
+              // head: 「🚀 メッセージ#オプチャグラフ\n#番号: タイトル」の 2 行のみ。
+              // (アバター画像から作者は分かるので By {author} は省く)
+              const head = '🚀 ' + tweetMsg + '#オプチャグラフ\n' +
+                '#' + prNumber + ': ' + prTitle;
               const urlSuffix = includeUrls ? '\n\n' + siteUrl + '\n\n' + prUrl : '';
               const separator = '\n---\n';
 


### PR DESCRIPTION
マージ通知の X ポストで、空白行や `By {author}` 行が無駄にツイート枠を消費していたのを整理。アバター画像から作者は判断できるので "By" 行は省略、PR 本文の連続空行も単改行に圧縮、ヘッダーと本文の間の空行も削除。同じ文字数でも見えるコンテンツ量が増える。

## Before
```
🚀 開発環境が更新されました。以下のPRがマージされました。#オプチャグラフ
(blank)
#256: [STG] fix: ...
By mimimiku778
(blank)
---
(blank)
## 目的
(blank)
Google ...
```

## After
```
🚀 開発環境が更新されました。以下のPRがマージされました。#オプチャグラフ
#256: [STG] fix: ...
---
## 目的
Google ...
```