### PR TITLE
[PROD] fix: デフォルトのエラーメッセージとステータスコードを設定

### DIFF
--- a/app/Views/errors/error.php
+++ b/app/Views/errors/error.php
@@ -211,6 +211,10 @@ class ErrorPage
 
 noStore();
 
+$detailsMessage = $detailsMessage ?? '';
+$httpStatusMessage = $httpStatusMessage ?? '';
+$httpCode = $httpCode ?? 506;
+
 try {
     if ($detailsMessage) {
         $m = new ErrorPage;


### PR DESCRIPTION
This pull request makes a small improvement to error handling in `app/Views/errors/error.php` by ensuring that the variables `$detailsMessage`, `$httpStatusMessage`, and `$httpCode` are always initialized with default values if they are not already set. This prevents potential "undefined variable" errors during error page rendering.