### PR TITLE
[STG] feat: 各部屋ページの「更新日」を実際の内容変化に合わせ、Googleの再クロールを促進

### DIFF
--- a/app/Models/Repositories/OcSitemapLastmodRepository.php
+++ b/app/Models/Repositories/OcSitemapLastmodRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Repositories;
+
+use App\Models\Repositories\DB;
+use App\Services\Sitemap\LastmodPolicy;
+
+class OcSitemapLastmodRepository implements OcSitemapLastmodRepositoryInterface
+{
+    public function refreshLastmod(): int
+    {
+        DB::connect();
+
+        // 閾値式は LastmodPolicy::significanceThreshold() と一致させること:
+        //   max(ceil(snapshot * 0.01), 5)  ==  GREATEST(CEILING(snapshot * 0.01), 5)
+        $ratio = LastmodPolicy::RELATIVE_RATIO;
+        $floor = LastmodPolicy::ABSOLUTE_FLOOR;
+
+        $sql =
+            "INSERT INTO oc_sitemap_lastmod (open_chat_id, lastmod, member_snapshot)
+             SELECT o.id, CURRENT_TIMESTAMP, o.member
+               FROM open_chat o
+               LEFT JOIN oc_sitemap_lastmod l ON l.open_chat_id = o.id
+              WHERE l.open_chat_id IS NULL
+                 OR o.updated_at > l.lastmod
+                 OR ABS(o.member - l.member_snapshot)
+                      >= GREATEST(CEILING(l.member_snapshot * {$ratio}), {$floor})
+             ON DUPLICATE KEY UPDATE
+                 lastmod         = CURRENT_TIMESTAMP,
+                 member_snapshot = VALUES(member_snapshot)";
+
+        return DB::execute($sql)->rowCount();
+    }
+}

--- a/app/Models/Repositories/OcSitemapLastmodRepositoryInterface.php
+++ b/app/Models/Repositories/OcSitemapLastmodRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Repositories;
+
+/**
+ * /oc/{id} の sitemap <lastmod> 専用テーブル oc_sitemap_lastmod を管理する Interface。
+ *
+ * open_chat.updated_at はメタ情報 (タイトル/説明/ステータス) 変更時しか動かず、
+ * 人数変化を反映しない。本テーブルは「ページ内容が実際に変わった日」を独立に保持し、
+ * Google に正確な再クロールヒントを与える。
+ */
+interface OcSitemapLastmodRepositoryInterface
+{
+    /**
+     * lastmod を最新化する (日次バッチ想定)。
+     *
+     * 対象 (= ページ内容が significant に変わった room):
+     *  - oc_sitemap_lastmod に未登録
+     *  - open_chat.updated_at がレコードの lastmod より新しい (メタ情報変更)
+     *  - 人数が前回 snapshot から significant に変化 (LastmodPolicy と一致する閾値)
+     *
+     * @return int upsert された行数
+     */
+    public function refreshLastmod(): int;
+}

--- a/app/Models/Repositories/OpenChatListRepository.php
+++ b/app/Models/Repositories/OpenChatListRepository.php
@@ -198,6 +198,14 @@ class OpenChatListRepository implements OpenChatListRepositoryInterface, OpenCha
      */
     public function getOpenChatSiteMapData(): array
     {
-        return DB::fetchAll("SELECT id, updated_at FROM open_chat ORDER BY id ASC");
+        // lastmod は専用テーブル oc_sitemap_lastmod (ページ内容が実際に変わった日) を優先し、
+        // 未登録 room は従来どおり open_chat.updated_at にフォールバック。
+        // 戻り値キーは updated_at のまま (SitemapGenerator 側は無改修)。
+        return DB::fetchAll(
+            "SELECT o.id, COALESCE(l.lastmod, o.updated_at) AS updated_at
+               FROM open_chat o
+               LEFT JOIN oc_sitemap_lastmod l ON l.open_chat_id = o.id
+              ORDER BY o.id ASC"
+        );
     }
 }

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Cron;
 
 use App\Config\AppConfig;
+use App\Models\Repositories\OcSitemapLastmodRepositoryInterface;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
 use App\Services\Cron\Utility\CronUtility;
@@ -30,6 +31,7 @@ class SyncOpenChat
         private OpenChatHourlyInvitationTicketUpdater $invitationTicketUpdater,
         private RankingBanTableUpdater $rankingBanUpdater,
         private SyncOpenChatStateRepositoryInterface $state,
+        private OcSitemapLastmodRepositoryInterface $lastmodRepo,
     ) {
         ini_set('memory_limit', '2G');
     }
@@ -140,6 +142,9 @@ class SyncOpenChat
         $updater->update(fn() => $this->state->setFalse(StateType::isDailyTaskActive));
 
         $this->executeAndCronLog(
+            // 全 member 確定後に sitemap lastmod を最新化。直後 (handle 末尾) の
+            // sitemap->generate() がこの lastmod を読む。
+            [fn() => $this->lastmodRepo->refreshLastmod(), 'sitemap lastmod 更新'],
             [
                 function () {
                     $result = purgeCacheCloudFlare(

--- a/app/Services/Sitemap/LastmodPolicy.php
+++ b/app/Services/Sitemap/LastmodPolicy.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Sitemap;
+
+/**
+ * sitemap の <lastmod> を「ページ内容が significant に変わった日」に保つためのポリシー。
+ *
+ * /oc/{id} ページの主役コンテンツは現在人数・推移・narrative であり、これらは人数で変わる。
+ * しかし trivial な人数の揺れ (±数人) で lastmod を毎回 bump すると、Google は lastmod 全体を
+ * 信用しなくなり無視する。そこで「前回 bump 時の人数からの累積変化」が一定の閾値を超えたときだけ
+ * significant とみなす。
+ *
+ * 閾値 = max( 前回人数の 1%, 5 人 )
+ *   - 相対 1%: 大規模ルームの軽微な揺れを無視 (例 9000 人 → 90 人未満は無視)
+ *   - 絶対下限 5 人: 小規模ルームのノイズを無視 (例 50 人 → ±4 は無視, +5 で bump)
+ *
+ * NOTE: この閾値式は OcSitemapLastmodRepository の set-based SQL
+ *       `GREATEST(CEILING(member_snapshot * 0.01), 5)` と必ず一致させること。
+ *       本クラスが仕様の source of truth。
+ */
+final class LastmodPolicy
+{
+    /** 相対閾値 (前回人数に対する割合) */
+    public const RELATIVE_RATIO = 0.01;
+
+    /** 絶対下限 (人) */
+    public const ABSOLUTE_FLOOR = 5;
+
+    /**
+     * significant とみなす最小変化量 (人)。
+     */
+    public static function significanceThreshold(int $snapshot): int
+    {
+        return max((int)ceil($snapshot * self::RELATIVE_RATIO), self::ABSOLUTE_FLOOR);
+    }
+
+    /**
+     * 前回 bump 時の人数 $snapshot から現在 $current への変化が significant か。
+     * 増加・減少どちらも内容変化として扱う (ABS)。
+     */
+    public static function isSignificantMemberChange(int $snapshot, int $current): bool
+    {
+        return abs($current - $snapshot) >= self::significanceThreshold($snapshot);
+    }
+}

--- a/app/Services/Sitemap/README.md
+++ b/app/Services/Sitemap/README.md
@@ -1,0 +1,44 @@
+# sitemap の更新日 (lastmod)
+
+各部屋ページ `/oc/{id}` を sitemap でGoogleに伝えるとき、その「最終更新日(lastmod)」を
+**ページ内容が実際に変わった日**にするための仕組み。
+
+元々は `open_chat.updated_at` を使っていたが、これはタイトル・説明・ステータスといった
+メタ情報を変えたときしか動かない。ページの主役は現在人数・推移・分析(narrative)で、これらは
+人数で変わる。そのため人数が伸びている部屋ほど更新日が古いまま放置され、Googleに
+「変わっていないページ」と誤って伝わり、再クロールが後回しになっていた。
+
+## 更新日が動く条件
+
+専用テーブル `oc_sitemap_lastmod` に「内容が変わった日」を独立して持つ。次のいずれかで更新:
+
+- メタ情報が変わった (`open_chat.updated_at` がレコードより新しい)
+- 人数が**意味のある幅**で変わった = 前回時点の人数の 1%、ただし最低 5 人
+
+数人程度の揺れは無視する。毎回ちょっとの増減で更新日を動かすと、Googleは更新日全体を
+信用しなくなり逆効果になるため。閾値は `max(ceil(人数 × 1%), 5)`。
+
+## 構成
+
+- 閾値の仕様(唯一の正): [`LastmodPolicy`](LastmodPolicy.php)
+- 日次の一括更新SQL: [`OcSitemapLastmodRepository`](../../Models/Repositories/OcSitemapLastmodRepository.php)
+  ([`SyncOpenChat::dailyTask`](../Cron/SyncOpenChat.php) から毎日実行 → 直後の sitemap 生成が読む)
+- sitemap 読み取り: `COALESCE(専用テーブル, 従来のupdated_at)` で未登録の部屋は従来どおり
+  ([`OpenChatListRepository::getOpenChatSiteMapData`](../../Models/Repositories/OpenChatListRepository.php))
+
+閾値の式は `LastmodPolicy` と更新SQLの両方に現れるので、変えるときは両方を一致させること
+(`LastmodPolicy` が仕様の正)。詳細は各ファイルのコメント参照。
+
+## 初期化 (一度きり・手動)
+
+テーブルはデプロイ時に schema-sync が自動で作る([../Schema/README.md](../Schema/README.md))が、
+**初期化だけは手動**で locale ごとに1回実行する:
+
+```bash
+php batch/exec/seed_sitemap_lastmod.php       # JP
+php batch/exec/seed_sitemap_lastmod.php /tw   # TW
+php batch/exec/seed_sitemap_lastmod.php /th   # TH
+```
+
+JP は分析(narrative)を全部屋に載せた日を下限にして更新日を底上げし、再クロールの波を起こす。
+TW/TH は底上げせず最小日時を下限にするだけ。以後の維持は日次更新が担う。

--- a/app/Services/Sitemap/test/LastmodPolicyTest.php
+++ b/app/Services/Sitemap/test/LastmodPolicyTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * LastmodPolicy のテスト
+ *
+ * 実行コマンド:
+ * docker compose exec app vendor/bin/phpunit app/Services/Sitemap/test/LastmodPolicyTest.php
+ *
+ * 内容: sitemap lastmod を bump する人数変化の significant 判定。
+ * 閾値 = max(ceil(snapshot * 1%), 5)。増減どちらも ABS で判定。
+ * この境界値は OcSitemapLastmodRepository の SQL と一致していなければならない。
+ */
+
+declare(strict_types=1);
+
+use App\Services\Sitemap\LastmodPolicy;
+use PHPUnit\Framework\TestCase;
+
+class LastmodPolicyTest extends TestCase
+{
+    public function test_threshold_uses_absolute_floor_for_small_rooms(): void
+    {
+        // 50人: ceil(0.5)=1 → max(1,5)=5
+        $this->assertSame(5, LastmodPolicy::significanceThreshold(50));
+        // 0人: max(0,5)=5
+        $this->assertSame(5, LastmodPolicy::significanceThreshold(0));
+        // 300人: ceil(3)=3 → max(3,5)=5
+        $this->assertSame(5, LastmodPolicy::significanceThreshold(300));
+    }
+
+    public function test_threshold_uses_relative_ratio_for_large_rooms(): void
+    {
+        // 600人: ceil(6)=6 → max(6,5)=6
+        $this->assertSame(6, LastmodPolicy::significanceThreshold(600));
+        // 9000人: ceil(90)=90 → 90
+        $this->assertSame(90, LastmodPolicy::significanceThreshold(9000));
+        // 9050人: ceil(90.5)=91
+        $this->assertSame(91, LastmodPolicy::significanceThreshold(9050));
+    }
+
+    public function test_small_room_boundary(): void
+    {
+        // 閾値 5
+        $this->assertFalse(LastmodPolicy::isSignificantMemberChange(50, 54)); // +4
+        $this->assertTrue(LastmodPolicy::isSignificantMemberChange(50, 55));  // +5
+        $this->assertTrue(LastmodPolicy::isSignificantMemberChange(50, 45));  // -5
+        $this->assertFalse(LastmodPolicy::isSignificantMemberChange(50, 46)); // -4
+    }
+
+    public function test_large_room_boundary(): void
+    {
+        // 9000人 → 閾値 90
+        $this->assertFalse(LastmodPolicy::isSignificantMemberChange(9000, 9050)); // +50
+        $this->assertTrue(LastmodPolicy::isSignificantMemberChange(9000, 9090));  // +90
+        $this->assertTrue(LastmodPolicy::isSignificantMemberChange(9000, 8910));  // -90
+    }
+
+    public function test_zero_snapshot_room(): void
+    {
+        // 0人 → 閾値 5
+        $this->assertFalse(LastmodPolicy::isSignificantMemberChange(0, 4));
+        $this->assertTrue(LastmodPolicy::isSignificantMemberChange(0, 5));
+    }
+
+    public function test_no_change_is_not_significant(): void
+    {
+        $this->assertFalse(LastmodPolicy::isSignificantMemberChange(1234, 1234));
+    }
+}

--- a/app/Services/Sitemap/test/OcSitemapLastmodRepositoryTest.php
+++ b/app/Services/Sitemap/test/OcSitemapLastmodRepositoryTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * OcSitemapLastmodRepository / sitemap 読み取りクエリの結合テスト
+ * (ローカル MariaDB に使い捨て DB を作り、実 SQL を検証する)
+ *
+ * 実行コマンド:
+ * docker compose exec app vendor/bin/phpunit app/Services/Sitemap/test/OcSitemapLastmodRepositoryTest.php
+ *
+ * setUp で `ocgraph_lastmod_test_<random>` を CREATE DATABASE し、最小の open_chat と
+ * oc_sitemap_lastmod を作る。tearDown で DROP。実データの DB には一切触れない。
+ * DB::connect() は既存接続を再利用するため、使い捨て DB に接続した状態で
+ * リポジトリの内部 DB::connect() も同じ接続を使う。
+ *
+ * 前提: 接続ユーザに CREATE/DROP DATABASE 権限があること (ローカルは root)。
+ */
+
+declare(strict_types=1);
+
+use App\Models\Repositories\DB;
+use App\Models\Repositories\OcSitemapLastmodRepository;
+use App\Models\Repositories\OpenChatListRepository;
+use App\Services\Sitemap\LastmodPolicy;
+use PHPUnit\Framework\TestCase;
+
+class OcSitemapLastmodRepositoryTest extends TestCase
+{
+    private string $testDb;
+    private OcSitemapLastmodRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->testDb = 'ocgraph_lastmod_test_' . bin2hex(random_bytes(6));
+        $this->repo = new OcSitemapLastmodRepository();
+
+        DB::$pdo = null;
+        DB::connect(['dbName' => 'information_schema']);
+        DB::execute("CREATE DATABASE `{$this->testDb}` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+
+        // 以降のクエリは全てこの使い捨て DB に対して実行する
+        DB::$pdo = null;
+        DB::connect(['dbName' => $this->testDb]);
+
+        // refreshLastmod / sitemap クエリが参照する列だけを持つ最小の open_chat
+        DB::execute(
+            "CREATE TABLE `open_chat` (
+                `id` int(11) NOT NULL AUTO_INCREMENT,
+                `member` int(11) NOT NULL,
+                `updated_at` datetime NOT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+        );
+        DB::execute(
+            "CREATE TABLE `oc_sitemap_lastmod` (
+                `open_chat_id` int(11) NOT NULL,
+                `lastmod` datetime NOT NULL,
+                `member_snapshot` int(11) NOT NULL,
+                PRIMARY KEY (`open_chat_id`),
+                KEY `lastmod` (`lastmod`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        DB::$pdo = null;
+        DB::connect(['dbName' => 'information_schema']);
+        DB::execute("DROP DATABASE IF EXISTS `{$this->testDb}`");
+        DB::$pdo = null;
+    }
+
+    private function lastmodOf(int $id): string
+    {
+        return (string) DB::execute(
+            "SELECT lastmod FROM oc_sitemap_lastmod WHERE open_chat_id = ?",
+            [$id],
+        )->fetchColumn();
+    }
+
+    /**
+     * 部屋を1件だけ隔離して用意し「現在人数 $current・前回 snapshot $snapshot・
+     * lastmod は過去の固定値」を作って refresh を1回流し、lastmod が動いた(=bumpされた)か返す。
+     * updated_at は lastmod より古くして「メタ変更なし＝人数差分だけで判定」させる。
+     */
+    private function memberChangeBumps(int $snapshot, int $current): bool
+    {
+        $sentinel = '2000-01-01 00:00:00';
+        DB::execute("DELETE FROM open_chat");
+        DB::execute("DELETE FROM oc_sitemap_lastmod");
+        DB::execute("INSERT INTO open_chat (id, member, updated_at) VALUES (1, ?, '1999-01-01 00:00:00')", [$current]);
+        DB::execute("INSERT INTO oc_sitemap_lastmod (open_chat_id, lastmod, member_snapshot) VALUES (1, ?, ?)", [$sentinel, $snapshot]);
+
+        $this->repo->refreshLastmod();
+
+        return $this->lastmodOf(1) !== $sentinel;
+    }
+
+    public function test_first_run_populates_all_rooms_with_member_snapshot(): void
+    {
+        DB::execute("INSERT INTO open_chat (id, member, updated_at) VALUES (1, 100, '2026-01-01 00:00:00'), (2, 200, '2026-02-02 00:00:00')");
+
+        $this->repo->refreshLastmod();
+
+        $this->assertSame(2, (int) DB::execute("SELECT COUNT(*) FROM oc_sitemap_lastmod")->fetchColumn());
+        $this->assertSame(100, (int) DB::execute("SELECT member_snapshot FROM oc_sitemap_lastmod WHERE open_chat_id = 1")->fetchColumn());
+
+        // 直後の再実行は何も変わらない (冪等)
+        $this->assertSame(0, $this->repo->refreshLastmod());
+    }
+
+    /**
+     * 人数差分の significant 判定が LastmodPolicy と完全に一致すること。
+     * 閾値式が SQL と PHP の2箇所に存在するため、両者の境界一致をこのテストで担保する。
+     */
+    public function test_member_change_threshold_matches_LastmodPolicy(): void
+    {
+        $cases = [
+            [50, 54],    // +4  小部屋: 下限5未満 → bumpしない
+            [50, 55],    // +5  ちょうど下限 → bump
+            [50, 45],    // -5  減少も ABS で bump
+            [50, 46],    // -4  → bumpしない
+            [9000, 9089], // +89 大部屋: 1%(90)未満 → bumpしない
+            [9000, 9090], // +90 ちょうど1% → bump
+            [0, 4],      // snapshot0: 下限5 → bumpしない
+            [0, 5],      // → bump
+            [1234, 1234], // 無変化 → bumpしない
+        ];
+
+        foreach ($cases as [$snapshot, $current]) {
+            $bumped = $this->memberChangeBumps($snapshot, $current);
+            $expected = LastmodPolicy::isSignificantMemberChange($snapshot, $current);
+            $this->assertSame(
+                $expected,
+                $bumped,
+                "SQL の判定が LastmodPolicy と不一致: snapshot={$snapshot} current={$current}",
+            );
+        }
+    }
+
+    public function test_significant_change_updates_snapshot_to_current(): void
+    {
+        DB::execute("INSERT INTO open_chat (id, member, updated_at) VALUES (1, 5000, '1999-01-01 00:00:00')");
+        DB::execute("INSERT INTO oc_sitemap_lastmod (open_chat_id, lastmod, member_snapshot) VALUES (1, '2000-01-01 00:00:00', 100)");
+
+        // 100 → 5000 は significant。bump 後は snapshot が現在人数に是正される
+        $this->repo->refreshLastmod();
+
+        $this->assertNotSame('2000-01-01 00:00:00', $this->lastmodOf(1));
+        $this->assertSame(5000, (int) DB::execute("SELECT member_snapshot FROM oc_sitemap_lastmod WHERE open_chat_id = 1")->fetchColumn());
+    }
+
+    /**
+     * 人数が1人も動かなくても、updated_at(メタ情報)が lastmod より新しければ bump される。
+     * = COALESCE が「古い人数変動の時刻」に固定されることはない。
+     */
+    public function test_metadata_change_bumps_lastmod_even_with_no_member_change(): void
+    {
+        // 人数は 100 で固定 (snapshot も 100)。updated_at だけ lastmod より新しい。
+        DB::execute("INSERT INTO open_chat (id, member, updated_at) VALUES (1, 100, '2026-05-10 00:00:00')");
+        DB::execute("INSERT INTO oc_sitemap_lastmod (open_chat_id, lastmod, member_snapshot) VALUES (1, '2026-05-01 00:00:00', 100)");
+
+        $this->repo->refreshLastmod();
+
+        $after = $this->lastmodOf(1);
+        $this->assertNotSame('2026-05-01 00:00:00', $after, '人数無変化でもメタ変更で lastmod が動くべき');
+        // CURRENT_TIMESTAMP (今日) まで進む = 古い時刻に張り付かない
+        $this->assertGreaterThan('2026-05-10 00:00:00', $after);
+    }
+
+    /**
+     * sitemap 読み取り (getOpenChatSiteMapData) は専用テーブルの lastmod を優先し、
+     * 未登録の部屋は従来の open_chat.updated_at にフォールバックする。
+     */
+    public function test_sitemap_query_prefers_tracked_lastmod_and_falls_back(): void
+    {
+        // id=1: 専用テーブルに登録あり → その lastmod を返す
+        DB::execute("INSERT INTO open_chat (id, member, updated_at) VALUES (1, 100, '2020-01-01 00:00:00')");
+        DB::execute("INSERT INTO oc_sitemap_lastmod (open_chat_id, lastmod, member_snapshot) VALUES (1, '2026-05-24 19:00:00', 100)");
+        // id=2: 未登録 → updated_at にフォールバック
+        DB::execute("INSERT INTO open_chat (id, member, updated_at) VALUES (2, 50, '2026-03-03 12:00:00')");
+
+        $rows = (new OpenChatListRepository())->getOpenChatSiteMapData();
+        $byId = array_column($rows, 'updated_at', 'id');
+
+        $this->assertSame('2026-05-24 19:00:00', $byId[1]);
+        $this->assertSame('2026-03-03 12:00:00', $byId[2]);
+    }
+}

--- a/batch/exec/seed_sitemap_lastmod.php
+++ b/batch/exec/seed_sitemap_lastmod.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * oc_sitemap_lastmod を一度きり seed するスクリプト。
+ *
+ * 使い方 (locale ごとに 1 回ずつ):
+ *   php batch/exec/seed_sitemap_lastmod.php        # JP
+ *   php batch/exec/seed_sitemap_lastmod.php /tw    # TW
+ *   php batch/exec/seed_sitemap_lastmod.php /th    # TH
+ *
+ * JP: narrative を全 /oc/{id} に載せた 2026-05-24 を floor にして lastmod を底上げし、
+ *     Google の再クロールの波を起こす (= GREATEST(updated_at, deploy))。
+ * TW/TH: narrative 未提供のため強制 bump しない。MINIMUM_LASTMOD を floor にするだけ。
+ *
+ * 以後の維持は SyncOpenChat::dailyTask() の refreshLastmod() が担う。
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Models\Repositories\DB;
+use App\Services\SitemapGenerator;
+use Shared\MimimalCmsConfig;
+
+// narrative (#259) を全 JP /oc/{id} へデプロイした日時
+const NARRATIVE_DEPLOY_AT = '2026-05-24 19:00:00';
+
+set_time_limit(3600);
+
+if (isset($argv[1]) && $argv[1]) {
+    MimimalCmsConfig::$urlRoot = $argv[1];
+}
+
+// JP は narrative デプロイ日を floor、TW/TH は従来の最小日時を floor
+$floor = MimimalCmsConfig::$urlRoot === ''
+    ? NARRATIVE_DEPLOY_AT
+    : SitemapGenerator::MINIMUM_LASTMOD;
+
+DB::connect();
+
+$sql =
+    "INSERT INTO oc_sitemap_lastmod (open_chat_id, lastmod, member_snapshot)
+     SELECT id, GREATEST(updated_at, :floor), member
+       FROM open_chat
+     ON DUPLICATE KEY UPDATE
+         lastmod         = VALUES(lastmod),
+         member_snapshot = VALUES(member_snapshot)";
+
+$rows = DB::execute($sql, ['floor' => $floor])->rowCount();
+
+printf(
+    "seeded oc_sitemap_lastmod for locale='%s' floor='%s' (affected=%d)\n",
+    MimimalCmsConfig::$urlRoot === '' ? 'ja' : ltrim(MimimalCmsConfig::$urlRoot, '/'),
+    $floor,
+    $rows
+);

--- a/setup/schema/mysql/ocgraph_ocreview_schema.sql
+++ b/setup/schema/mysql/ocgraph_ocreview_schema.sql
@@ -75,6 +75,14 @@ CREATE TABLE `open_chat` (
   KEY `member` (`member`),
   KEY `updated_at` (`updated_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+DROP TABLE IF EXISTS `oc_sitemap_lastmod`;
+CREATE TABLE `oc_sitemap_lastmod` (
+  `open_chat_id` int(11) NOT NULL,
+  `lastmod` datetime NOT NULL,
+  `member_snapshot` int(11) NOT NULL,
+  PRIMARY KEY (`open_chat_id`),
+  KEY `lastmod` (`lastmod`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 DROP TABLE IF EXISTS `open_chat_deleted`;
 CREATE TABLE `open_chat_deleted` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/setup/schema/mysql/ocgraph_ocreviewth_schema.sql
+++ b/setup/schema/mysql/ocgraph_ocreviewth_schema.sql
@@ -75,6 +75,14 @@ CREATE TABLE `open_chat` (
   KEY `member` (`member`),
   KEY `updated_at` (`updated_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+DROP TABLE IF EXISTS `oc_sitemap_lastmod`;
+CREATE TABLE `oc_sitemap_lastmod` (
+  `open_chat_id` int(11) NOT NULL,
+  `lastmod` datetime NOT NULL,
+  `member_snapshot` int(11) NOT NULL,
+  PRIMARY KEY (`open_chat_id`),
+  KEY `lastmod` (`lastmod`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 DROP TABLE IF EXISTS `open_chat_deleted`;
 CREATE TABLE `open_chat_deleted` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/setup/schema/mysql/ocgraph_ocreviewtw_schema.sql
+++ b/setup/schema/mysql/ocgraph_ocreviewtw_schema.sql
@@ -82,6 +82,14 @@ CREATE TABLE `open_chat` (
   KEY `member` (`member`),
   KEY `updated_at` (`updated_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+DROP TABLE IF EXISTS `oc_sitemap_lastmod`;
+CREATE TABLE `oc_sitemap_lastmod` (
+  `open_chat_id` int(11) NOT NULL,
+  `lastmod` datetime NOT NULL,
+  `member_snapshot` int(11) NOT NULL,
+  PRIMARY KEY (`open_chat_id`),
+  KEY `lastmod` (`lastmod`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 DROP TABLE IF EXISTS `open_chat_deleted`;
 CREATE TABLE `open_chat_deleted` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/shared/MimimalCmsConfig.php
+++ b/shared/MimimalCmsConfig.php
@@ -44,6 +44,7 @@ class MimimalCmsConfig
         \App\Models\Repositories\OpenChatRecentListRepositoryInterface::class => \App\Models\Repositories\OpenChatListRepository::class,
         \App\Models\Repositories\OpenChatPageRepositoryInterface::class => \App\Models\Repositories\OpenChatPageRepository::class,
         \App\Models\Repositories\OcNarrativeRepositoryInterface::class => \App\Models\Repositories\OcNarrativeRepository::class,
+        \App\Models\Repositories\OcSitemapLastmodRepositoryInterface::class => \App\Models\Repositories\OcSitemapLastmodRepository::class,
 
         \App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepositoryInterface::class => \App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepository::class,
 


### PR DESCRIPTION
人気が伸びているオープンチャットの部屋ページほど、Google に「更新されていない」と誤って伝わり、検索結果が古いまま再クロールされにくくなっていた。これを是正し、ページの中身が実際に変わった日を正確に伝える。

## 問題

各部屋ページ `/oc/{id}` の主役は「現在の人数・推移・分析(narrative)」で、これは人数が動くたびに変わる。ところが sitemap がGoogleに伝える「最終更新日」は `open_chat.updated_at` を使っており、これはタイトル・説明・ステータスといったメタ情報を変えたときしか動かない。

結果、毎日人数が伸びてページ内容が変わっている部屋でも「更新日」は何ヶ月も前のまま。Google から見ると「変わっていないページ」に見え、再クロールが後回しになって検索結果の鮮度が落ちていた。

## 対処

「ページ内容が実際に変わった日」を専用テーブル `oc_sitemap_lastmod` で独立管理する。

- **更新日 = max(メタ情報の更新日, 人数が意味のある幅で変わった日)**
- 「意味のある幅」= 前回時点の人数の1%、ただし最低5人 ([`LastmodPolicy`](../blob/oc-pdca/feat/sitemap-lastmod-table/app/Services/Sitemap/LastmodPolicy.php))。
  数人程度の揺れは無視する。毎回ちょっとの増減で更新日を動かすと、Google は更新日全体を信用しなくなり逆効果になるため。
- 毎日の更新処理 ([`SyncOpenChat::dailyTask`](../blob/oc-pdca/feat/sitemap-lastmod-table/app/Services/Cron/SyncOpenChat.php)) で全部屋を一括 upsert。直後の sitemap 生成がこの更新日を読む。
- sitemap 読み取りは `COALESCE(専用テーブルの更新日, 従来のupdated_at)` で、未登録の部屋は従来どおりにフォールバック。sitemap 生成側のコードは変更なし。

判定式（人数の閾値）は PHP の `LastmodPolicy` と更新SQLの両方に現れるが、同じ式 `max(ceil(人数 × 1%), 5)` で一致させており、境界値はユニットテストで担保している。

## テーブルの作成と初期化

- テーブル `oc_sitemap_lastmod` は ja/tw/th 各スキーマに追加済み。デプロイ時に schema-sync (#261) が本番へ自動で追加する（追加のみ・既存データは触らない）。
- 初期化は [`batch/exec/seed_sitemap_lastmod.php`](../blob/oc-pdca/feat/sitemap-lastmod-table/batch/exec/seed_sitemap_lastmod.php) を locale ごとに一度だけ手動実行する。
  - JP: 全部屋に分析(narrative)を載せた日 (2026-05-24) を下限にして更新日を底上げし、再クロールの波を意図的に起こす。
  - TW/TH: 分析は未提供のため強制的な底上げはせず、従来の最小日時を下限にするだけ。

## テスト

- `LastmodPolicyTest` 6件 / `SchemaDifferTest` 8件 すべてパス。
- schema-sync の `--dry-run` で、ja/tw/th 3DBに `oc_sitemap_lastmod` が追加対象として正しく検出されること（DB修飾子付き・警告ゼロ）を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
