### PR TITLE
[STG] fix: 台湾・タイ版ページを正しい言語で検索表示させる(hreflang対応)

### DIFF
--- a/app/Views/components/hreflang.php
+++ b/app/Views/components/hreflang.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * hreflang alternate links for fully-translated pages (ja / zh-TW / th).
+ *
+ * path() は現在の urlRoot (''/'/tw'/'/th') を除いた言語非依存パスを返すため、
+ * 各言語の base URL に同じパスを付ければ対応する言語版 URL になる。
+ * 3言語すべてに同一内容のページが存在するテンプレート（/oc など）でのみ include すること。
+ */
+
+use Shadow\Kernel\Dispatcher\ReceptionInitializer;
+
+$cleanPath = strstr(path(), '?', true) ?: path();
+
+// urlRoot => hreflang 言語コード（<html lang> と一致させる）
+$hreflangRoots = [
+    ''    => 'ja',
+    '/tw' => 'zh-TW',
+    '/th' => 'th',
+];
+
+foreach ($hreflangRoots as $root => $lang) {
+    echo '<link rel="alternate" hreflang="' . $lang . '" href="'
+        . ReceptionInitializer::getDomainAndHttpHost($root) . $cleanPath . '">' . "\n";
+}
+
+// x-default は日本語（ルート）を指す
+echo '<link rel="alternate" hreflang="x-default" href="'
+    . ReceptionInitializer::getDomainAndHttpHost('') . $cleanPath . '">' . "\n";

--- a/app/Views/components/oc_head.php
+++ b/app/Views/components/oc_head.php
@@ -14,6 +14,7 @@
     <?php endforeach ?>
     <link rel="icon" type="image/png" href="<?php echo fileUrl(\App\Config\AppConfig::SITE_ICON_FILE_PATH, urlRoot: '') ?>">
     <link rel="canonical" href="<?php echo url(strstr(path(), '?', true) ?: path()) ?>">
+    <?php viewComponent('hreflang') ?>
     <?php if (isset($_schema)) : ?>
         <?php echo $_schema ?>
     <?php endif ?>


### PR DESCRIPTION
## 問題の概要

台湾・タイ版のページが Google 検索で正しく扱われていませんでした。

サイトは `/oc/123`（日本語）・`/tw/oc/123`（繁体字）・`/th/oc/123`（タイ語）と、同じ内容を言語別URLで配信しています。しかし **hreflang アノテーションが全ページで一切出力されておらず**、Google は3つが「同一内容の言語違い」だと認識できていませんでした。

その結果:

- 台湾・タイの検索利用者に**日本語版を表示**してしまう等の言語マッチング事故
- 言語をまたいで**評価シグナルが分散**し、台湾・タイでの検索順位が伸びにくい

台湾・タイのSEOが弱い構造的な一因と考えられます。

## 対処内容

OpenChat 詳細ページの `<head>` に hreflang の相互リンクを追加し、各言語版（`ja` / `zh-TW` / `th`）と `x-default` を相互に宣言するようにしました。

- 新規 [`components/hreflang.php`](app/Views/components/hreflang.php): `path()` が言語接頭辞を除いたパスを返す仕様を利用し、各言語のベースURLに同じパスを付けて対応URLを生成。
- [`oc_head.php`](app/Views/components/oc_head.php) の canonical 直後に追加。
- **対象を OpenChat 詳細ページに限定**: 3言語すべてに実体があり、かつ台湾・タイの検索表示回数の大半を占めるため。`/recommend` `/ranking` トップ等は効果を切り分けて別途追加予定。
- 削除済みルームの 410 ページは独自 `<head>` のため alternate を出力しません（正しい挙動）。

## 検証について

広告と違い hreflang は staging でも描画されるため、デプロイ後に実ページのソースで確認できます。効果（台湾・タイの表示順位・正しい言語版の表示）はデプロイ後1〜2週間の Search Console で判定します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)