### PR TITLE
[PROD] テーマ別一覧の「勢い」グラフの集計起点を最終更新時刻に変更（更新遅延時も表示されるよう仕様調整）

### DIFF
--- a/app/Controllers/Pages/RecommendOpenChatPageController.php
+++ b/app/Controllers/Pages/RecommendOpenChatPageController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Controllers\Pages;
 
 use App\Config\AppConfig;
-use App\Models\Repositories\Recommend\RecommendGrowthRepository;
+use App\Models\Repositories\Recommend\RecommendGrowthRepositoryInterface;
 use App\Services\Recommend\RecommendPageList;
 use App\Services\Recommend\TagDefinition\Ja\RecommendTagDescription;
 use App\Services\Recommend\TagDefinition\Ja\RecommendTagFilters;
@@ -17,7 +17,8 @@ use Shared\MimimalCmsConfig;
 class RecommendOpenChatPageController
 {
     function __construct(
-        private PageBreadcrumbsListSchema $breadcrumbsShema
+        private PageBreadcrumbsListSchema $breadcrumbsShema,
+        private RecommendGrowthRepositoryInterface $recommendGrowthRepository,
     ) {}
 
     function index(
@@ -112,7 +113,12 @@ class RecommendOpenChatPageController
 
         // テーマの勢い: rank/rising は ranking_position.db(ロケール別)、
         // member(合計人数)は statistics.db(ロケール別)から集計。ja/tw/th 全ロケール対応。
-        $growth = RecommendGrowthRepository::themeMomentum(array_column($recommend->getList(false, null), 'id'));
+        // 集計窓の起点は現在時刻ではなく最終 cron 時刻($hourlyUpdatedAt)を渡す。クロール遅延や
+        // ローカルの古いデータでも窓が実データに乗るようにするため(時刻取得はこの利用元の責務)。
+        $growth = $this->recommendGrowthRepository->themeMomentum(
+            array_column($recommend->getList(false, null), 'id'),
+            $hourlyUpdatedAt
+        );
 
         return view('recommend_content', compact(
             '_meta',

--- a/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
+++ b/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
@@ -30,7 +30,7 @@ use App\Models\SQLite\SQLiteStatistics;
  *   - rank は ranking_position.db(ロケール別)、member は statistics.db(ロケール別)から集計。
  *     いずれも ja/tw/th 全ロケール対応。ocgraph_sqlapi は使用しない。
  */
-class RecommendGrowthRepository
+class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
 {
     /** ランキングの全体カテゴリ(=全体ランキング)。 */
     private const RANK_CATEGORY_OVERALL = 0;
@@ -38,11 +38,16 @@ class RecommendGrowthRepository
     /**
      * テーマの勢いを 1 つの配列にまとめて返す(ja/tw/th 全ロケール対応・呼び出し側はそのままビューへ)。
      *
+     * 「直近 N 日」の起点は現在時刻ではなく $anchorDate(最後に時報 cron が更新した時刻)を呼び出し側から渡す。
+     * 集計窓を実データの存在期間に合わせるためで、クロール遅延やローカルの古いデータでも窓がデータに乗る
+     * (本番では現在時刻とほぼ一致するので挙動は変わらない)。時刻取得はこの層の責務にしない。
+     *
      * @param int[] $openChatIds 掲載部屋の ID 群
+     * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
      * @param int $days 遡る日数
      * @return array{
      *   spanDays: int,
-     *   rank: array{points: array{date:string, value:int}[], current:int, first:int},
+     *   rank: array{points: array{date:string, value:int}[], current:int, first:int, leaderId:int},
      *   member: array{points: array{date:string, value:int}[], increase:int, rooms:int}
      * }|array{} データ不足時は空配列
      *
@@ -50,12 +55,12 @@ class RecommendGrowthRepository
      *          leaderId = 最新日にその最高順位を持っていた部屋の open_chat_id(どの部屋の話か示すため)。
      * member = 同一部屋コホートの合計人数(規模・rank が無いテーマのフォールバック)。
      */
-    public static function themeMomentum(array $openChatIds, int $days = 7): array
+    public function themeMomentum(array $openChatIds, \DateTime $anchorDate, int $days = 7): array
     {
-        $rank   = self::bestRankPositionDaily($openChatIds, $days);
+        $rank   = $this->bestRankPositionDaily($openChatIds, $anchorDate, $days);
         // rank は ranking_position.db(ロケール別)、member は statistics.db(ロケール別)から集計。
         // いずれも ja/tw/th 全ロケール対応。
-        $member = self::themeGrowth($openChatIds, $days);
+        $member = $this->themeGrowth($openChatIds, $anchorDate, $days);
 
         // ヒーロー(rank)が 2 点未満 かつ member も空ならグラフ・数値を出す意味が無いので空配列。
         if (count($rank['points']) < 2 && !$member['points']) {
@@ -109,20 +114,21 @@ class RecommendGrowthRepository
      * where + group by は高速。
      *
      * @param int[] $openChatIds 掲載部屋の ID 群
+     * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
      * @param int $days 遡る日数
      * @return array{points: array{date:string, value:int}[], leaderId: int}
      *         points: 日付昇順 / value: その日のテーマ最高順位(= MIN(position)・小さいほど良い)
      *         leaderId: 最新日に最高順位だった部屋の open_chat_id(無ければ 0)
      */
-    private static function bestRankPositionDaily(array $openChatIds, int $days): array
+    private function bestRankPositionDaily(array $openChatIds, \DateTime $anchorDate, int $days): array
     {
-        $ids = self::sanitizeIds($openChatIds);
+        $ids = $this->sanitizeIds($openChatIds);
         if (!$ids) {
             return ['points' => [], 'leaderId' => 0];
         }
 
         $in = implode(',', $ids);
-        $since = (new \DateTime("-{$days} days"))->format('Y-m-d');
+        $since = (clone $anchorDate)->modify("-{$days} days")->format('Y-m-d');
         $category = self::RANK_CATEGORY_OVERALL;
 
         SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
@@ -137,6 +143,8 @@ class RecommendGrowthRepository
         );
 
         // 「どの部屋の話か」を示すため、最新日に最高(=最小)順位だった部屋を1つ特定する。
+        // 表示順位(rankCurrent)と同じ「最新の有データ日」を使うこと。日付の選び方をどちらか片方だけ
+        // 変えると、画面に出る順位とリーダー部屋がズレるため意図的に同一日にそろえている。
         // $latest は DB から取り出した値の再注入になるため、プレースホルダでバインドして埋め込む。
         $leaderId = 0;
         if ($rows) {
@@ -167,22 +175,23 @@ class RecommendGrowthRepository
      * 同一部屋コホートの合計メンバー数を日次で返す。
      *
      * @param int[] $openChatIds 掲載部屋の ID 群
+     * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
      * @param int $days 遡る日数
      * @return array{points: array{date:string, value:int}[], rooms:int}
      *         points: 日付昇順の合計 / rooms: コホートに含まれる部屋数
      */
-    public static function themeGrowth(array $openChatIds, int $days = 21): array
+    public function themeGrowth(array $openChatIds, \DateTime $anchorDate, int $days = 21): array
     {
         $empty = ['points' => [], 'rooms' => 0];
 
-        $ids = self::sanitizeIds($openChatIds);
+        $ids = $this->sanitizeIds($openChatIds);
         if (count($ids) < 3) {
             return $empty;
         }
 
         $in = implode(',', $ids);
         // DateTime 由来の Y-m-d 固定書式なのでインライン化(注入リスクなし)。
-        $since = (new \DateTime("-{$days} days"))->format('Y-m-d');
+        $since = (clone $anchorDate)->modify("-{$days} days")->format('Y-m-d');
 
         SQLiteStatistics::connect(['mode' => '?mode=ro']);
 
@@ -229,7 +238,7 @@ class RecommendGrowthRepository
      * @param int[] $openChatIds
      * @return int[]
      */
-    private static function sanitizeIds(array $openChatIds): array
+    private function sanitizeIds(array $openChatIds): array
     {
         return array_values(array_filter(array_map('intval', $openChatIds)));
     }

--- a/app/Models/Repositories/Recommend/RecommendGrowthRepositoryInterface.php
+++ b/app/Models/Repositories/Recommend/RecommendGrowthRepositoryInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Repositories\Recommend;
+
+/**
+ * /recommend テーマページの「勢いグラフ」用データ取得(集計のみ・副作用なし)。
+ *
+ * 「直近 N 日」の起点は現在時刻ではなく呼び出し側が渡す $anchorDate(最終 cron 時刻)を使う。
+ * 詳細・指標の意味は実装 {@see RecommendGrowthRepository} の docブロックを参照。
+ */
+interface RecommendGrowthRepositoryInterface
+{
+    /**
+     * テーマの勢いを 1 つの配列にまとめて返す(ja/tw/th 全ロケール対応)。
+     *
+     * @param int[] $openChatIds 掲載部屋の ID 群
+     * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
+     * @param int $days 遡る日数
+     * @return array{
+     *   spanDays: int,
+     *   rank: array{points: array{date:string, value:int}[], current:int, first:int, leaderId:int},
+     *   member: array{points: array{date:string, value:int}[], increase:int, rooms:int}
+     * }|array{} データ不足時は空配列
+     */
+    public function themeMomentum(array $openChatIds, \DateTime $anchorDate, int $days = 7): array;
+
+    /**
+     * 同一部屋コホートの合計メンバー数を日次で返す。
+     *
+     * @param int[] $openChatIds 掲載部屋の ID 群
+     * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
+     * @param int $days 遡る日数
+     * @return array{points: array{date:string, value:int}[], rooms:int}
+     */
+    public function themeGrowth(array $openChatIds, \DateTime $anchorDate, int $days = 21): array;
+}

--- a/app/Models/Repositories/Recommend/test/RecommendGrowthRepositoryTest.php
+++ b/app/Models/Repositories/Recommend/test/RecommendGrowthRepositoryTest.php
@@ -24,6 +24,7 @@
 declare(strict_types=1);
 
 use App\Models\Repositories\Recommend\RecommendGrowthRepository;
+use App\Services\Storage\FileStorageInterface;
 use PHPUnit\Framework\TestCase;
 
 class RecommendGrowthRepositoryTest extends TestCase
@@ -34,13 +35,29 @@ class RecommendGrowthRepositoryTest extends TestCase
      */
     private const STABLE_IDS = [3, 17, 18, 19, 20];
 
+    /**
+     * 集計窓の起点。本番(コントローラ)と同じく最終 cron 時刻を使い、現在時刻には依存させない。
+     * これによりローカルの古いデータでもテストの不変条件が安定して成立する。
+     */
+    private \DateTime $anchor;
+
+    private RecommendGrowthRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->anchor = new \DateTime(
+            app(FileStorageInterface::class)->getContents('@hourlyCronUpdatedAtDatetime')
+        );
+        $this->repo = new RecommendGrowthRepository();
+    }
+
     // ===================================================
     // themeMomentum: 空・無効 ID
     // ===================================================
 
     public function test_themeMomentum_returns_empty_array_for_empty_ids(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum([]);
+        $result = $this->repo->themeMomentum([], $this->anchor);
         $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
@@ -48,7 +65,7 @@ class RecommendGrowthRepositoryTest extends TestCase
     public function test_themeMomentum_returns_empty_array_for_nonexistent_ids(): void
     {
         // 絶対に存在しない ID (int_max 付近)
-        $result = RecommendGrowthRepository::themeMomentum([PHP_INT_MAX - 1, PHP_INT_MAX - 2, PHP_INT_MAX - 3]);
+        $result = $this->repo->themeMomentum([PHP_INT_MAX - 1, PHP_INT_MAX - 2, PHP_INT_MAX - 3], $this->anchor);
         $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
@@ -57,7 +74,7 @@ class RecommendGrowthRepositoryTest extends TestCase
     {
         // 1件のみ → rank も member も成立しない可能性が高い → 空
         // (空ではない場合も shape チェックだけ行う)
-        $result = RecommendGrowthRepository::themeMomentum([3]);
+        $result = $this->repo->themeMomentum([3], $this->anchor);
         $this->assertIsArray($result);
         // 空でも非空でも落ちない: 非空なら shape を確認する
         if (!empty($result)) {
@@ -71,7 +88,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_returns_correct_top_level_keys(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -83,7 +100,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_rank_has_correct_keys(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -96,7 +113,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_member_has_correct_keys(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -113,7 +130,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_spanDays_is_int(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -124,7 +141,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_rank_current_and_first_are_ints(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -135,7 +152,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_leaderId_is_int(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -145,7 +162,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_member_increase_and_rooms_are_ints(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -161,7 +178,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_rank_points_are_date_ascending(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result) || empty($result['rank']['points'])) {
             $this->markTestSkipped('rank.points が空のためスキップ');
         }
@@ -175,7 +192,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_rank_points_have_correct_shape(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result) || empty($result['rank']['points'])) {
             $this->markTestSkipped('rank.points が空のためスキップ');
         }
@@ -194,7 +211,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_member_points_have_correct_shape(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 21);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 21);
         if (empty($result) || empty($result['member']['points'])) {
             $this->markTestSkipped('member.points が空のためスキップ');
         }
@@ -211,7 +228,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_member_points_are_date_ascending(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 21);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 21);
         if (empty($result) || empty($result['member']['points'])) {
             $this->markTestSkipped('member.points が空のためスキップ');
         }
@@ -229,7 +246,7 @@ class RecommendGrowthRepositoryTest extends TestCase
     public function test_themeMomentum_leaderId_is_in_input_ids_when_positive(): void
     {
         $ids = self::STABLE_IDS;
-        $result = RecommendGrowthRepository::themeMomentum($ids, 7);
+        $result = $this->repo->themeMomentum($ids, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -253,7 +270,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_spanDays_is_consistent_with_points(): void
     {
-        $result = RecommendGrowthRepository::themeMomentum(self::STABLE_IDS, 7);
+        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
         if (empty($result)) {
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
@@ -273,7 +290,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeGrowth_returns_empty_for_zero_ids(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth([]);
+        $result = $this->repo->themeGrowth([], $this->anchor);
         $this->assertIsArray($result);
         $this->assertArrayHasKey('points', $result);
         $this->assertArrayHasKey('rooms', $result);
@@ -283,21 +300,21 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeGrowth_returns_empty_for_one_id(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth([3]);
+        $result = $this->repo->themeGrowth([3], $this->anchor);
         $this->assertEmpty($result['points']);
         $this->assertSame(0, $result['rooms']);
     }
 
     public function test_themeGrowth_returns_empty_for_two_ids(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth([3, 17]);
+        $result = $this->repo->themeGrowth([3, 17], $this->anchor);
         $this->assertEmpty($result['points']);
         $this->assertSame(0, $result['rooms']);
     }
 
     public function test_themeGrowth_returns_data_for_five_ids(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth(self::STABLE_IDS, 21);
+        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
         // データがある場合は shape を確認(データがなければ empty shape も正常)
         $this->assertArrayHasKey('points', $result);
         $this->assertArrayHasKey('rooms', $result);
@@ -308,7 +325,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeGrowth_rooms_matches_cohort_count(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth(self::STABLE_IDS, 21);
+        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
         if (empty($result['points'])) {
             $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
         }
@@ -321,7 +338,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeGrowth_nonexistent_ids_return_empty(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth([PHP_INT_MAX - 1, PHP_INT_MAX - 2, PHP_INT_MAX - 3], 21);
+        $result = $this->repo->themeGrowth([PHP_INT_MAX - 1, PHP_INT_MAX - 2, PHP_INT_MAX - 3], $this->anchor, 21);
         $this->assertEmpty($result['points']);
         $this->assertSame(0, $result['rooms']);
     }
@@ -332,7 +349,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeGrowth_points_are_date_ascending(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth(self::STABLE_IDS, 21);
+        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
         if (empty($result['points'])) {
             $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
         }
@@ -345,7 +362,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeGrowth_points_values_are_ints(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth(self::STABLE_IDS, 21);
+        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
         if (empty($result['points'])) {
             $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
         }
@@ -358,7 +375,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeGrowth_points_dates_match_expected_format(): void
     {
-        $result = RecommendGrowthRepository::themeGrowth(self::STABLE_IDS, 21);
+        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
         if (empty($result['points'])) {
             $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
         }
@@ -371,7 +388,7 @@ class RecommendGrowthRepositoryTest extends TestCase
     public function test_themeGrowth_points_count_does_not_exceed_days(): void
     {
         $days = 14;
-        $result = RecommendGrowthRepository::themeGrowth(self::STABLE_IDS, $days);
+        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, $days);
         if (empty($result['points'])) {
             $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
         }

--- a/public/style/recommend_page.css
+++ b/public/style/recommend_page.css
@@ -606,18 +606,6 @@ section aside:hover {
   font-feature-settings: 'tnum';
 }
 
-.recommend-growth--up {
-  --rg-color: #06c755;
-}
-
-.recommend-growth--down {
-  --rg-color: #e8553e;
-}
-
-.recommend-growth--flat {
-  --rg-color: #9aa0a6;
-}
-
 /* ---- ブランドロックアップ(LINE × オープンチャット)+ 勢いラベル ---- */
 .recommend-growth__head {
   display: flex;
@@ -671,15 +659,6 @@ section aside:hover {
   color: #1f2328;
   letter-spacing: 0.01em;
   line-height: 1.25;
-}
-
-/* ---- ヒーロー: 活発な部屋数(WHAT + 今 + 推移) ---- */
-.recommend-growth__hero {
-  position: relative;
-}
-
-.recommend-growth__herometa {
-  margin: 0 0 6px;
 }
 
 /* グラフが何を測っているかの小キャプション(タイトルの補足)。控えめにしてタイトルと競合させない。 */
@@ -782,14 +761,6 @@ section aside:hover {
   letter-spacing: 0.02em;
 }
 
-.recommend-growth__qualifier {
-  margin: 1px 0 0;
-  font-size: 10.5px;
-  font-weight: 500;
-  color: #8a9097;
-  line-height: 1.35;
-}
-
 /* 曲線(背景) + 大きな現在値(前景)を重ねて、同じ指標だと一目で分かるようにする。 */
 .recommend-growth__heroplot {
   position: relative;
@@ -841,168 +812,6 @@ section aside:hover {
   }
 }
 
-/* 数値の可読性のため、曲線の左側に淡い白グラデーションを敷く(画像不要・CSSのみ)。 */
-
-.recommend-growth__readout {
-  position: absolute;
-  left: 0;
-  bottom: 2px;
-  z-index: 1;
-  display: flex;
-  align-items: baseline;
-  gap: 3px;
-  line-height: 1;
-}
-
-.recommend-growth__nowlabel {
-  align-self: flex-end;
-  margin-right: 1px;
-  margin-bottom: 4px;
-  font-size: 10px;
-  font-weight: 700;
-  color: #aab0b7;
-  letter-spacing: 0.02em;
-}
-
-/* 「全体」の小さな接頭ラベル(大きな順位数値に従属させる)。 */
-.recommend-growth__bigpre {
-  align-self: flex-end;
-  margin-right: 1px;
-  margin-bottom: 5px;
-  font-size: 13px;
-  font-weight: 800;
-  color: #4a4f56;
-  letter-spacing: 0.01em;
-}
-
-.recommend-growth__bignum {
-  font-size: 38px;
-  font-weight: 800;
-  color: #14161a;
-  letter-spacing: -0.02em;
-}
-
-.recommend-growth__bigunit {
-  margin-left: -1px;
-  font-size: 15px;
-  font-weight: 700;
-  color: #4a4f56;
-}
-
-.recommend-growth__bigdelta {
-  align-self: flex-end;
-  margin-left: 5px;
-  margin-bottom: 5px;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: #f1f3f5; /* color-mix 非対応ブラウザ用フォールバック(淡いピル) */
-  background: color-mix(in srgb, var(--rg-color) 12%, #fff);
-  font-size: 13px;
-  font-weight: 800;
-  line-height: 1;
-  white-space: nowrap;
-}
-
-.recommend-growth__bigdelta--flat {
-  font-size: 11px;
-  font-weight: 700;
-}
-
-/* from→to の推移を実数で具体化する。 */
-.recommend-growth__trend {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 4px 7px;
-  margin: 7px 0 0;
-  font-size: 12px;
-  line-height: 1.3;
-}
-
-.recommend-growth__trendago {
-  color: #8a9097;
-  font-weight: 600;
-}
-
-.recommend-growth__trendarrow {
-  font-weight: 800;
-}
-
-.recommend-growth__trendnow {
-  color: #2b2f36;
-  font-weight: 800;
-}
-
-/* ---- 補助ステータス(メンバー / 急上昇入り): ヒーローより明確に小さく従属させる ---- */
-.recommend-growth__substats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 14px;
-  margin: 10px 0 0;
-  padding-top: 9px;
-  border-top: 1px solid #eef0f3;
-}
-
-.recommend-growth__sub {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  min-width: 0;
-}
-
-.recommend-growth__sublabel {
-  font-size: 11px;
-  font-weight: 600;
-  color: #777e87;
-  white-space: nowrap;
-}
-
-.recommend-growth__sublabel-span {
-  font-weight: 500;
-  color: #aab0b7;
-}
-
-.recommend-growth__subval {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 2px;
-  color: #2b2f36;
-  line-height: 1;
-}
-
-.recommend-growth__subnum {
-  font-size: 16px;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-}
-
-.recommend-growth__subunit {
-  font-size: 10.5px;
-  font-weight: 600;
-  color: #9aa0a6;
-}
-
-.recommend-growth__subval--up .recommend-growth__subunit,
-.recommend-growth__subval--down .recommend-growth__subunit {
-  color: inherit;
-  opacity: 0.7;
-}
-
-.recommend-growth__note {
-  margin: 9px 0 0;
-  font-size: 11.5px;
-  line-height: 1.55;
-  color: #54585f;
-}
-
-.recommend-growth__scope {
-  display: block;
-  margin-top: 1px;
-  color: #9aa0a6;
-  font-size: 10.5px;
-  line-height: 1.5;
-}
-
 /* デスクトップ: zoom ではなくパディング/余白を素直に広げて精度を保つ。 */
 @media screen and (min-width: 768px) {
   .recommend-growth {
@@ -1022,25 +831,8 @@ section aside:hover {
     height: 64px;
   }
 
-  .recommend-growth__bignum {
-    font-size: 42px;
-  }
+  
 
-  .recommend-growth__bigunit {
-    font-size: 16px;
-  }
+  
 
-  .recommend-growth__trend {
-    font-size: 12.5px;
-  }
-
-  .recommend-growth__substats {
-    gap: 24px;
-  }
-
-  .recommend-growth__subnum {
-    font-size: 17px;
-  }
 }
-
-

--- a/shared/MimimalCmsConfig.php
+++ b/shared/MimimalCmsConfig.php
@@ -48,6 +48,7 @@ class MimimalCmsConfig
 
         \App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepositoryInterface::class => \App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepository::class,
         \App\Models\Repositories\SimilarSizeRoomRepositoryInterface::class => \App\Models\Repositories\SimilarSizeRoomRepository::class,
+        \App\Models\Repositories\Recommend\RecommendGrowthRepositoryInterface::class => \App\Models\Repositories\Recommend\RecommendGrowthRepository::class,
 
         \App\Models\CommentRepositories\CommentListRepositoryInterface::class => \App\Models\CommentRepositories\CommentListRepository::class,
         \App\Models\CommentRepositories\CommentLogRepositoryInterface::class => \App\Models\CommentRepositories\CommentLogRepository::class,


### PR DESCRIPTION
stg で検証済みの内容を本番(main)へ昇格。

詳細: #282

「勢い」グラフの集計起点を現在時刻から最終更新時刻に変更し、更新遅延時もグラフが表示されるよう仕様調整。あわせて集計クラスをインターフェース+DI化し、未使用CSSを削除。
