### PR TITLE
[STG] perf: 広告を遅延読み込みして表示効率を上げ、広告収益を底上げ

### DIFF
--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -74,10 +74,27 @@ class GoogleAdsense
         echo <<<EOT
         <script>
             document.addEventListener('DOMContentLoaded', function() {
-                const num = document.querySelectorAll('ins.manual').length;
-                for (let i = 0; i < num; i++) {
-                    (adsbygoogle = window.adsbygoogle || []).push({});
+                var ads = Array.prototype.slice.call(document.querySelectorAll('ins.manual'));
+                if (!ads.length) return;
+                var push = function() { (adsbygoogle = window.adsbygoogle || []).push({}); };
+
+                // IntersectionObserver 非対応環境は従来どおり一括読み込み（フォールバック）
+                if (!('IntersectionObserver' in window)) {
+                    ads.forEach(push);
+                    return;
                 }
+
+                // 各広告がビューポート手前 600px に入って初めて読み込む。
+                // 下部広告がユーザー到達前に「表示済み」化するのを防ぎ視認率(viewability)を上げる。
+                // push() は DOM 順で最も先頭の未読み込み ins を埋めるため、上→下のスクロールで順に充填される。
+                var io = new IntersectionObserver(function(entries, obs) {
+                    entries.forEach(function(entry) {
+                        if (!entry.isIntersecting) return;
+                        push();
+                        obs.unobserve(entry.target);
+                    });
+                }, { rootMargin: '600px 0px' });
+                ads.forEach(function(ad) { io.observe(ad); });
             });
         </script>
         EOT;


### PR DESCRIPTION
## 問題の概要

ページ下部の広告が「ユーザーに見られないまま読み込み済み」になっており、広告の単価が安く評価されていました。

直近30日の AdSense をフォーマット別に見ると、表示回数の約9割を占める **In-page（手動ディスプレイ）広告の表示RPMは ¥37** にとどまり、Vignette（¥334）や Rewarded（¥737）の **1/10以下**。原因を追うと、下部の広告ユニットほど**視認率（実際に画面に入った割合）が低い**ことが分かりました。

| 広告の位置 | 視認率 | 表示RPM |
|---|---|---|
| オープンチャット詳細ページ最下部 | **11%** | ¥11 |
| 同ページ中部 | 36% | ¥17 |
| おすすめページ区切り（表示回数 約42,000＝最多） | 30% | ¥16 |

### 具体的な問題

[`GoogleAdsense::loadAdsTag()`](app/Views/Classes/Ads/GoogleAdsense.php) が、ページ内の全広告枠（`ins.manual`）を `DOMContentLoaded` の時点で**一括で読み込み**ていました。そのため、ユーザーがスクロールして到達する前に下部の広告まで読み込まれ、「読み込まれたが一度も見られていない広告」が大量に発生。広告の入札は見られた広告（viewable impression）を重視するため、見られない広告は安く買い叩かれ、単価が低迷していました。

## 対処内容

`IntersectionObserver` を使い、**各広告がビューポート手前 600px に入って初めて読み込む**遅延読み込みに変更しました。

- スクロールで実際に近づいた広告だけを読み込むため、視認率が上がり、viewable 重視の入札単価が引き上がる見込み。
- 600px の先読みにより、ユーザーが見る時点では広告が表示済みで「空枠」を体感しない。
- 下部広告の通信を後ろ倒しにするため、Core Web Vitals（初期表示・通信量）もむしろ改善方向。
- `IntersectionObserver` 非対応環境は従来どおり一括読み込みにフォールバック。
- 高単価の Vignette / Rewarded は Auto ads 由来で別系統のため、本変更の影響を受けません。

## 検証について

⚠️ 広告は staging では描画されない（`$isStaging` で return）ため、実挙動は本番でのみ確認できます。効果はデプロイ後1〜2週間の **AdSense 視認率・ページRPM** で判定します。問題があれば本PRの revert で即ロールバック可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)