### PR TITLE
[STG] feat: 入室前の「参加確認」ページを台湾・タイにも対応し、デザインを刷新

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -124,9 +124,6 @@ Route::path('oc/{open_chat_id}', [OpenChatPageController::class, 'index'])
 Route::path('oc/{open_chat_id}/jump', [JumpOpenChatPageController::class, 'index'])
     ->matchNum('open_chat_id', min: 1)
     ->match(function (FileStorageInterface $fileStorage) {
-        if (MimimalCmsConfig::$urlRoot !== '')
-            return false;
-
         checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
     });
 

--- a/app/Controllers/Pages/JumpOpenChatPageController.php
+++ b/app/Controllers/Pages/JumpOpenChatPageController.php
@@ -36,6 +36,9 @@ class JumpOpenChatPageController
             case '/th':
                 $view = 'oc_content_jump_th';
                 break;
+            case '/tw':
+                $view = 'oc_content_jump_tw';
+                break;
             default:
                 $view = 'oc_content_jump';
                 break;

--- a/app/Controllers/Pages/RobotsController.php
+++ b/app/Controllers/Pages/RobotsController.php
@@ -58,10 +58,12 @@ TXT;
 User-agent: Mediapartners-Google
 Allow: /oc/*/jump
 Allow: /th/oc/*/jump
+Allow: /tw/oc/*/jump
 
 User-agent: AdsBot-Google
 Allow: /oc/*/jump
 Allow: /th/oc/*/jump
+Allow: /tw/oc/*/jump
 
 # その他すべてのクローラー
 User-agent: *
@@ -71,6 +73,7 @@ Disallow: /th/recently-registered
 Disallow: /recently-registered
 Disallow: /oc/*/jump
 Disallow: /th/oc/*/jump
+Disallow: /tw/oc/*/jump
 
 Sitemap: https://openchat-review.me/sitemap.xml
 TXT;

--- a/app/Views/components/oc_jump_page.php
+++ b/app/Views/components/oc_jump_page.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * 入室確認(jump)ページ 共通レイアウト
+ *
+ * 言語別ビュー(oc_content_jump / _th / _tw)から、文言と禁止事項リストだけを
+ * 渡して呼び出す。レイアウト・広告・ボタン・スクリプトはここに一本化する。
+ *
+ * @param array  $oc            部屋データ
+ * @param array  $_meta, $_css  view() から引き継ぎ
+ * @param string $htmlLang      <html lang="">（既定: t('ja') で各言語に解決）
+ * @param array  $txt           UI文言 [
+ *                                noticeTitle, noticeLead, aboutLabel,
+ *                                rulesTitle, rulesLead, sourceLabel,
+ *                                sourceText, sourceUrl, openButton
+ *                              ]
+ * @param array  $rules         禁止事項 [ ['title'=>..., 'desc'=>...(任意)], ... ]
+ * @param ?string $rulesImage   公式ガイドライン画像のfileUrlパス（任意・JAのみ）
+ * @param ?string $rulesImageAlt
+ */
+
+use App\Views\Ads\GoogleAdsense as GAd;
+
+$htmlLang   = $htmlLang   ?? t('ja');
+$rules      = $rules      ?? [];
+$rulesImage = $rulesImage ?? null;
+
+$_css[] = 'oc-jump';
+?>
+<!DOCTYPE html>
+<html lang="<?php echo $htmlLang ?>">
+<?php viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']); ?>
+
+<body>
+  <?php viewComponent('site_header') ?>
+  <?php GAd::gTag() ?>
+  <div class="unset openchat body oc-jump-wrap">
+    <article class="unset oc-jump-stack">
+
+      <!-- 1. 参加前の確認 -->
+      <section class="oc-jump-notice oc-jump-rise">
+        <span class="oc-jump-notice__icon" aria-hidden="true">!</span>
+        <div class="oc-jump-notice__body">
+          <h2 class="oc-jump-notice__title"><?php echo $txt['noticeTitle'] ?></h2>
+          <span class="oc-jump-notice__lead"><?php echo $txt['noticeLead'] ?></span>
+        </div>
+      </section>
+
+      <!-- 2-4. 部屋情報 + 説明文 -->
+      <section class="oc-jump-card oc-jump-rise">
+        <img class="oc-jump-banner" alt="<?php echo $oc['name'] ?>" src="<?php echo imgUrl($oc['img_url']) ?>">
+        <div class="oc-jump-room">
+          <h1 class="oc-jump-room__title"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
+          <span class="oc-jump-room__meta"><?php echo sprintfT('メンバー %s人', number_format($oc['member'])) ?></span>
+          <span class="oc-jump-about__label"><?php echo $txt['aboutLabel'] ?></span>
+          <div class="oc-jump-about__body talkroom_description_box" id="talkroom_description_box">
+            <p class="talkroom_description" id="talkroom-description">
+              <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 広告: 説明文と禁止事項の間（最高単価の枠） -->
+      <div class="oc-jump-ad oc-jump-rise">
+        <?php GAd::output('siteSeparatorWide', true) ?>
+      </div>
+
+      <!-- 5. 禁止事項 -->
+      <section class="oc-jump-card oc-jump-rules oc-jump-rise">
+        <div class="oc-jump-rules__head">
+          <h3 class="oc-jump-rules__title"><?php echo $txt['rulesTitle'] ?></h3>
+          <span class="oc-jump-rules__lead"><?php echo $txt['rulesLead'] ?></span>
+        </div>
+        <?php if ($rulesImage) : ?>
+          <img class="oc-jump-rules__image" src="<?php echo fileUrl($rulesImage) ?>" alt="<?php echo $rulesImageAlt ?? '' ?>">
+        <?php endif ?>
+        <ul class="oc-jump-rule-list">
+          <?php foreach ($rules as $rule) : ?>
+            <li><b><?php echo $rule['title'] ?></b><?php if (!empty($rule['desc'])) : ?><span><?php echo $rule['desc'] ?></span><?php endif ?></li>
+          <?php endforeach ?>
+        </ul>
+        <span class="oc-jump-source"><?php echo $txt['sourceLabel'] ?><a href="<?php echo $txt['sourceUrl'] ?>" target="_blank" rel="noopener nofollow"><?php echo $txt['sourceText'] ?></a></span>
+      </section>
+
+      <!-- 6. 入室ボタン -->
+      <?php if ($oc['url']) : ?>
+        <section class="oc-jump-action oc-jump-rise">
+          <div class="oc-jump-room-mini">
+            <img aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
+            <div>
+              <div class="oc-jump-room-mini__name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
+              <div class="oc-jump-room-mini__member">(<?php echo formatMember($oc['member']) ?>)</div>
+            </div>
+          </div>
+          <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="oc-jump-line-button openchat_link">
+            <div class="oc-jump-line-button-content">
+              <?php if ($oc['join_method_type'] !== 0) : ?>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
+                  <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
+                </svg>
+              <?php endif ?>
+              <span class="text"><?php echo t('LINEで開く') ?></span>
+            </div>
+          </a>
+        </section>
+      <?php endif ?>
+
+    </article>
+    <!-- 最下部広告 -->
+    <div class="oc-jump-ad" style="margin-top: 14px;">
+      <?php GAd::output('siteSeparatorResponsive', true) ?>
+    </div>
+    <?php viewComponent('footer_inner') ?>
+  </div>
+  <?php GAd::loadAdsTag() ?>
+  <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
+  <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
+</body>
+
+</html>

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -144,7 +144,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
           <?php endif ?>
           <section class="open-btn sp-btn" style="flex: 1; margin: 0; padding: 0;">
             <?php if ($oc['url']) : ?>
-              <a href="<?php echo MimimalCmsConfig::$urlRoot === '' ? url('oc', $oc['id'], 'jump') : lineAppUrl($oc) ?>" class="openchat_link" style="font-size: 16px;">
+              <a href="<?php echo url('oc', $oc['id'], 'jump') ?>" class="openchat_link" style="font-size: 16px;">
                 <div style="display: flex; align-items: center; justify-content: center;">
                   <?php if ($oc['join_method_type'] !== 0) : ?>
                     <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">

--- a/app/Views/oc_content_jump.php
+++ b/app/Views/oc_content_jump.php
@@ -1,100 +1,39 @@
-<!DOCTYPE html>
-<html lang="<?php echo t('ja') ?>">
 <?php
 
-use App\Views\Ads\GoogleAdsense as GAd;
+/** 入室確認ページ（日本語）。レイアウトは components/oc_jump_page に集約。
+ *  禁止事項の出典: LINE公式「オープンチャット禁止規定」(OpenChat固有) */
 
-$_css[] = 'oc-jump';
-viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']); ?>
+$txt = [
+  'noticeTitle' => '参加前の確認',
+  'noticeLead'  => '参加するオープンチャットの説明文と、LINEの禁止事項をご確認ください。',
+  'aboutLabel'  => 'このオープンチャットについて',
+  'rulesTitle'  => 'オープンチャットの禁止事項',
+  'rulesLead'   => '以下の禁止事項をご確認のうえ、「LINEで開く」を押してください。',
+  'sourceLabel' => '出典：',
+  'sourceText'  => 'LINEオープンチャット 禁止規定',
+  'sourceUrl'   => 'https://openchat-jp.line.me/other/prohibited_activities',
+  'openButton'  => t('LINEで開く'),
+];
 
-<body>
-  <style>
-    .responsive-google-parent {
-      padding: 0;
-    }
-  </style>
-  <?php viewComponent('site_header') ?>
-  <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
-  <div class="unset openchat body" style="overflow: hidden; max-width: 600px;">
-    <article class="unset" style="display: block;">
-      <section class="oc-jump-section oc-info-section">
-        <h2 class="oc-jump-main-title"><?php echo t('⚠️参加前の確認') ?></h2>
-        <span class="oc-jump-instruction"><?php echo t('参加するオープンチャットの説明文をご確認ください。') ?></span>
-        <div class="oc-jump-image-wrapper">
-          <img class="talkroom_banner_img oc-jump-banner-img"
-            alt="<?php echo $oc['name'] ?>"
-            src="<?php echo imgUrl($oc['img_url']) ?>">
-        </div>
-        <div class="oc-jump-info-content">
-          <h1 class="talkroom_link_h1 unset oc-jump-chat-title"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
-          <div class="oc-jump-member-count">
-            <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('メンバー %s人', number_format($oc['member'])) ?></span>
-          </div>
-          <span class="oc-jump-content-label"><?php echo t('このオープンチャットについて') ?></span>
-          <div class="talkroom_description_box" id="talkroom_description_box">
-            <p class="talkroom_description" id="talkroom-description">
-              <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
-            </p>
-          </div>
-        </div>
-      </section>
-      <?php GAd::output('siteSeparatorWide', true) ?>
-      <section class="oc-jump-section oc-rules-section">
-        <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title"><?php echo t('オープンチャットの禁止事項') ?></h3>
-          <span class="oc-jump-instruction"><?php echo t('以下の禁止事項をご確認のうえ、「LINEで開く」を押してください。') ?></span>
-          <img src="<?php echo fileUrl('assets/line-guilde/line-guilde.webp') ?>" alt="<?php echo t('オープンチャット禁止事項') ?>"
-            class="oc-jump-rule-image">
-        </div>
-        <ul class="oc-jump-rule-list">
-          <li><b><?php echo t('1. 個人情報の掲載') ?></b><span><?php echo t('自分自身や他人の個人を特定できる情報（LINE ID・電話番号・氏名・住所・顔写真など）を掲載することは禁止されています。') ?></span></li>
-          <li><b><?php echo t('2. 誹謗中傷・過度な批判的表現') ?></b><span><?php echo t('特定の個人等に対し、名誉を毀損する行為や、苛烈な表現・他人に不快感や嫌悪感を感じさせる表現を用いることは禁止されています。') ?></span></li>
-          <li><b><?php echo t('3. 差別的発言・ヘイトスピーチ') ?></b><span><?php echo t('人種・民族・国・性別・性的指向・病気・障がい・宗教などへの差別やヘイトスピーチに当たる投稿、又はこれらを煽動する行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('4. 知的財産権・プライバシー・肖像権等の権利侵害') ?></b><span><?php echo t('第三者の著作物・商標・肖像等を無断で掲載・利用するなど、第三者の権利を侵害する行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('5. 自殺・自傷、他人に対する危害等の予告等') ?></b><span><?php echo t('自殺や自傷行為、他人や物に対する危害を予告・示唆したり、これらの方法を具体的に提示したりする行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('6. 児童ポルノコンテンツの投稿または青少年を危険に晒す行為') ?></b><span><?php echo t('18歳未満の児童を性的に描写・搾取すると判断される画像・動画等の投稿、又は青少年を危険に晒す行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('7. わいせつ・暴力的など一般人が不快と感じる内容を投稿する行為') ?></b><span><?php echo t('わいせつ・暴力的・猟奇的、過激な描写、動物虐待等、一般人が不快だと感じる可能性のある内容の投稿は禁止されています。') ?></span></li>
-          <li><b><?php echo t('8. 出会いを目的とする行為') ?></b><span><?php echo t('面識のない他人との出会いや交際のみを目的とする投稿、又は不健全な目的で人を引き合わせる行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('9. 法令違反または法令違反につながる恐れのある行為') ?></b><span><?php echo t('投稿自体が法令違反（犯罪を含む）を構成し得る内容、又は法令違反を誘発・助長する恐れのある行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('10. 明らかな偽誤情報の拡散・流布') ?></b><span><?php echo t('明らかに事実と異なり社会的に混乱を招くおそれのある投稿や、健康被害等をもたらす可能性のある偽誤情報の拡散・流布は禁止されています。') ?></span></li>
-          <li><b><?php echo t('11. なりすまし') ?></b><span><?php echo t('ユーザー本人以外の人物や組織などになりすます行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('12. サイバーセキュリティリスクの恐れがある行為') ?></b><span><?php echo t('システムにアクセス負荷をかけたり脆弱性の詮索を行うなど、サーバー又はネットワークの機能を破壊・妨害する行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('13. サービス運営の妨害（荒らし行為）') ?></b><span><?php echo t('ユーザー間の意見交換・交流を著しく困難なものとするなど、サービスの適正な運営を阻害するおそれがある行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('14. 商用宣伝を目的とする行為') ?></b><span><?php echo t('本サービスを商業目的や広告目的に利用することは禁止されています（身元が明確かつ違法でない場合を除く）。') ?></span></li>
-          <li><b><?php echo t('15. その他当社が不適切とみなす行為') ?></b><span><?php echo t('社会通念上、他人やほかのユーザーが不快・迷惑と感じる行為や、サービスの趣旨にそぐわない行為は禁止されています。') ?></span></li>
-        </ul>
-        <span class="oc-jump-source"><?php echo t('出典：') ?><a href="https://openchat-jp.line.me/other/prohibited_activities" target="_blank" rel="noopener nofollow"><?php echo t('LINEオープンチャット 禁止規定') ?></a></span>
-        <div class="oc-jump-footer-info">
-          <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
-          <div class="oc-jump-footer-text">
-            <div class="oc-jump-footer-name-wrapper">
-              <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
-              <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
-            </div>
-          </div>
-        </div>
-        <?php if ($oc['url']) : ?>
-          <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="oc-jump-line-button openchat_link" style="max-width: 100%;">
-            <div class="oc-jump-line-button-content">
-              <?php if ($oc['join_method_type'] !== 0) : ?>
-                <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 489.4 489.4" xml:space="preserve">
-                  <path
-                    d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
-                </svg>
-              <?php endif ?>
-              <span class="text"><?php echo t('LINEで開く') ?></span>
-            </div>
-          </a>
-        <?php endif ?>
-      </section>
-    </article>
-    <?php GAd::output('siteSeparatorResponsive', true) ?>
-    <?php viewComponent('footer_inner') ?>
-  </div>
-  <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-  <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
-  <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
-</body>
+$rulesImage    = 'assets/line-guilde/line-guilde.webp';
+$rulesImageAlt = 'オープンチャット禁止事項';
 
-</html>
+$rules = [
+  ['title' => '1. 個人情報の掲載', 'desc' => '自分自身や他人の個人を特定できる情報（LINE ID・電話番号・氏名・住所・顔写真など）を掲載することは禁止されています。'],
+  ['title' => '2. 誹謗中傷・過度な批判的表現', 'desc' => '特定の個人等に対し、名誉を毀損する行為や、苛烈な表現・他人に不快感や嫌悪感を感じさせる表現を用いることは禁止されています。'],
+  ['title' => '3. 差別的発言・ヘイトスピーチ', 'desc' => '人種・民族・国・性別・性的指向・病気・障がい・宗教などへの差別やヘイトスピーチに当たる投稿、又はこれらを煽動する行為は禁止されています。'],
+  ['title' => '4. 知的財産権・プライバシー・肖像権等の権利侵害', 'desc' => '第三者の著作物・商標・肖像等を無断で掲載・利用するなど、第三者の権利を侵害する行為は禁止されています。'],
+  ['title' => '5. 自殺・自傷、他人に対する危害等の予告等', 'desc' => '自殺や自傷行為、他人や物に対する危害を予告・示唆したり、これらの方法を具体的に提示したりする行為は禁止されています。'],
+  ['title' => '6. 児童ポルノコンテンツの投稿または青少年を危険に晒す行為', 'desc' => '18歳未満の児童を性的に描写・搾取すると判断される画像・動画等の投稿、又は青少年を危険に晒す行為は禁止されています。'],
+  ['title' => '7. わいせつ・暴力的など一般人が不快と感じる内容を投稿する行為', 'desc' => 'わいせつ・暴力的・猟奇的、過激な描写、動物虐待等、一般人が不快だと感じる可能性のある内容の投稿は禁止されています。'],
+  ['title' => '8. 出会いを目的とする行為', 'desc' => '面識のない他人との出会いや交際のみを目的とする投稿、又は不健全な目的で人を引き合わせる行為は禁止されています。'],
+  ['title' => '9. 法令違反または法令違反につながる恐れのある行為', 'desc' => '投稿自体が法令違反（犯罪を含む）を構成し得る内容、又は法令違反を誘発・助長する恐れのある行為は禁止されています。'],
+  ['title' => '10. 明らかな偽誤情報の拡散・流布', 'desc' => '明らかに事実と異なり社会的に混乱を招くおそれのある投稿や、健康被害等をもたらす可能性のある偽誤情報の拡散・流布は禁止されています。'],
+  ['title' => '11. なりすまし', 'desc' => 'ユーザー本人以外の人物や組織などになりすます行為は禁止されています。'],
+  ['title' => '12. サイバーセキュリティリスクの恐れがある行為', 'desc' => 'システムにアクセス負荷をかけたり脆弱性の詮索を行うなど、サーバー又はネットワークの機能を破壊・妨害する行為は禁止されています。'],
+  ['title' => '13. サービス運営の妨害（荒らし行為）', 'desc' => 'ユーザー間の意見交換・交流を著しく困難なものとするなど、サービスの適正な運営を阻害するおそれがある行為は禁止されています。'],
+  ['title' => '14. 商用宣伝を目的とする行為', 'desc' => '本サービスを商業目的や広告目的に利用することは禁止されています（身元が明確かつ違法でない場合を除く）。'],
+  ['title' => '15. その他当社が不適切とみなす行為', 'desc' => '社会通念上、他人やほかのユーザーが不快・迷惑と感じる行為や、サービスの趣旨にそぐわない行為は禁止されています。'],
+];
+
+viewComponent('oc_jump_page', compact('_meta', '_css', 'oc', 'txt', 'rules', 'rulesImage', 'rulesImageAlt'));

--- a/app/Views/oc_content_jump.php
+++ b/app/Views/oc_content_jump.php
@@ -15,30 +15,25 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
   </style>
   <?php viewComponent('site_header') ?>
   <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
-  <?php GAd::output('siteTopRectangle', true) ?>
   <div class="unset openchat body" style="overflow: hidden; max-width: 600px;">
     <article class="unset" style="display: block;">
       <section class="oc-jump-section oc-info-section">
-        <h2 class="oc-jump-main-title">⚠️参加前の確認</h2>
-        <span class="oc-jump-instruction">以下の説明文をご確認ください。</span>
+        <h2 class="oc-jump-main-title"><?php echo t('⚠️参加前の確認') ?></h2>
+        <span class="oc-jump-instruction"><?php echo t('参加するオープンチャットの説明文をご確認ください。') ?></span>
         <div class="oc-jump-image-wrapper">
-          <img class="talkroom_banner_img" style="aspect-ratio: 1.8; border-radius: 0;"
+          <img class="talkroom_banner_img oc-jump-banner-img"
             alt="<?php echo $oc['name'] ?>"
             src="<?php echo imgUrl($oc['img_url']) ?>">
         </div>
         <div class="oc-jump-info-content">
-          <h1 class="talkroom_link_h1 unset" style="text-align: center; white-space: normal;">
-            <?php if ($oc['emblem'] === 1) : ?><span
-                class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span
-                class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
-          <div style="text-align: center;">
-            <span class="number_of_members"
-              style="color: #111; font-weight: normal;"><?php echo sprintfT('メンバー %s人', number_format($oc['member'])) ?></span>
+          <h1 class="talkroom_link_h1 unset oc-jump-chat-title"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
+          <div class="oc-jump-member-count">
+            <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('メンバー %s人', number_format($oc['member'])) ?></span>
           </div>
+          <span class="oc-jump-content-label"><?php echo t('このオープンチャットについて') ?></span>
           <div class="talkroom_description_box" id="talkroom_description_box">
             <p class="talkroom_description" id="talkroom-description">
-              <span
-                id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
+              <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
             </p>
           </div>
         </div>
@@ -46,17 +41,27 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
       <?php GAd::output('siteSeparatorWide', true) ?>
       <section class="oc-jump-section oc-rules-section">
         <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title">オープンチャットの禁止事項</h3>
-          <span class="oc-jump-instruction">以下の禁止事項をご確認後、「LINEで開く」を押してください。</span>
-          <img src="<?php echo fileUrl('assets/line-guilde/line-guilde.webp') ?>" alt="オープンチャット禁止事項"
+          <h3 class="oc-jump-section-title"><?php echo t('オープンチャットの禁止事項') ?></h3>
+          <span class="oc-jump-instruction"><?php echo t('以下の禁止事項をご確認のうえ、「LINEで開く」を押してください。') ?></span>
+          <img src="<?php echo fileUrl('assets/line-guilde/line-guilde.webp') ?>" alt="<?php echo t('オープンチャット禁止事項') ?>"
             class="oc-jump-rule-image">
         </div>
-        <div style="display: flex; flex-direction: row; align-items: center; gap: 6px; margin: 1rem;">
+        <ul class="oc-jump-rule-list">
+          <li><b><?php echo t('思いやりのある発言をしよう') ?></b><span><?php echo t('誹謗中傷や暴言、名誉や信用を傷つける行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('個人情報を大切に扱おう') ?></b><span><?php echo t('LINE ID・電話番号・住所など、個人が特定できる情報の投稿は控えましょう。') ?></span></li>
+          <li><b><?php echo t('知らない人と会わないようにしよう') ?></b><span><?php echo t('面識のない人との出会いや交際を目的とする行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('不適切な性的表現をさけよう') ?></b><span><?php echo t('露骨な性的描写やわいせつな表現・画像の投稿は禁止されています。') ?></span></li>
+          <li><b><?php echo t('著作権を守ろう') ?></b><span><?php echo t('他人の著作物を無断で投稿・利用する行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('スパム・違法行為・商用利用の禁止') ?></b><span><?php echo t('迷惑行為や法律に違反する行為、無断の宣伝・勧誘は禁止されています。') ?></span></li>
+          <li><b><?php echo t('青少年の安全を守ろう') ?></b><span><?php echo t('青少年との不健全な出会いや、危険・搾取につながる行為は一切禁止です。') ?></span></li>
+        </ul>
+        <span class="oc-jump-source"><?php echo t('出典：') ?><a href="https://guide.line.me/ja/safety/contributionStandard" target="_blank" rel="noopener nofollow"><?php echo t('LINE 投稿に関する基準') ?></a></span>
+        <div class="oc-jump-footer-info">
           <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
-          <div style="display: flex; flex-direction: column; gap: 2px;">
-            <div class="title-bar-oc-name-wrapper" style="padding-right: 1.5rem;">
-              <div class="title-bar-oc-name" style="color: #111; font-size: 12px;"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
-              <div class="title-bar-oc-member" style="color: #111; font-size: 12px;">(<?php echo formatMember($oc['member']) ?>)</div>
+          <div class="oc-jump-footer-text">
+            <div class="oc-jump-footer-name-wrapper">
+              <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
+              <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
             </div>
           </div>
         </div>

--- a/app/Views/oc_content_jump.php
+++ b/app/Views/oc_content_jump.php
@@ -47,15 +47,23 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
             class="oc-jump-rule-image">
         </div>
         <ul class="oc-jump-rule-list">
-          <li><b><?php echo t('思いやりのある発言をしよう') ?></b><span><?php echo t('誹謗中傷や暴言、名誉や信用を傷つける行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('個人情報を大切に扱おう') ?></b><span><?php echo t('LINE ID・電話番号・住所など、個人が特定できる情報の投稿は控えましょう。') ?></span></li>
-          <li><b><?php echo t('知らない人と会わないようにしよう') ?></b><span><?php echo t('面識のない人との出会いや交際を目的とする行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('不適切な性的表現をさけよう') ?></b><span><?php echo t('露骨な性的描写やわいせつな表現・画像の投稿は禁止されています。') ?></span></li>
-          <li><b><?php echo t('著作権を守ろう') ?></b><span><?php echo t('他人の著作物を無断で投稿・利用する行為は禁止されています。') ?></span></li>
-          <li><b><?php echo t('スパム・違法行為・商用利用の禁止') ?></b><span><?php echo t('迷惑行為や法律に違反する行為、無断の宣伝・勧誘は禁止されています。') ?></span></li>
-          <li><b><?php echo t('青少年の安全を守ろう') ?></b><span><?php echo t('青少年との不健全な出会いや、危険・搾取につながる行為は一切禁止です。') ?></span></li>
+          <li><b><?php echo t('1. 個人情報の掲載') ?></b><span><?php echo t('自分自身や他人の個人を特定できる情報（LINE ID・電話番号・氏名・住所・顔写真など）を掲載することは禁止されています。') ?></span></li>
+          <li><b><?php echo t('2. 誹謗中傷・過度な批判的表現') ?></b><span><?php echo t('特定の個人等に対し、名誉を毀損する行為や、苛烈な表現・他人に不快感や嫌悪感を感じさせる表現を用いることは禁止されています。') ?></span></li>
+          <li><b><?php echo t('3. 差別的発言・ヘイトスピーチ') ?></b><span><?php echo t('人種・民族・国・性別・性的指向・病気・障がい・宗教などへの差別やヘイトスピーチに当たる投稿、又はこれらを煽動する行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('4. 知的財産権・プライバシー・肖像権等の権利侵害') ?></b><span><?php echo t('第三者の著作物・商標・肖像等を無断で掲載・利用するなど、第三者の権利を侵害する行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('5. 自殺・自傷、他人に対する危害等の予告等') ?></b><span><?php echo t('自殺や自傷行為、他人や物に対する危害を予告・示唆したり、これらの方法を具体的に提示したりする行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('6. 児童ポルノコンテンツの投稿または青少年を危険に晒す行為') ?></b><span><?php echo t('18歳未満の児童を性的に描写・搾取すると判断される画像・動画等の投稿、又は青少年を危険に晒す行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('7. わいせつ・暴力的など一般人が不快と感じる内容を投稿する行為') ?></b><span><?php echo t('わいせつ・暴力的・猟奇的、過激な描写、動物虐待等、一般人が不快だと感じる可能性のある内容の投稿は禁止されています。') ?></span></li>
+          <li><b><?php echo t('8. 出会いを目的とする行為') ?></b><span><?php echo t('面識のない他人との出会いや交際のみを目的とする投稿、又は不健全な目的で人を引き合わせる行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('9. 法令違反または法令違反につながる恐れのある行為') ?></b><span><?php echo t('投稿自体が法令違反（犯罪を含む）を構成し得る内容、又は法令違反を誘発・助長する恐れのある行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('10. 明らかな偽誤情報の拡散・流布') ?></b><span><?php echo t('明らかに事実と異なり社会的に混乱を招くおそれのある投稿や、健康被害等をもたらす可能性のある偽誤情報の拡散・流布は禁止されています。') ?></span></li>
+          <li><b><?php echo t('11. なりすまし') ?></b><span><?php echo t('ユーザー本人以外の人物や組織などになりすます行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('12. サイバーセキュリティリスクの恐れがある行為') ?></b><span><?php echo t('システムにアクセス負荷をかけたり脆弱性の詮索を行うなど、サーバー又はネットワークの機能を破壊・妨害する行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('13. サービス運営の妨害（荒らし行為）') ?></b><span><?php echo t('ユーザー間の意見交換・交流を著しく困難なものとするなど、サービスの適正な運営を阻害するおそれがある行為は禁止されています。') ?></span></li>
+          <li><b><?php echo t('14. 商用宣伝を目的とする行為') ?></b><span><?php echo t('本サービスを商業目的や広告目的に利用することは禁止されています（身元が明確かつ違法でない場合を除く）。') ?></span></li>
+          <li><b><?php echo t('15. その他当社が不適切とみなす行為') ?></b><span><?php echo t('社会通念上、他人やほかのユーザーが不快・迷惑と感じる行為や、サービスの趣旨にそぐわない行為は禁止されています。') ?></span></li>
         </ul>
-        <span class="oc-jump-source"><?php echo t('出典：') ?><a href="https://guide.line.me/ja/safety/contributionStandard" target="_blank" rel="noopener nofollow"><?php echo t('LINE 投稿に関する基準') ?></a></span>
+        <span class="oc-jump-source"><?php echo t('出典：') ?><a href="https://openchat-jp.line.me/other/prohibited_activities" target="_blank" rel="noopener nofollow"><?php echo t('LINEオープンチャット 禁止規定') ?></a></span>
         <div class="oc-jump-footer-info">
           <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
           <div class="oc-jump-footer-text">

--- a/app/Views/oc_content_jump_th.php
+++ b/app/Views/oc_content_jump_th.php
@@ -221,6 +221,7 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
         <hr class="hr-bottom">
+        <span class="oc-jump-source">ที่มา：<a href="https://guide.line.me/th/safety/contributionStandard" target="_blank" rel="noopener nofollow">มาตรฐานเกี่ยวกับการโพสต์บน LINE</a></span>
       </section>
       <div class="oc-jump-footer-info">
         <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">

--- a/app/Views/oc_content_jump_th.php
+++ b/app/Views/oc_content_jump_th.php
@@ -48,8 +48,7 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
       <section class="oc-jump-section oc-rules-section">
         <div class="oc-rule-item">
           <h3 class="oc-jump-section-title">มาตรฐานเกี่ยวกับการโพสต์บน LINE</h3>
-          <span class="oc-jump-instruction">โปรดทำเครื่องหมายในแต่ละข้อด้านล่าง</span>
-          <span class="oc-jump-instruction">เมื่อทำเครื่องหมายครบทุกข้อ ปุ่ม "เปิดใน LINE" ที่อยู่ด้านล่างสุดจะใช้งานได้</span>
+          <span class="oc-jump-instruction">โปรดอ่านข้อห้ามแต่ละข้อด้านล่าง ก่อนกดปุ่ม "เปิดใน LINE" ที่อยู่ด้านล่างสุด</span>
         </div>
         <hr class="hr-bottom">
         <div class="oc-rule-item">
@@ -70,10 +69,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-general" class="oc-jump-checkbox">
-          <label for="check-general" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "ไม่นัดพบคนไม่รู้จัก" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
         <?php ad() ?>
         <h3 class="oc-jump-section-title">ไม่แชร์เนื้อหาอนาจาร</h3>
@@ -97,10 +92,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-adult" class="oc-jump-checkbox">
-          <label for="check-adult" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "ไม่แชร์เนื้อหาอนาจาร" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
         <?php ad() ?>
         <h3 class="oc-jump-section-title">สแปม</h3>
@@ -122,10 +113,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-spam" class="oc-jump-checkbox">
-          <label for="check-spam" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "สแปม" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
         <?php ad() ?>
         <h3 class="oc-jump-section-title">การใช้ LINE และ LINE Official Account ในเชิงพาณิชย์อย่างไม่เหมาะสม</h3>
@@ -147,10 +134,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-commercial" class="oc-jump-checkbox">
-          <label for="check-commercial" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "การใช้ LINE และ LINE Official Account ในเชิงพาณิชย์อย่างไม่เหมาะสม" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
         <?php ad() ?>
         <h3 class="oc-jump-section-title">การกระทำที่ก่อให้เกิดผลเสียต่อ LINE</h3>
@@ -176,10 +159,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-harmful" class="oc-jump-checkbox">
-          <label for="check-harmful" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "การกระทำที่ก่อให้เกิดผลเสียต่อ LINE" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
         <?php ad() ?>
         <h3 class="oc-jump-section-title">ไม่ทำให้ผู้อื่นขุ่นเคืองใจ</h3>
@@ -201,10 +180,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-offensive" class="oc-jump-checkbox">
-          <label for="check-offensive" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "ไม่ทำให้ผู้อื่นขุ่นเคืองใจ" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
         <?php ad() ?>
         <h3 class="oc-jump-section-title">การกระทำที่ผิดกฎหมายและการกระทำเพื่อสนับสนุน</h3>
@@ -228,10 +203,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-illegal" class="oc-jump-checkbox">
-          <label for="check-illegal" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "การกระทำที่ผิดกฎหมายและการกระทำเพื่อสนับสนุน" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
         <?php ad() ?>
         <h3 class="oc-jump-section-title">ข้อห้ามอื่นๆ</h3>
@@ -249,10 +220,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <br>
           หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
         </span>
-        <div class="oc-jump-checkbox-wrapper">
-          <input type="checkbox" id="check-other" class="oc-jump-checkbox">
-          <label for="check-other" class="oc-jump-checkbox-label-th">ฉันยืนยันว่าได้ตรวจสอบข้อ "ข้อห้ามอื่นๆ" แล้ว</label>
-        </div>
         <hr class="hr-bottom">
       </section>
       <div class="oc-jump-footer-info">
@@ -265,9 +232,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
         </div>
       </div>
       <?php if ($oc['url']) : ?>
-        <div id="checkbox-warning" class="oc-jump-checkbox-warning">
-          ※ โปรดทำเครื่องหมายในช่องตรวจสอบสำหรับทุกข้อ
-        </div>
         <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button">
           <div class="oc-jump-line-button-content">
             <?php if ($oc['join_method_type'] !== 0) : ?>
@@ -286,48 +250,6 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
   <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
   <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
-  <script>
-    // Check the status of checkboxes and toggle button enable/disable
-    function checkAllCheckboxes() {
-      const checkboxes = document.querySelectorAll('input[type="checkbox"]');
-
-      const allChecked = Array.from(checkboxes).every(checkbox => checkbox.checked);
-
-      const button = document.getElementById('line-open-button');
-      const warning = document.getElementById('checkbox-warning');
-
-      if (button) {
-        if (allChecked) {
-          // Enable button when all checkboxes are checked
-          button.style.opacity = '1';
-          button.style.pointerEvents = 'auto';
-          if (warning) {
-            warning.style.display = 'none';
-          }
-        } else {
-          // Disable button when checkboxes are incomplete
-          button.style.opacity = '0.5';
-          button.style.pointerEvents = 'none';
-          if (warning) {
-            warning.style.display = 'block';
-          }
-        }
-      }
-    }
-
-    // Execute on page load and checkbox changes
-    document.addEventListener('DOMContentLoaded', function() {
-      // Add event listeners to each checkbox
-      const checkboxes = document.querySelectorAll('input[type="checkbox"]');
-
-      checkboxes.forEach(checkbox => {
-        checkbox.addEventListener('change', checkAllCheckboxes);
-      });
-    });
-
-    // Check initial state
-    checkAllCheckboxes();
-  </script>
 </body>
 
 </html>

--- a/app/Views/oc_content_jump_th.php
+++ b/app/Views/oc_content_jump_th.php
@@ -1,87 +1,31 @@
-<!DOCTYPE html>
-<html lang="<?php echo t('ja') ?>">
 <?php
 
-use App\Views\Ads\GoogleAdsense as GAd;
+/** หน้ายืนยันก่อนเข้าร่วม (ไทย). โครงเค้าหน้าอยู่ที่ components/oc_jump_page
+ *  ที่มาข้อห้าม: LINE Safety Center「มาตรฐานเกี่ยวกับการโพสต์บน LINE」 */
 
-$_css[] = 'oc-jump';
-viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']); ?>
+$htmlLang = t('ja'); // translation.json: ja => th
 
-<body>
-  <style>
-    .responsive-google-parent {
-      padding: 0;
-    }
-  </style>
-  <?php viewComponent('site_header') ?>
-  <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
-  <div class="unset openchat body" style="overflow: hidden; max-width: 600px;">
-    <article class="unset" style="display: block;">
-      <section class="oc-jump-section oc-info-section">
-        <h2 class="oc-jump-main-title">⚠️โปรดอ่านก่อนเข้าร่วม</h2>
-        <span class="oc-jump-instruction">โปรดตรวจสอบรายละเอียดของ Open Chat ที่จะเข้าร่วม</span>
-        <div class="oc-jump-image-wrapper">
-          <img class="talkroom_banner_img oc-jump-banner-img" alt="<?php echo $oc['name'] ?>" src="<?php echo imgUrl($oc['img_url']) ?>">
-        </div>
-        <div class="oc-jump-info-content">
-          <h1 class="talkroom_link_h1 unset oc-jump-chat-title"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
-          <div class="oc-jump-member-count">
-            <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('สมาชิก %s คน', number_format($oc['member'])) ?></span>
-          </div>
-          <span class="oc-jump-content-label">เกี่ยวกับ Open Chat นี้</span>
-          <div class="talkroom_description_box" id="talkroom_description_box">
-            <p class="talkroom_description" id="talkroom-description">
-              <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
-            </p>
-          </div>
-        </div>
-      </section>
-      <?php GAd::output('siteSeparatorWide', true) ?>
-      <section class="oc-jump-section oc-rules-section">
-        <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title">มาตรฐานเกี่ยวกับการโพสต์บน LINE</h3>
-          <span class="oc-jump-instruction">โปรดอ่านข้อห้ามแต่ละข้อด้านล่าง ก่อนกดปุ่ม "เปิดใน LINE" ที่อยู่ด้านล่างสุด</span>
-        </div>
-        <ul class="oc-jump-rule-list">
-          <li><b>ไม่นัดพบคนไม่รู้จัก</b><span>LINE คือเครื่องมือติดต่อสื่อสารกับคนที่คุณรู้จัก ไม่แนะนำให้กระทำการที่เป็นการรบกวนหรือนัดพบกันซึ่งอาจนำไปสู่การกระทำที่ผิดกฎหมาย</span></li>
-          <li><b>ไม่แชร์เนื้อหาอนาจาร</b><span>LINE ไม่อนุญาตให้ผู้ใช้โพสต์ข้อความหรือรูปลามกอนาจาร รวมถึงการร้องขอสิ่งเหล่านั้นจากผู้อื่น</span></li>
-          <li><b>สแปม</b><span>ไม่อนุญาตให้ใช้วิธีการติดต่อสื่อสารกับคนที่ไม่รู้จักโดยไม่เจาะจงเพื่อเพิ่มเป็นเพื่อนหรือเพิ่มในกลุ่มแชท รวมถึงห้ามทำการใดๆ ที่ LINE พิจารณาว่าเป็นสแปม หรือใช้เทคโนโลยีในการก่อกวน</span></li>
-          <li><b>การใช้ LINE ในเชิงพาณิชย์อย่างไม่เหมาะสม</b><span>ห้ามจำหน่ายสินค้า เชิญชวนผู้คน หรือรับสมัครงานใดๆ (ยกเว้นกรณีที่ได้รับอนุญาตจาก LINE) โปรดระวังการชักชวนซื้อสินค้าแบรนด์เนมปลอม บริการทางเพศ และการลงทุนเพื่อผลกำไร</span></li>
-          <li><b>การกระทำที่ก่อให้เกิดผลเสียต่อ LINE</b><span>ไม่อนุญาตให้แอบอ้างชื่อบัญชีทางการของ LINE Corporation หรือปล่อยข่าวลือที่เป็นเท็จเกี่ยวกับบริการของ LINE รวมถึงการกระทำที่รบกวนผู้ใช้ LINE</span></li>
-          <li><b>ไม่ทำให้ผู้อื่นขุ่นเคืองใจ</b><span>ไม่แชร์ข้อความหรือรูปที่ทำให้ผู้อื่นขุ่นเคืองใจ เช่น การกลั่นแกล้ง การชักชวนให้ฆ่าตัวตาย รูปภาพที่ทำให้รู้สึกไม่สบายใจ หรือลิงก์ที่มีวัตถุประสงค์เพื่อหลอกลวง</span></li>
-          <li><b>การกระทำที่ผิดกฎหมายและการกระทำเพื่อสนับสนุน</b><span>ไม่ขู่บังคับหรือเรียกร้องให้ทำสิ่งผิดกฎหมาย (เช่น อาชญากรรม การใช้ยาเสพติด) และไม่เผยแพร่การกระทำที่ผิดกฎหมายของคุณหรือบุคคลอื่น</span></li>
-          <li><b>ข้อห้ามอื่นๆ</b><span>ไม่อนุญาตให้ทำการใดๆ ที่ LINE เห็นว่าไม่เหมาะสม ที่ส่งผลต่อความปลอดภัยของผู้ใช้งานทั้งหมด เช่น การแชร์ข้อมูลส่วนบุคคล (LINE ID, คิวอาร์โค้ด, เบอร์โทรศัพท์, ที่อยู่)</span></li>
-        </ul>
-        <span class="oc-jump-source">ที่มา：<a href="https://guide.line.me/th/safety/contributionStandard" target="_blank" rel="noopener nofollow">มาตรฐานเกี่ยวกับการโพสต์บน LINE</a></span>
-        <div class="oc-jump-footer-info">
-          <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
-          <div class="oc-jump-footer-text">
-            <div class="oc-jump-footer-name-wrapper">
-              <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
-              <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
-            </div>
-          </div>
-        </div>
-        <?php if ($oc['url']) : ?>
-          <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button" style="max-width: 100%;">
-            <div class="oc-jump-line-button-content">
-              <?php if ($oc['join_method_type'] !== 0) : ?>
-                <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
-                  <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
-                </svg>
-              <?php endif ?>
-              <span class="text"><?php echo t('LINEで開く') ?></span>
-            </div>
-          </a>
-        <?php endif ?>
-      </section>
-    </article>
-    <?php GAd::output('siteSeparatorResponsive', true) ?>
-    <?php viewComponent('footer_inner') ?>
-  </div>
-  <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-  <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
-  <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
-</body>
+$txt = [
+  'noticeTitle' => 'โปรดอ่านก่อนเข้าร่วม',
+  'noticeLead'  => 'โปรดตรวจสอบรายละเอียดของ Open Chat และข้อห้ามของ LINE ก่อนเข้าร่วม',
+  'aboutLabel'  => 'เกี่ยวกับ Open Chat นี้',
+  'rulesTitle'  => 'มาตรฐานเกี่ยวกับการโพสต์บน LINE',
+  'rulesLead'   => 'โปรดอ่านข้อห้ามแต่ละข้อด้านล่าง ก่อนกดปุ่ม "เปิดใน LINE"',
+  'sourceLabel' => 'ที่มา：',
+  'sourceText'  => 'มาตรฐานเกี่ยวกับการโพสต์บน LINE',
+  'sourceUrl'   => 'https://guide.line.me/th/safety/contributionStandard',
+  'openButton'  => t('LINEで開く'),
+];
 
-</html>
+$rules = [
+  ['title' => 'ไม่นัดพบคนไม่รู้จัก', 'desc' => 'LINE คือเครื่องมือติดต่อสื่อสารกับคนที่คุณรู้จัก ไม่แนะนำให้กระทำการที่เป็นการรบกวนหรือนัดพบกันซึ่งอาจนำไปสู่การกระทำที่ผิดกฎหมาย'],
+  ['title' => 'ไม่แชร์เนื้อหาอนาจาร', 'desc' => 'LINE ไม่อนุญาตให้ผู้ใช้โพสต์ข้อความหรือรูปลามกอนาจาร รวมถึงการร้องขอสิ่งเหล่านั้นจากผู้อื่น'],
+  ['title' => 'สแปม', 'desc' => 'ไม่อนุญาตให้ใช้วิธีการติดต่อสื่อสารกับคนที่ไม่รู้จักโดยไม่เจาะจงเพื่อเพิ่มเป็นเพื่อนหรือเพิ่มในกลุ่มแชท รวมถึงห้ามทำการใดๆ ที่ LINE พิจารณาว่าเป็นสแปม หรือใช้เทคโนโลยีในการก่อกวน'],
+  ['title' => 'การใช้ LINE ในเชิงพาณิชย์อย่างไม่เหมาะสม', 'desc' => 'ห้ามจำหน่ายสินค้า เชิญชวนผู้คน หรือรับสมัครงานใดๆ (ยกเว้นกรณีที่ได้รับอนุญาตจาก LINE) โปรดระวังการชักชวนซื้อสินค้าแบรนด์เนมปลอม บริการทางเพศ และการลงทุนเพื่อผลกำไร'],
+  ['title' => 'การกระทำที่ก่อให้เกิดผลเสียต่อ LINE', 'desc' => 'ไม่อนุญาตให้แอบอ้างชื่อบัญชีทางการของ LINE Corporation หรือปล่อยข่าวลือที่เป็นเท็จเกี่ยวกับบริการของ LINE รวมถึงการกระทำที่รบกวนผู้ใช้ LINE'],
+  ['title' => 'ไม่ทำให้ผู้อื่นขุ่นเคืองใจ', 'desc' => 'ไม่แชร์ข้อความหรือรูปที่ทำให้ผู้อื่นขุ่นเคืองใจ เช่น การกลั่นแกล้ง การชักชวนให้ฆ่าตัวตาย รูปภาพที่ทำให้รู้สึกไม่สบายใจ หรือลิงก์ที่มีวัตถุประสงค์เพื่อหลอกลวง'],
+  ['title' => 'การกระทำที่ผิดกฎหมายและการกระทำเพื่อสนับสนุน', 'desc' => 'ไม่ขู่บังคับหรือเรียกร้องให้ทำสิ่งผิดกฎหมาย (เช่น อาชญากรรม การใช้ยาเสพติด) และไม่เผยแพร่การกระทำที่ผิดกฎหมายของคุณหรือบุคคลอื่น'],
+  ['title' => 'ข้อห้ามอื่นๆ', 'desc' => 'ไม่อนุญาตให้ทำการใดๆ ที่ LINE เห็นว่าไม่เหมาะสม ที่ส่งผลต่อความปลอดภัยของผู้ใช้งานทั้งหมด เช่น การแชร์ข้อมูลส่วนบุคคล (LINE ID, คิวอาร์โค้ด, เบอร์โทรศัพท์, ที่อยู่)'],
+];
+
+viewComponent('oc_jump_page', compact('_meta', '_css', 'oc', 'txt', 'rules', 'htmlLang'));

--- a/app/Views/oc_content_jump_th.php
+++ b/app/Views/oc_content_jump_th.php
@@ -2,33 +2,24 @@
 <html lang="<?php echo t('ja') ?>">
 <?php
 
-use App\Config\AppConfig;
 use App\Views\Ads\GoogleAdsense as GAd;
-
-function ad(bool $show = true)
-{
-  if (!$show) return;
-
-?>
-  <div style="margin: -24px 0;">
-    <?php GAd::output('siteSeparatorResponsive') ?>
-  </div>
-<?php
-
-}
 
 $_css[] = 'oc-jump';
 viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']); ?>
 
 <body>
+  <style>
+    .responsive-google-parent {
+      padding: 0;
+    }
+  </style>
   <?php viewComponent('site_header') ?>
-  <div class="unset openchat body" style="overflow: hidden;">
-    <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+  <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+  <div class="unset openchat body" style="overflow: hidden; max-width: 600px;">
     <article class="unset" style="display: block;">
       <section class="oc-jump-section oc-info-section">
         <h2 class="oc-jump-main-title">⚠️โปรดอ่านก่อนเข้าร่วม</h2>
-        <hr class="hr-bottom">
-        <h3 class="oc-jump-section-title">ตรวจสอบ Open Chat ที่จะเข้าร่วม</h3>
+        <span class="oc-jump-instruction">โปรดตรวจสอบรายละเอียดของ Open Chat ที่จะเข้าร่วม</span>
         <div class="oc-jump-image-wrapper">
           <img class="talkroom_banner_img oc-jump-banner-img" alt="<?php echo $oc['name'] ?>" src="<?php echo imgUrl($oc['img_url']) ?>">
         </div>
@@ -37,6 +28,7 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           <div class="oc-jump-member-count">
             <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('สมาชิก %s คน', number_format($oc['member'])) ?></span>
           </div>
+          <span class="oc-jump-content-label">เกี่ยวกับ Open Chat นี้</span>
           <div class="talkroom_description_box" id="talkroom_description_box">
             <p class="talkroom_description" id="talkroom-description">
               <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
@@ -44,208 +36,47 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           </div>
         </div>
       </section>
-      <hr class="hr-bottom">
+      <?php GAd::output('siteSeparatorWide', true) ?>
       <section class="oc-jump-section oc-rules-section">
         <div class="oc-rule-item">
           <h3 class="oc-jump-section-title">มาตรฐานเกี่ยวกับการโพสต์บน LINE</h3>
           <span class="oc-jump-instruction">โปรดอ่านข้อห้ามแต่ละข้อด้านล่าง ก่อนกดปุ่ม "เปิดใน LINE" ที่อยู่ด้านล่างสุด</span>
         </div>
-        <hr class="hr-bottom">
-        <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title">ไม่นัดพบคนไม่รู้จัก</h3>
-          <b class="oc-jump-rule-title">ไม่นัดพบเพศตรงข้ามที่ไม่รู้จัก หรือชักชวนมีเพศสัมพันธ์ที่ผิดกฎหมาย</b>
-        <span class="oc-jump-rule-description">
-          LINE คือเครื่องมือติดต่อสื่อสารกับคนที่คุณรู้จัก ไม่แนะนำให้กระทำการที่เป็นการรบกวนหรือนัดพบกันซึ่งอาจนำไปสู่การกระทำที่ผิดกฎหมาย
-          <br>
-          <br>
-          ・"ฉันกำลังหาแฟน" (หาคู่รักเพื่อออกเดต)
-          <br>
-          ・"เรามาแลกข้อมูลกันนอก LINE เถอะ" (เชิญชวนให้ใช้โซเชียลเน็ตเวิร์คอื่นหรือแอปพลิเคชันหาคู่)
-          <br>
-          ・"ยินดีที่ได้รู้จัก มาเข้ากลุ่มเราไหม" (เชิญคนที่ไม่รู้จักให้มาเข้ากลุ่มแชท)
-          <br>
-          ・การกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">ไม่แชร์เนื้อหาอนาจาร</h3>
-        <b class="oc-jump-rule-title">ไม่อนุญาตให้โพสต์ข้อความที่มีการแสดงออกทางเพศหรือรูปลามกอนาจาร</b>
-        <span class="oc-jump-rule-description">
-          LINE ไม่อนุญาตให้ผู้ใช้โพสต์ข้อความหรือรูปลามกอนาจาร รวมถึงการร้องขอสิ่งเหล่านั้นจากผู้อื่น เนื้อหาที่ไม่อนุญาตมีดังต่อไปนี้
-          <br>
-          <br>
-          ・รูปภาพหรือวิดีโอที่แสดงถึงการร่วมเพศ
-          <br>
-          ・คำพูดลามกอนาจาร คำพูดเกี่ยวกับการร่วมเพศ การโพสต์ลิงก์เว็บไซต์ลามกอนาจาร
-          <br>
-          ・ภาพเปลือยที่ไม่เซ็นเซอร์
-          <br>
-          ・ภาพที่มีการแสดงออกทางเพศของเด็ก
-          <br>
-          ・ภาพลามกอนาจารของเด็ก
-          <br>
-          ・การกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">สแปม</h3>
-        <b class="oc-jump-rule-title">ไม่อนุญาตให้ก่อกวนโดยใช้วิธีทางเทคนิค</b>
-        <span class="oc-jump-rule-description">
-          LINE ให้บริการในหลายช่องทางเพื่อให้คุณได้ติดต่อสื่อสารกับคนที่รู้จัก ไม่อนุญาตให้ใช้วิธีการติดต่อสื่อสารเหล่านั้นกับคนที่ไม่รู้จักโดยไม่เจาะจงเพื่อเพิ่มเป็นเพื่อนหรือเพิ่มในกลุ่มแชท รวมถึงห้ามทำการใดๆ ที่ LINE พิจารณาว่าเป็นสแปม หรือใช้เทคโนโลยีในการกระทำที่เป็นการก่อกวน
-          <br>
-          <br>
-          ・โพสต์สติกเกอร์หรือความคิดเห็นอัตโนมัติอย่างต่อเนื่อง โดยใช้กลุ่มคำสั่งที่สามารถทำงานอัตโนมัติ หรือเครื่องมืออื่นๆ
-          <br>
-          ・โพสต์ LINE ID ลิงก์ หรือคิวอาร์โค้ดบนเว็บไซต์ภายนอกเพื่อเชิญชวนคนอื่นๆ โดยไม่เจาะจง
-          <br>
-          ・เชิญชวนผู้ใช้โดยไม่เจาะจงไปยังแอปพลิเคชันหรือเว็บไซต์หาคู่ หรือห้องแชทลามกอนาจาร
-          <br>
-          ・เชิญชวนผู้ใช้โดยไม่เจาะจงไปยังบล็อกการตลาดแบบล่องหน (การโฆษณาในรูปแบบบทความทั่วไป)
-          <br>
-          ・การกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">การใช้ LINE และ LINE Official Account ในเชิงพาณิชย์อย่างไม่เหมาะสม</h3>
-        <b class="oc-jump-rule-title">ไม่อนุญาตให้ใช้งานในเชิงพาณิชย์โดยไม่ได้รับอนุญาตจาก LINE</b>
-        <span class="oc-jump-rule-description">
-          ห้ามจำหน่ายสินค้า เชิญชวนผู้คน หรือรับสมัครงานใดๆ (ยกเว้นกรณีที่ได้รับอนุญาตจาก LINE) โปรดระวังร้านค้าที่เชิญชวนให้ซื้อสินค้าแบรนด์เนมปลอม บริการทางเพศ และข้อมูลเกี่ยวกับการลงทุนเพื่อผลกำไร
-          <br>
-          <br>
-          ・โพสต์ของร้านค้าที่นำเสนอหรือดูเหมือนมีการนำเสนอบริการทางเพศ
-          <br>
-          ・โพสต์ที่มีเนื้อหาลามกอนาจาร โพสต์ธุรกิจเครือข่าย (ธุรกิจปิระมิด) และอื่นๆ
-          <br>
-          ・โพสต์เพื่อเสนอขายข้อมูล (การลงทุนเพื่อผลกำไร การพนัน การพัฒนาตนเอง และอื่นๆ)
-          <br>
-          ・โพสต์ของร้านค้าที่นำเสนอหรือดูเหมือนมีการนำเสนอสินค้าแบรนด์เนมปลอม (จำหน่าย โฆษณา เชิญชวน)
-          <br>
-          ・ธุรกิจและการกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">การกระทำที่ก่อให้เกิดผลเสียต่อ LINE</h3>
-        <b class="oc-jump-rule-title">ไม่อนุญาตให้แอบอ้างชื่อหรือปล่อยข่าวลือที่เป็นเท็จ</b>
-        <span class="oc-jump-rule-description">
-          ไม่อนุญาตให้แอบอ้างชื่อบัญชีทางการของ LINE Corporation หรือปล่อยข่าวลือที่เป็นเท็จเกี่ยวกับบริการของ LINE รวมถึงการกระทำที่รบกวนผู้ใช้ LINE
-          <br>
-          <br>
-          ・"แจ้งข่าวจาก LINE รับสติกเกอร์ LINE ฟรีเพียงแค่คุณ 〇〇!" (แอบอ้างชื่อบัญชีทางการของ LINE Corporation)
-          <br>
-          ・"ฉันต้องการขายบัญชี LINE ของฉัน" (ละเมิดนโยบายของ LINE)
-          <br>
-          ・โพสต์ข่าวลือที่เป็นเท็จ
-          <br>
-          ・การใช้ โฆษณา จำหน่ายกลุ่มคำสั่งที่สามารถทำงานอัตโนมัติ หรือเครื่องมือที่ไม่ใช่ทางการเพื่อทำการต่อไปนี้ การกระทำที่สร้างความเสียหายให้แก่กลุ่มบริษัท LINE, การกระทำที่จงใจสร้างปัญหาให้กับ LINE ของผู้ใช้อื่น, การกระทำที่ทำให้ไม่สามารถใช้ LINE ได้ตามปกติ
-          <br>
-          ・"เพิ่มฉันเป็นเพื่อนสิ แล้วจะให้สติกเกอร์ LINE ฟรี!" (ประกาศให้ของขวัญแก่ผู้ใช้ทั่วไป)
-          <br>
-          ・"เพิ่มคนนี้เป็นเพื่อน คุณจะได้รับของขวัญ" (ประกาศให้ของขวัญโดยบุคคลที่สาม)
-          <br>
-          ・การกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">ไม่ทำให้ผู้อื่นขุ่นเคืองใจ</h3>
-        <b class="oc-jump-rule-title">ไม่ใช้คำพูดที่ทำให้ขุ่นเคืองใจและทำสิ่งที่เป็นการก่อกวน</b>
-        <span class="oc-jump-rule-description">
-          ไม่แชร์ข้อความหรือรูปที่ทำให้ผู้อื่นขุ่นเคืองใจ LINE ห้ามโพสต์เนื้อหาต่อไปนี้แม้จะไม่เป็นการผิดกฎหมายก็ตาม
-          <br>
-          <br>
-          ・คำพูดหรือรูปภาพที่สร้างความขุ่นเคืองใจต่อบุคคลใดบุคคลหนึ่ง (หรือเป็นการรังแก)
-          <br>
-          ・คำแนะนำให้ฆ่าตัวตาย
-          <br>
-          ・รูปภาพที่ทำให้คนที่เห็นรู้สึกไม่สบายใจ
-          <br>
-          ・ลิงก์ที่มีวัตถุประสงค์เพื่อหลอกลวง
-          <br>
-          ・การกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">การกระทำที่ผิดกฎหมายและการกระทำเพื่อสนับสนุน</h3>
-        <b class="oc-jump-rule-title">ห้ามการกระทำที่ผิดกฎหมาย (เช่น อาชญากรรม การใช้ยาเสพติด) และการกระทำเพื่อสนับสนุน</b>
-        <span class="oc-jump-rule-description">
-          ไม่ขู่บังคับหรือเรียกร้องให้ทำสิ่งผิดกฎหมาย และไม่เผยแพร่การกระทำที่ผิดกฎหมายของคุณหรือบุคคลอื่น
-          <br>
-          <br>
-          ・การกระทำที่เป็นอาชญากรรม
-          <br>
-          ・จำหน่ายและซื้อยาเสพติดหรือยาเสพติดที่ถูกดัดแปลงเพื่อเลี่ยงกฎหมาย (Designer drug)
-          <br>
-          ・จำหน่ายและซื้อสินค้าในราคาที่สูงเกินไปอย่างเห็นได้ชัด
-          <br>
-          ・แลกเปลี่ยนบัญชีออนไลน์ สกุลเงิน และรูปประจำตัวเป็นเงิน
-          <br>
-          ・อาชญากรรมที่ไม่รุนแรง (เช่น การดื่มสุราและสูบบุหรี่ของเยาวชน การลักขโมยสินค้าในร้าน) และการกระทำเพื่อเผยแพร่
-          <br>
-          ・การกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">ข้อห้ามอื่นๆ</h3>
-        <b class="oc-jump-rule-title">ไม่คุกคามผู้อื่น เพื่อให้ใช้งาน LINE อย่างไม่ปลอดภัย</b>
-        <span class="oc-jump-rule-description">
-          ไม่อนุญาตให้ทำการใดๆ ที่ LINE เห็นว่าไม่เหมาะสม ที่ส่งผลต่อความมั่นใจด้านความปลอดภัยของผู้ใช้งานทั้งหมด
-          <br>
-          <br>
-          ・แชร์ข้อมูลส่วนบุคคล เช่น LINE ID คิวอาร์โค้ด หมายเลขโทรศัพท์ ที่อยู่ และอื่นๆ
-          <br>
-          ・ปรับแต่งโลโก้และภาพตัวละครของ LINE ให้แสดงถึงความลามกอนาจารและความรุนแรง
-          <br>
-          ・การกระทำอื่นๆ ที่ LINE เห็นว่าไม่เหมาะสม
-          <br>
-          <br>
-          หาก LINE พบการกระทำดังกล่าวผ่านการรายงานปัญหา หรืออื่นๆ จะดำเนินการตามความเหมาะสม เช่น ซ่อนโพสต์ หรือระงับการใช้งานบัญชี (ชั่วคราวและถาวร)
-        </span>
-        <hr class="hr-bottom">
+        <ul class="oc-jump-rule-list">
+          <li><b>ไม่นัดพบคนไม่รู้จัก</b><span>LINE คือเครื่องมือติดต่อสื่อสารกับคนที่คุณรู้จัก ไม่แนะนำให้กระทำการที่เป็นการรบกวนหรือนัดพบกันซึ่งอาจนำไปสู่การกระทำที่ผิดกฎหมาย</span></li>
+          <li><b>ไม่แชร์เนื้อหาอนาจาร</b><span>LINE ไม่อนุญาตให้ผู้ใช้โพสต์ข้อความหรือรูปลามกอนาจาร รวมถึงการร้องขอสิ่งเหล่านั้นจากผู้อื่น</span></li>
+          <li><b>สแปม</b><span>ไม่อนุญาตให้ใช้วิธีการติดต่อสื่อสารกับคนที่ไม่รู้จักโดยไม่เจาะจงเพื่อเพิ่มเป็นเพื่อนหรือเพิ่มในกลุ่มแชท รวมถึงห้ามทำการใดๆ ที่ LINE พิจารณาว่าเป็นสแปม หรือใช้เทคโนโลยีในการก่อกวน</span></li>
+          <li><b>การใช้ LINE ในเชิงพาณิชย์อย่างไม่เหมาะสม</b><span>ห้ามจำหน่ายสินค้า เชิญชวนผู้คน หรือรับสมัครงานใดๆ (ยกเว้นกรณีที่ได้รับอนุญาตจาก LINE) โปรดระวังการชักชวนซื้อสินค้าแบรนด์เนมปลอม บริการทางเพศ และการลงทุนเพื่อผลกำไร</span></li>
+          <li><b>การกระทำที่ก่อให้เกิดผลเสียต่อ LINE</b><span>ไม่อนุญาตให้แอบอ้างชื่อบัญชีทางการของ LINE Corporation หรือปล่อยข่าวลือที่เป็นเท็จเกี่ยวกับบริการของ LINE รวมถึงการกระทำที่รบกวนผู้ใช้ LINE</span></li>
+          <li><b>ไม่ทำให้ผู้อื่นขุ่นเคืองใจ</b><span>ไม่แชร์ข้อความหรือรูปที่ทำให้ผู้อื่นขุ่นเคืองใจ เช่น การกลั่นแกล้ง การชักชวนให้ฆ่าตัวตาย รูปภาพที่ทำให้รู้สึกไม่สบายใจ หรือลิงก์ที่มีวัตถุประสงค์เพื่อหลอกลวง</span></li>
+          <li><b>การกระทำที่ผิดกฎหมายและการกระทำเพื่อสนับสนุน</b><span>ไม่ขู่บังคับหรือเรียกร้องให้ทำสิ่งผิดกฎหมาย (เช่น อาชญากรรม การใช้ยาเสพติด) และไม่เผยแพร่การกระทำที่ผิดกฎหมายของคุณหรือบุคคลอื่น</span></li>
+          <li><b>ข้อห้ามอื่นๆ</b><span>ไม่อนุญาตให้ทำการใดๆ ที่ LINE เห็นว่าไม่เหมาะสม ที่ส่งผลต่อความปลอดภัยของผู้ใช้งานทั้งหมด เช่น การแชร์ข้อมูลส่วนบุคคล (LINE ID, คิวอาร์โค้ด, เบอร์โทรศัพท์, ที่อยู่)</span></li>
+        </ul>
         <span class="oc-jump-source">ที่มา：<a href="https://guide.line.me/th/safety/contributionStandard" target="_blank" rel="noopener nofollow">มาตรฐานเกี่ยวกับการโพสต์บน LINE</a></span>
-      </section>
-      <div class="oc-jump-footer-info">
-        <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
-        <div class="oc-jump-footer-text">
-          <div class="oc-jump-footer-name-wrapper">
-            <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
-            <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
+        <div class="oc-jump-footer-info">
+          <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
+          <div class="oc-jump-footer-text">
+            <div class="oc-jump-footer-name-wrapper">
+              <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
+              <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
+            </div>
           </div>
         </div>
-      </div>
-      <?php if ($oc['url']) : ?>
-        <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button">
-          <div class="oc-jump-line-button-content">
-            <?php if ($oc['join_method_type'] !== 0) : ?>
-              <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
-                <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
-              </svg>
-            <?php endif ?>
-            <span class="text"><?php echo t('LINEで開く') ?></span>
-          </div>
-        </a>
-      <?php endif ?>
+        <?php if ($oc['url']) : ?>
+          <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button" style="max-width: 100%;">
+            <div class="oc-jump-line-button-content">
+              <?php if ($oc['join_method_type'] !== 0) : ?>
+                <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
+                  <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
+                </svg>
+              <?php endif ?>
+              <span class="text"><?php echo t('LINEで開く') ?></span>
+            </div>
+          </a>
+        <?php endif ?>
       </section>
     </article>
+    <?php GAd::output('siteSeparatorResponsive', true) ?>
     <?php viewComponent('footer_inner') ?>
   </div>
   <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>

--- a/app/Views/oc_content_jump_tw.php
+++ b/app/Views/oc_content_jump_tw.php
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="<?php echo t('ja') ?>">
+<?php
+
+use App\Config\AppConfig;
+use App\Views\Ads\GoogleAdsense as GAd;
+
+function ad(bool $show = true)
+{
+  if (!$show) return;
+
+?>
+  <div style="margin: -24px 0;">
+    <?php GAd::output('siteSeparatorResponsive') ?>
+  </div>
+<?php
+
+}
+
+$_css[] = 'oc-jump';
+viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']); ?>
+
+<body>
+  <?php viewComponent('site_header') ?>
+  <div class="unset openchat body" style="overflow: hidden;">
+    <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+    <article class="unset" style="display: block;">
+      <section class="oc-jump-section oc-info-section">
+        <h2 class="oc-jump-main-title">⚠️加入前的確認</h2>
+        <hr class="hr-bottom">
+        <h3 class="oc-jump-section-title">確認您要加入的開放式聊天</h3>
+        <div class="oc-jump-image-wrapper">
+          <img class="talkroom_banner_img oc-jump-banner-img" alt="<?php echo $oc['name'] ?>" src="<?php echo imgUrl($oc['img_url']) ?>">
+        </div>
+        <div class="oc-jump-info-content">
+          <h1 class="talkroom_link_h1 unset oc-jump-chat-title"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
+          <div class="oc-jump-member-count">
+            <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('メンバー %s人', number_format($oc['member'])) ?></span>
+          </div>
+          <div class="talkroom_description_box" id="talkroom_description_box">
+            <p class="talkroom_description" id="talkroom-description">
+              <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
+            </p>
+          </div>
+        </div>
+      </section>
+      <hr class="hr-bottom">
+      <section class="oc-jump-section oc-rules-section">
+        <div class="oc-rule-item">
+          <h3 class="oc-jump-section-title">LINE 貼文準則</h3>
+          <span class="oc-jump-instruction">請於點擊最下方的「以LINE開啟」按鈕前，先閱讀以下各項禁止事項。</span>
+        </div>
+        <hr class="hr-bottom">
+        <div class="oc-rule-item">
+          <h3 class="oc-jump-section-title">請勿與陌生人見面</h3>
+          <b class="oc-jump-rule-title">請勿尋求違法的性交易或異性邀約</b>
+          <span class="oc-jump-rule-description">
+            LINE 是與認識的人聯繫的工具，不建議從事可能造成他人困擾、或涉及犯罪的約會邀約等行為。
+            <br>
+            <br>
+            ・「我在找交往對象」（尋找可約會的戀愛對象）
+            <br>
+            ・「我們到 LINE 以外的地方交換資訊吧」（邀請至其他社群網站或約會交友軟體）
+            <br>
+            ・「很高興認識你，要不要加入我們的群組？」（邀請陌生人加入聊天群組）
+            <br>
+            ・其他 LINE 認為不適當的行為
+            <br>
+            <br>
+            若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+          </span>
+        </div>
+        <hr class="hr-bottom">
+        <?php ad() ?>
+        <h3 class="oc-jump-section-title">請勿張貼猥褻內容</h3>
+        <b class="oc-jump-rule-title">請勿張貼含性暗示或猥褻圖片的貼文</b>
+        <span class="oc-jump-rule-description">
+          LINE 不允許使用者張貼猥褻文字或圖片，亦不允許向他人索取此類內容。不被允許的內容如下：
+          <br>
+          <br>
+          ・描繪性行為的圖片或影片
+          <br>
+          ・猥褻言詞、與性行為相關的言論、張貼色情網站連結
+          <br>
+          ・未經修飾的裸體圖片
+          <br>
+          ・含有兒童少年性表現的圖片
+          <br>
+          ・兒童色情圖片
+          <br>
+          ・其他 LINE 認為不適當的行為
+          <br>
+          <br>
+          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+        </span>
+        <hr class="hr-bottom">
+        <?php ad() ?>
+        <h3 class="oc-jump-section-title">濫用行為</h3>
+        <b class="oc-jump-rule-title">請勿以各種技術手法造成他人困擾</b>
+        <span class="oc-jump-rule-description">
+          LINE 提供多種管道讓您與認識的人聯繫，不允許對不特定的陌生人使用這些聯繫方式來加好友或加入群組，亦禁止任何 LINE 視為濫發訊息（spam）、或以技術手段造成困擾的行為。
+          <br>
+          <br>
+          ・使用可自動執行的指令群組或其他工具，連續張貼貼圖或自動留言
+          <br>
+          ・在外部網站張貼 LINE ID、連結或行動條碼，向不特定對象招攬
+          <br>
+          ・向不特定使用者招攬至約會交友軟體、交友網站或色情聊天室
+          <br>
+          ・向不特定使用者招攬至隱性行銷部落格（偽裝成一般文章的廣告）
+          <br>
+          ・其他 LINE 認為不適當的行為
+          <br>
+          <br>
+          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+        </span>
+        <hr class="hr-bottom">
+        <?php ad() ?>
+        <h3 class="oc-jump-section-title">以不當商業手法使用 LINE 及 LINE 官方帳號</h3>
+        <b class="oc-jump-rule-title">請勿使用未經 LINE 許可的商業手法</b>
+        <span class="oc-jump-rule-description">
+          禁止販售商品、招攬人員或徵才（經 LINE 許可者除外）。請慎防招攬購買仿冒名牌商品、性服務及營利投資資訊的店家。
+          <br>
+          <br>
+          ・提供或疑似提供性服務的店家貼文
+          <br>
+          ・含色情內容的貼文、網路直銷（金字塔式銷售）等貼文
+          <br>
+          ・販售資訊的貼文（營利投資、賭博、自我成長等）
+          <br>
+          ・提供或疑似提供仿冒名牌商品的店家貼文（販售、廣告、招攬）
+          <br>
+          ・其他 LINE 認為不適當的商業及行為
+          <br>
+          <br>
+          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+        </span>
+        <hr class="hr-bottom">
+        <?php ad() ?>
+        <h3 class="oc-jump-section-title">危害 LINE 的行為</h3>
+        <b class="oc-jump-rule-title">請勿假冒他人或散播不實謠言</b>
+        <span class="oc-jump-rule-description">
+          不允許假冒 LINE Corporation 的官方帳號名稱，或散播與 LINE 服務相關的不實謠言，以及對 LINE 使用者造成困擾的行為。
+          <br>
+          <br>
+          ・「LINE 通知您，只要您○○即可免費獲得 LINE 貼圖！」（假冒 LINE Corporation 官方帳號）
+          <br>
+          ・「我想出售我的 LINE 帳號」（違反 LINE 政策）
+          <br>
+          ・張貼不實謠言
+          <br>
+          ・使用、廣告、販售可自動執行的指令群組或非官方工具，以從事下列行為：危害 LINE 集團企業之行為、故意對其他使用者的 LINE 造成困擾之行為、使 LINE 無法正常使用之行為
+          <br>
+          ・「加我好友就送你免費 LINE 貼圖！」（向一般使用者宣告贈禮）
+          <br>
+          ・「加這個人好友，你就能獲得禮物」（由第三方宣告贈禮）
+          <br>
+          ・其他 LINE 認為不適當的行為
+          <br>
+          <br>
+          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+        </span>
+        <hr class="hr-bottom">
+        <?php ad() ?>
+        <h3 class="oc-jump-section-title">請勿讓他人感覺不舒服</h3>
+        <b class="oc-jump-rule-title">請勿使用令人不舒服的表現手法或從事騷擾行為</b>
+        <span class="oc-jump-rule-description">
+          請勿分享令他人感覺不舒服的訊息或圖片。即使未違法，LINE 仍禁止張貼下列內容。
+          <br>
+          <br>
+          ・對特定對象造成困擾的言詞或圖片（或屬於霸凌者）
+          <br>
+          ・鼓吹自殺的言論
+          <br>
+          ・讓觀看者感到不適的圖片
+          <br>
+          ・以詐騙為目的的連結
+          <br>
+          ・其他 LINE 認為不適當的行為
+          <br>
+          <br>
+          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+        </span>
+        <hr class="hr-bottom">
+        <?php ad() ?>
+        <h3 class="oc-jump-section-title">違法行為及助長違法的行為</h3>
+        <b class="oc-jump-rule-title">禁止違法行為（如犯罪、使用毒品）及助長此類行為</b>
+        <span class="oc-jump-rule-description">
+          請勿脅迫或要求他人從事違法行為，亦不得散播您本人或他人的違法行為。
+          <br>
+          <br>
+          ・構成犯罪的行為
+          <br>
+          ・販售及購買毒品或為規避法律而改造的毒品（Designer drug）
+          <br>
+          ・以明顯過高的價格販售及購買商品
+          <br>
+          ・將線上帳號、虛擬貨幣及頭像兌換成金錢
+          <br>
+          ・非重大犯罪（如未成年人飲酒吸菸、順手牽羊）及助長此類行為
+          <br>
+          ・其他 LINE 認為不適當的行為
+          <br>
+          <br>
+          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+        </span>
+        <hr class="hr-bottom">
+        <?php ad() ?>
+        <h3 class="oc-jump-section-title">其他禁止事項</h3>
+        <b class="oc-jump-rule-title">請勿做出任何危害 LINE 使用安全的行為</b>
+        <span class="oc-jump-rule-description">
+          不允許從事任何 LINE 認為不適當、且影響全體使用者安全信賴的行為。
+          <br>
+          <br>
+          ・分享個人資訊，如 LINE ID、行動條碼、電話號碼、地址等
+          <br>
+          ・將 LINE 商標及角色圖片變造為猥褻或暴力的內容
+          <br>
+          ・其他 LINE 認為不適當的行為
+          <br>
+          <br>
+          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
+        </span>
+        <hr class="hr-bottom">
+      </section>
+      <div class="oc-jump-footer-info">
+        <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
+        <div class="oc-jump-footer-text">
+          <div class="oc-jump-footer-name-wrapper">
+            <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
+            <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
+          </div>
+        </div>
+      </div>
+      <?php if ($oc['url']) : ?>
+        <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button">
+          <div class="oc-jump-line-button-content">
+            <?php if ($oc['join_method_type'] !== 0) : ?>
+              <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
+                <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
+              </svg>
+            <?php endif ?>
+            <span class="text"><?php echo t('LINEで開く') ?></span>
+          </div>
+        </a>
+      <?php endif ?>
+    </article>
+    <?php viewComponent('footer_inner') ?>
+  </div>
+  <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
+  <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
+  <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
+</body>
+
+</html>

--- a/app/Views/oc_content_jump_tw.php
+++ b/app/Views/oc_content_jump_tw.php
@@ -1,86 +1,30 @@
-<!DOCTYPE html>
-<html lang="<?php echo t('ja') ?>">
 <?php
 
-use App\Views\Ads\GoogleAdsense as GAd;
+/** 加入前確認頁面（繁體中文）。版面集中於 components/oc_jump_page
+ *  禁止事項來源: LINE 台灣官方部落格「LINE 社群使用規範」 */
 
-$_css[] = 'oc-jump';
-viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']); ?>
+$htmlLang = t('ja'); // translation.json: ja => zh-TW
 
-<body>
-  <style>
-    .responsive-google-parent {
-      padding: 0;
-    }
-  </style>
-  <?php viewComponent('site_header') ?>
-  <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
-  <div class="unset openchat body" style="overflow: hidden; max-width: 600px;">
-    <article class="unset" style="display: block;">
-      <section class="oc-jump-section oc-info-section">
-        <h2 class="oc-jump-main-title">⚠️加入前的確認</h2>
-        <span class="oc-jump-instruction">請確認您要加入的開放式聊天的說明內容</span>
-        <div class="oc-jump-image-wrapper">
-          <img class="talkroom_banner_img oc-jump-banner-img" alt="<?php echo $oc['name'] ?>" src="<?php echo imgUrl($oc['img_url']) ?>">
-        </div>
-        <div class="oc-jump-info-content">
-          <h1 class="talkroom_link_h1 unset oc-jump-chat-title"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
-          <div class="oc-jump-member-count">
-            <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('成員 %s 人', number_format($oc['member'])) ?></span>
-          </div>
-          <span class="oc-jump-content-label">關於此開放式聊天</span>
-          <div class="talkroom_description_box" id="talkroom_description_box">
-            <p class="talkroom_description" id="talkroom-description">
-              <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
-            </p>
-          </div>
-        </div>
-      </section>
-      <?php GAd::output('siteSeparatorWide', true) ?>
-      <section class="oc-jump-section oc-rules-section">
-        <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title">LINE 社群（開放式聊天）禁止事項</h3>
-          <span class="oc-jump-instruction">請於點擊最下方的「以LINE開啟」按鈕前，先閱讀以下各項禁止事項。</span>
-        </div>
-        <ul class="oc-jump-rule-list">
-          <li><b>禁止揭露個人 LINE ID</b><span>禁止在聊天內容中揭露個人 LINE ID（如果是官方帳號的 ID 則沒關係）。</span></li>
-          <li><b>禁止單獨會面相關對話</b><span>禁止在 LINE 社群中溝通與「有單獨會面意圖」的所有對話。</span></li>
-          <li><b>禁止直銷相關討論</b><span>禁止傳直銷相關討論。</span></li>
-          <li><b>禁止有害兒少內容</b><span>禁止色情、暴力、血腥、恐怖等「有害兒少身心健康」相關討論及內容。</span></li>
-          <li><b>菸酒及管制物品討論應符合法令</b><span>菸（包括雪茄、加熱菸、類菸品如電子菸等）、酒類，或法令禁止或列管兒少接觸物品之討論，應符合法令。</span></li>
-          <li><b>禁止博弈與投注</b><span>禁止博弈（包括麻將、撲克）、運動賽事投注相關討論。</span></li>
-          <li><b>禁止違法行為</b><span>禁止任何違法行為（包括禁止販售：仿冒品、活體寵物、處方箋藥物…等，任何違法行為）。</span></li>
-        </ul>
-        <span class="oc-jump-source">資料來源：<a href="https://line-tw-official.weblog.to/archives/82859412.html" target="_blank" rel="noopener nofollow">LINE 台灣官方部落格・LINE 社群使用規範</a></span>
-        <div class="oc-jump-footer-info">
-          <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
-          <div class="oc-jump-footer-text">
-            <div class="oc-jump-footer-name-wrapper">
-              <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
-              <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
-            </div>
-          </div>
-        </div>
-        <?php if ($oc['url']) : ?>
-          <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button" style="max-width: 100%;">
-            <div class="oc-jump-line-button-content">
-              <?php if ($oc['join_method_type'] !== 0) : ?>
-                <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
-                  <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
-                </svg>
-              <?php endif ?>
-              <span class="text"><?php echo t('LINEで開く') ?></span>
-            </div>
-          </a>
-        <?php endif ?>
-      </section>
-    </article>
-    <?php GAd::output('siteSeparatorResponsive', true) ?>
-    <?php viewComponent('footer_inner') ?>
-  </div>
-  <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
-  <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
-  <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
-</body>
+$txt = [
+  'noticeTitle' => '加入前的確認',
+  'noticeLead'  => '請先確認此開放式聊天的說明內容與 LINE 的各項禁止事項，再加入。',
+  'aboutLabel'  => '關於此開放式聊天',
+  'rulesTitle'  => 'LINE 社群（開放式聊天）禁止事項',
+  'rulesLead'   => '請於點擊「以LINE開啟」按鈕前，先閱讀以下各項禁止事項。',
+  'sourceLabel' => '資料來源：',
+  'sourceText'  => 'LINE 台灣官方部落格・LINE 社群使用規範',
+  'sourceUrl'   => 'https://line-tw-official.weblog.to/archives/82859412.html',
+  'openButton'  => t('LINEで開く'),
+];
 
-</html>
+$rules = [
+  ['title' => '禁止揭露個人 LINE ID', 'desc' => '禁止在聊天內容中揭露個人 LINE ID（如果是官方帳號的 ID 則沒關係）。'],
+  ['title' => '禁止單獨會面相關對話', 'desc' => '禁止在 LINE 社群中溝通與「有單獨會面意圖」的所有對話。'],
+  ['title' => '禁止直銷相關討論', 'desc' => '禁止傳直銷相關討論。'],
+  ['title' => '禁止有害兒少內容', 'desc' => '禁止色情、暴力、血腥、恐怖等「有害兒少身心健康」相關討論及內容。'],
+  ['title' => '菸酒及管制物品討論應符合法令', 'desc' => '菸（包括雪茄、加熱菸、類菸品如電子菸等）、酒類，或法令禁止或列管兒少接觸物品之討論，應符合法令。'],
+  ['title' => '禁止博弈與投注', 'desc' => '禁止博弈（包括麻將、撲克）、運動賽事投注相關討論。'],
+  ['title' => '禁止違法行為', 'desc' => '禁止任何違法行為（包括禁止販售：仿冒品、活體寵物、處方箋藥物…等，任何違法行為）。'],
+];
+
+viewComponent('oc_jump_page', compact('_meta', '_css', 'oc', 'txt', 'rules', 'htmlLang'));

--- a/app/Views/oc_content_jump_tw.php
+++ b/app/Views/oc_content_jump_tw.php
@@ -2,41 +2,33 @@
 <html lang="<?php echo t('ja') ?>">
 <?php
 
-use App\Config\AppConfig;
 use App\Views\Ads\GoogleAdsense as GAd;
-
-function ad(bool $show = true)
-{
-  if (!$show) return;
-
-?>
-  <div style="margin: -24px 0;">
-    <?php GAd::output('siteSeparatorResponsive') ?>
-  </div>
-<?php
-
-}
 
 $_css[] = 'oc-jump';
 viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']); ?>
 
 <body>
+  <style>
+    .responsive-google-parent {
+      padding: 0;
+    }
+  </style>
   <?php viewComponent('site_header') ?>
-  <div class="unset openchat body" style="overflow: hidden;">
-    <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+  <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+  <div class="unset openchat body" style="overflow: hidden; max-width: 600px;">
     <article class="unset" style="display: block;">
       <section class="oc-jump-section oc-info-section">
         <h2 class="oc-jump-main-title">⚠️加入前的確認</h2>
-        <hr class="hr-bottom">
-        <h3 class="oc-jump-section-title">確認您要加入的開放式聊天</h3>
+        <span class="oc-jump-instruction">請確認您要加入的開放式聊天的說明內容</span>
         <div class="oc-jump-image-wrapper">
           <img class="talkroom_banner_img oc-jump-banner-img" alt="<?php echo $oc['name'] ?>" src="<?php echo imgUrl($oc['img_url']) ?>">
         </div>
         <div class="oc-jump-info-content">
           <h1 class="talkroom_link_h1 unset oc-jump-chat-title"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
           <div class="oc-jump-member-count">
-            <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('メンバー %s人', number_format($oc['member'])) ?></span>
+            <span class="number_of_members oc-jump-member-text"><?php echo sprintfT('成員 %s 人', number_format($oc['member'])) ?></span>
           </div>
+          <span class="oc-jump-content-label">關於此開放式聊天</span>
           <div class="talkroom_description_box" id="talkroom_description_box">
             <p class="talkroom_description" id="talkroom-description">
               <span id="talkroom-description-btn"><?php echo trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description'])) ?></span>
@@ -44,66 +36,46 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           </div>
         </div>
       </section>
-      <hr class="hr-bottom">
+      <?php GAd::output('siteSeparatorWide', true) ?>
       <section class="oc-jump-section oc-rules-section">
         <div class="oc-rule-item">
           <h3 class="oc-jump-section-title">LINE 社群（開放式聊天）禁止事項</h3>
           <span class="oc-jump-instruction">請於點擊最下方的「以LINE開啟」按鈕前，先閱讀以下各項禁止事項。</span>
         </div>
-        <hr class="hr-bottom">
-        <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title">禁止揭露個人 LINE ID</h3>
-          <b class="oc-jump-rule-title">禁止在聊天內容中揭露個人 LINE ID（官方帳號的 ID 則不在此限）</b>
-        </div>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">禁止單獨會面相關對話</h3>
-        <b class="oc-jump-rule-title">禁止在 LINE 社群中溝通與「有單獨會面意圖」的所有對話</b>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">禁止直銷相關討論</h3>
-        <b class="oc-jump-rule-title">禁止傳送直銷相關討論</b>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">禁止有害兒少內容</h3>
-        <b class="oc-jump-rule-title">禁止色情、暴力、血腥、恐怖等「有害兒少身心健康」相關討論及內容</b>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">禁止菸酒及管制物品討論</h3>
-        <b class="oc-jump-rule-title">菸（包括雪茄、加熱菸、類菸品如電子菸等）、酒類，或法令禁止或列管兒少接觸物品之討論，應符合法令</b>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">禁止博弈與投注</h3>
-        <b class="oc-jump-rule-title">禁止博弈（包括麻將、撲克）、運動賽事投注相關討論</b>
-        <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">禁止違法行為</h3>
-        <b class="oc-jump-rule-title">禁止任何違法行為（包括禁止販售：仿冒品、活體寵物、處方箋藥物等，任何違法行為）</b>
-        <hr class="hr-bottom">
+        <ul class="oc-jump-rule-list">
+          <li><b>禁止揭露個人 LINE ID</b><span>禁止在聊天內容中揭露個人 LINE ID（如果是官方帳號的 ID 則沒關係）。</span></li>
+          <li><b>禁止單獨會面相關對話</b><span>禁止在 LINE 社群中溝通與「有單獨會面意圖」的所有對話。</span></li>
+          <li><b>禁止直銷相關討論</b><span>禁止傳直銷相關討論。</span></li>
+          <li><b>禁止有害兒少內容</b><span>禁止色情、暴力、血腥、恐怖等「有害兒少身心健康」相關討論及內容。</span></li>
+          <li><b>菸酒及管制物品討論應符合法令</b><span>菸（包括雪茄、加熱菸、類菸品如電子菸等）、酒類，或法令禁止或列管兒少接觸物品之討論，應符合法令。</span></li>
+          <li><b>禁止博弈與投注</b><span>禁止博弈（包括麻將、撲克）、運動賽事投注相關討論。</span></li>
+          <li><b>禁止違法行為</b><span>禁止任何違法行為（包括禁止販售：仿冒品、活體寵物、處方箋藥物…等，任何違法行為）。</span></li>
+        </ul>
         <span class="oc-jump-source">資料來源：<a href="https://line-tw-official.weblog.to/archives/82859412.html" target="_blank" rel="noopener nofollow">LINE 台灣官方部落格・LINE 社群使用規範</a></span>
-      </section>
-      <div class="oc-jump-footer-info">
-        <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
-        <div class="oc-jump-footer-text">
-          <div class="oc-jump-footer-name-wrapper">
-            <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
-            <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
+        <div class="oc-jump-footer-info">
+          <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
+          <div class="oc-jump-footer-text">
+            <div class="oc-jump-footer-name-wrapper">
+              <div class="oc-jump-footer-name"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></div>
+              <div class="oc-jump-footer-member">(<?php echo formatMember($oc['member']) ?>)</div>
+            </div>
           </div>
         </div>
-      </div>
-      <?php if ($oc['url']) : ?>
-        <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button">
-          <div class="oc-jump-line-button-content">
-            <?php if ($oc['join_method_type'] !== 0) : ?>
-              <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
-                <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
-              </svg>
-            <?php endif ?>
-            <span class="text"><?php echo t('LINEで開く') ?></span>
-          </div>
-        </a>
-      <?php endif ?>
+        <?php if ($oc['url']) : ?>
+          <a href="<?php echo lineAppUrl($oc) ?>" id="line-open-button" class="openchat_link oc-jump-line-button" style="max-width: 100%;">
+            <div class="oc-jump-line-button-content">
+              <?php if ($oc['join_method_type'] !== 0) : ?>
+                <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
+                  <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
+                </svg>
+              <?php endif ?>
+              <span class="text"><?php echo t('LINEで開く') ?></span>
+            </div>
+          </a>
+        <?php endif ?>
+      </section>
     </article>
+    <?php GAd::output('siteSeparatorResponsive', true) ?>
     <?php viewComponent('footer_inner') ?>
   </div>
   <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>

--- a/app/Views/oc_content_jump_tw.php
+++ b/app/Views/oc_content_jump_tw.php
@@ -47,182 +47,40 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
       <hr class="hr-bottom">
       <section class="oc-jump-section oc-rules-section">
         <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title">LINE 貼文準則</h3>
+          <h3 class="oc-jump-section-title">LINE 社群（開放式聊天）禁止事項</h3>
           <span class="oc-jump-instruction">請於點擊最下方的「以LINE開啟」按鈕前，先閱讀以下各項禁止事項。</span>
         </div>
         <hr class="hr-bottom">
         <div class="oc-rule-item">
-          <h3 class="oc-jump-section-title">請勿與陌生人見面</h3>
-          <b class="oc-jump-rule-title">請勿尋求違法的性交易或異性邀約</b>
-          <span class="oc-jump-rule-description">
-            LINE 是與認識的人聯繫的工具，不建議從事可能造成他人困擾、或涉及犯罪的約會邀約等行為。
-            <br>
-            <br>
-            ・「我在找交往對象」（尋找可約會的戀愛對象）
-            <br>
-            ・「我們到 LINE 以外的地方交換資訊吧」（邀請至其他社群網站或約會交友軟體）
-            <br>
-            ・「很高興認識你，要不要加入我們的群組？」（邀請陌生人加入聊天群組）
-            <br>
-            ・其他 LINE 認為不適當的行為
-            <br>
-            <br>
-            若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-          </span>
+          <h3 class="oc-jump-section-title">禁止揭露個人 LINE ID</h3>
+          <b class="oc-jump-rule-title">禁止在聊天內容中揭露個人 LINE ID（官方帳號的 ID 則不在此限）</b>
         </div>
         <hr class="hr-bottom">
         <?php ad() ?>
-        <h3 class="oc-jump-section-title">請勿張貼猥褻內容</h3>
-        <b class="oc-jump-rule-title">請勿張貼含性暗示或猥褻圖片的貼文</b>
-        <span class="oc-jump-rule-description">
-          LINE 不允許使用者張貼猥褻文字或圖片，亦不允許向他人索取此類內容。不被允許的內容如下：
-          <br>
-          <br>
-          ・描繪性行為的圖片或影片
-          <br>
-          ・猥褻言詞、與性行為相關的言論、張貼色情網站連結
-          <br>
-          ・未經修飾的裸體圖片
-          <br>
-          ・含有兒童少年性表現的圖片
-          <br>
-          ・兒童色情圖片
-          <br>
-          ・其他 LINE 認為不適當的行為
-          <br>
-          <br>
-          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-        </span>
+        <h3 class="oc-jump-section-title">禁止單獨會面相關對話</h3>
+        <b class="oc-jump-rule-title">禁止在 LINE 社群中溝通與「有單獨會面意圖」的所有對話</b>
         <hr class="hr-bottom">
         <?php ad() ?>
-        <h3 class="oc-jump-section-title">濫用行為</h3>
-        <b class="oc-jump-rule-title">請勿以各種技術手法造成他人困擾</b>
-        <span class="oc-jump-rule-description">
-          LINE 提供多種管道讓您與認識的人聯繫，不允許對不特定的陌生人使用這些聯繫方式來加好友或加入群組，亦禁止任何 LINE 視為濫發訊息（spam）、或以技術手段造成困擾的行為。
-          <br>
-          <br>
-          ・使用可自動執行的指令群組或其他工具，連續張貼貼圖或自動留言
-          <br>
-          ・在外部網站張貼 LINE ID、連結或行動條碼，向不特定對象招攬
-          <br>
-          ・向不特定使用者招攬至約會交友軟體、交友網站或色情聊天室
-          <br>
-          ・向不特定使用者招攬至隱性行銷部落格（偽裝成一般文章的廣告）
-          <br>
-          ・其他 LINE 認為不適當的行為
-          <br>
-          <br>
-          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-        </span>
+        <h3 class="oc-jump-section-title">禁止直銷相關討論</h3>
+        <b class="oc-jump-rule-title">禁止傳送直銷相關討論</b>
         <hr class="hr-bottom">
         <?php ad() ?>
-        <h3 class="oc-jump-section-title">以不當商業手法使用 LINE 及 LINE 官方帳號</h3>
-        <b class="oc-jump-rule-title">請勿使用未經 LINE 許可的商業手法</b>
-        <span class="oc-jump-rule-description">
-          禁止販售商品、招攬人員或徵才（經 LINE 許可者除外）。請慎防招攬購買仿冒名牌商品、性服務及營利投資資訊的店家。
-          <br>
-          <br>
-          ・提供或疑似提供性服務的店家貼文
-          <br>
-          ・含色情內容的貼文、網路直銷（金字塔式銷售）等貼文
-          <br>
-          ・販售資訊的貼文（營利投資、賭博、自我成長等）
-          <br>
-          ・提供或疑似提供仿冒名牌商品的店家貼文（販售、廣告、招攬）
-          <br>
-          ・其他 LINE 認為不適當的商業及行為
-          <br>
-          <br>
-          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-        </span>
+        <h3 class="oc-jump-section-title">禁止有害兒少內容</h3>
+        <b class="oc-jump-rule-title">禁止色情、暴力、血腥、恐怖等「有害兒少身心健康」相關討論及內容</b>
         <hr class="hr-bottom">
         <?php ad() ?>
-        <h3 class="oc-jump-section-title">危害 LINE 的行為</h3>
-        <b class="oc-jump-rule-title">請勿假冒他人或散播不實謠言</b>
-        <span class="oc-jump-rule-description">
-          不允許假冒 LINE Corporation 的官方帳號名稱，或散播與 LINE 服務相關的不實謠言，以及對 LINE 使用者造成困擾的行為。
-          <br>
-          <br>
-          ・「LINE 通知您，只要您○○即可免費獲得 LINE 貼圖！」（假冒 LINE Corporation 官方帳號）
-          <br>
-          ・「我想出售我的 LINE 帳號」（違反 LINE 政策）
-          <br>
-          ・張貼不實謠言
-          <br>
-          ・使用、廣告、販售可自動執行的指令群組或非官方工具，以從事下列行為：危害 LINE 集團企業之行為、故意對其他使用者的 LINE 造成困擾之行為、使 LINE 無法正常使用之行為
-          <br>
-          ・「加我好友就送你免費 LINE 貼圖！」（向一般使用者宣告贈禮）
-          <br>
-          ・「加這個人好友，你就能獲得禮物」（由第三方宣告贈禮）
-          <br>
-          ・其他 LINE 認為不適當的行為
-          <br>
-          <br>
-          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-        </span>
+        <h3 class="oc-jump-section-title">禁止菸酒及管制物品討論</h3>
+        <b class="oc-jump-rule-title">菸（包括雪茄、加熱菸、類菸品如電子菸等）、酒類，或法令禁止或列管兒少接觸物品之討論，應符合法令</b>
         <hr class="hr-bottom">
         <?php ad() ?>
-        <h3 class="oc-jump-section-title">請勿讓他人感覺不舒服</h3>
-        <b class="oc-jump-rule-title">請勿使用令人不舒服的表現手法或從事騷擾行為</b>
-        <span class="oc-jump-rule-description">
-          請勿分享令他人感覺不舒服的訊息或圖片。即使未違法，LINE 仍禁止張貼下列內容。
-          <br>
-          <br>
-          ・對特定對象造成困擾的言詞或圖片（或屬於霸凌者）
-          <br>
-          ・鼓吹自殺的言論
-          <br>
-          ・讓觀看者感到不適的圖片
-          <br>
-          ・以詐騙為目的的連結
-          <br>
-          ・其他 LINE 認為不適當的行為
-          <br>
-          <br>
-          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-        </span>
+        <h3 class="oc-jump-section-title">禁止博弈與投注</h3>
+        <b class="oc-jump-rule-title">禁止博弈（包括麻將、撲克）、運動賽事投注相關討論</b>
         <hr class="hr-bottom">
         <?php ad() ?>
-        <h3 class="oc-jump-section-title">違法行為及助長違法的行為</h3>
-        <b class="oc-jump-rule-title">禁止違法行為（如犯罪、使用毒品）及助長此類行為</b>
-        <span class="oc-jump-rule-description">
-          請勿脅迫或要求他人從事違法行為，亦不得散播您本人或他人的違法行為。
-          <br>
-          <br>
-          ・構成犯罪的行為
-          <br>
-          ・販售及購買毒品或為規避法律而改造的毒品（Designer drug）
-          <br>
-          ・以明顯過高的價格販售及購買商品
-          <br>
-          ・將線上帳號、虛擬貨幣及頭像兌換成金錢
-          <br>
-          ・非重大犯罪（如未成年人飲酒吸菸、順手牽羊）及助長此類行為
-          <br>
-          ・其他 LINE 認為不適當的行為
-          <br>
-          <br>
-          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-        </span>
+        <h3 class="oc-jump-section-title">禁止違法行為</h3>
+        <b class="oc-jump-rule-title">禁止任何違法行為（包括禁止販售：仿冒品、活體寵物、處方箋藥物等，任何違法行為）</b>
         <hr class="hr-bottom">
-        <?php ad() ?>
-        <h3 class="oc-jump-section-title">其他禁止事項</h3>
-        <b class="oc-jump-rule-title">請勿做出任何危害 LINE 使用安全的行為</b>
-        <span class="oc-jump-rule-description">
-          不允許從事任何 LINE 認為不適當、且影響全體使用者安全信賴的行為。
-          <br>
-          <br>
-          ・分享個人資訊，如 LINE ID、行動條碼、電話號碼、地址等
-          <br>
-          ・將 LINE 商標及角色圖片變造為猥褻或暴力的內容
-          <br>
-          ・其他 LINE 認為不適當的行為
-          <br>
-          <br>
-          若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
-        </span>
-        <hr class="hr-bottom">
-        <span class="oc-jump-source">資料來源：<a href="https://guide.line.me/tw/safety/contributionStandard" target="_blank" rel="noopener nofollow">LINE 貼文準則</a></span>
+        <span class="oc-jump-source">資料來源：<a href="https://line-tw-official.weblog.to/archives/82859412.html" target="_blank" rel="noopener nofollow">LINE 台灣官方部落格・LINE 社群使用規範</a></span>
       </section>
       <div class="oc-jump-footer-info">
         <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">

--- a/app/Views/oc_content_jump_tw.php
+++ b/app/Views/oc_content_jump_tw.php
@@ -222,6 +222,7 @@ viewComponent('oc_head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']
           若 LINE 透過檢舉等方式發現上述行為，將採取隱藏貼文或停用帳號（暫時及永久）等適當處置。
         </span>
         <hr class="hr-bottom">
+        <span class="oc-jump-source">資料來源：<a href="https://guide.line.me/tw/safety/contributionStandard" target="_blank" rel="noopener nofollow">LINE 貼文準則</a></span>
       </section>
       <div class="oc-jump-footer-info">
         <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">

--- a/public/style/oc-jump.css
+++ b/public/style/oc-jump.css
@@ -222,7 +222,7 @@
   font-weight: bold;
   color: #555;
   text-align: left;
-  margin: 0 2rem 0.25rem;
+  margin: 0 0 0.25rem;
 }
 
 /* 禁止事項: 画像とテキストの両方を出す。テキストは公式項目の箇条書き。 */

--- a/public/style/oc-jump.css
+++ b/public/style/oc-jump.css
@@ -191,3 +191,93 @@
   aspect-ratio: 1.8;
   border-radius: 0;
 }
+
+/* === Revamp 2026-05: 「説明文を読ませる」ための可読性向上 === */
+
+/* 説明文ボックス: jump では全文を読ませるのが目的。
+   room_page.css の .talkroom_description は text-align:center だが、
+   長文を読ませる用途では中央寄せは読みづらいので左寄せ・行間広めに上書きする。 */
+.oc-jump-section .talkroom_description_box {
+  margin: 0;
+  max-height: none;
+}
+
+.oc-jump-section .talkroom_description {
+  text-align: left;
+  line-height: 1.8;
+  font-size: 15px;
+  color: #222;
+}
+
+.oc-jump-section #talkroom-description-btn {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+/* 「この部屋について」など本文セクションの小見出し */
+.oc-jump-content-label {
+  display: block;
+  font-size: 13px;
+  font-weight: bold;
+  color: #555;
+  text-align: left;
+  margin: 0 2rem 0.25rem;
+}
+
+/* 禁止事項: 画像とテキストの両方を出す。テキストは公式項目の箇条書き。 */
+.oc-jump-rule-image {
+  margin: 0.5rem 0;
+}
+
+.oc-jump-rule-list {
+  margin: 1rem 2rem;
+  padding: 0;
+  list-style: none;
+  text-align: left;
+}
+
+.oc-jump-rule-list > li {
+  position: relative;
+  padding-left: 1.4em;
+  margin-bottom: 0.85rem;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #222;
+}
+
+.oc-jump-rule-list > li::before {
+  content: "🚫";
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-size: 0.95em;
+}
+
+.oc-jump-rule-list > li b {
+  display: block;
+  font-size: 14px;
+  font-weight: bold;
+  color: #111;
+  margin-bottom: 0.1rem;
+}
+
+.oc-jump-rule-list > li span {
+  display: block;
+  font-size: 13px;
+  color: #555;
+}
+
+/* 出典クレジット */
+.oc-jump-source {
+  display: block;
+  text-align: center;
+  font-size: 12px;
+  color: #888;
+  margin: 0.5rem 2rem 1rem;
+}
+
+.oc-jump-source a {
+  color: #888;
+  text-decoration: underline;
+}

--- a/public/style/oc-jump.css
+++ b/public/style/oc-jump.css
@@ -1,145 +1,390 @@
-/* OpenChat Jump Page Styles */
+/* =========================================================================
+   OpenChat 入室確認ページ (/oc/{id}/jump)  -- 2026-05 redesign
+   コンセプト: 「公式の安全確認ゲート」。落ち着いた紙色の背景に、警告=琥珀 /
+   行動=LINEグリーン の2アクセント。カード基調・余白広め・階層を明快に。
+   多言語(ja/th/tw)共通。Thai/繁体字のグリフを壊さないため本文フォントは
+   var(--font-family) を踏襲し、デザインは余白・色・罫線・影で作る。
+   ========================================================================= */
 
-/* Main sections */
-.oc-jump-section {
+:root {
+  --ocj-bg: #f6f5f3;
+  --ocj-card: #ffffff;
+  --ocj-border: #e9e7e3;
+  --ocj-ink: #1c1b19;
+  --ocj-ink-soft: #5c5953;
+  --ocj-ink-mute: #8a857d;
+  --ocj-amber: #d98a00;
+  --ocj-amber-bg: #fdf6e8;
+  --ocj-amber-line: #f0d9a8;
+  --ocj-line-green: #06c755;
+  --ocj-line-green-press: #05a647;
+  --ocj-radius: 14px;
+  --ocj-radius-sm: 10px;
+  --ocj-shadow: 0 1px 2px rgba(28, 27, 25, .04), 0 6px 18px rgba(28, 27, 25, .05);
+  --ocj-shadow-btn: 0 6px 16px rgba(6, 199, 85, .32);
+}
+
+/* ページ全体の地色（カードを浮かせる） */
+body:has(.oc-jump-wrap) {
+  background: var(--ocj-bg);
+}
+
+/* グローバルと最大幅を揃える(.openchat.body=812px)。inの過去の 600px 上書きは撤去済 */
+.oc-jump-wrap {
   display: block;
-  margin: 1rem 0;
-  width: 100%;
+  padding: 14px 14px 28px;
 }
 
-.oc-info-section {
-  display: block;
-}
-
-.oc-rules-section {
-  margin: 1rem 0;
-  width: 100%;
-}
-
-/* Titles and headings */
-.oc-jump-main-title {
-  margin: 1rem;
-  text-align: center;
-}
-
-.oc-jump-section-title {
-  margin: 1rem;
-  text-align: center;
-}
-
-/* Instructions */
-.oc-jump-instruction {
-  text-align: center;
-  display: block;
-  margin: 1rem;
-  font-size: 16px;
-}
-
-/* Image wrappers */
-.oc-jump-image-wrapper {
-  margin: 1rem 2rem;
-}
-
-/* Rule items container */
-.oc-rule-item {
-  margin-bottom: 0;
-}
-
-/* Rule images */
-.oc-jump-rule-image {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
-/* Info content area */
-.oc-jump-info-content {
-  margin: 1rem 2rem;
-  padding: 0;
+.oc-jump-stack {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 14px;
 }
 
-/* Checkbox styles */
-.oc-jump-checkbox-wrapper {
-  margin: 1rem 2rem;
+/* ---- 読み込み時のさりげない段階表示 ---- */
+@media (prefers-reduced-motion: no-preference) {
+  .oc-jump-rise {
+    opacity: 0;
+    transform: translateY(10px);
+    animation: ocjRise .55s cubic-bezier(.22, .61, .36, 1) forwards;
+  }
+  .oc-jump-rise:nth-child(1) { animation-delay: .02s; }
+  .oc-jump-rise:nth-child(2) { animation-delay: .09s; }
+  .oc-jump-rise:nth-child(3) { animation-delay: .16s; }
+  .oc-jump-rise:nth-child(4) { animation-delay: .23s; }
+  .oc-jump-rise:nth-child(5) { animation-delay: .30s; }
+}
+@keyframes ocjRise {
+  to { opacity: 1; transform: none; }
+}
+
+/* =========================================================================
+   1. 警告バナー（参加前の確認）
+   ========================================================================= */
+.oc-jump-notice {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  gap: 12px;
+  background: var(--ocj-amber-bg);
+  border: 1px solid var(--ocj-amber-line);
+  border-left: 4px solid var(--ocj-amber);
+  border-radius: var(--ocj-radius-sm);
+  padding: 14px 16px;
 }
 
-.oc-jump-checkbox {
-  width: 20px;
-  height: 20px;
-  margin-right: 10px;
-}
-
-.oc-jump-checkbox-label {
-  font-size: 15px;
-  cursor: pointer;
-}
-
-/* Warning text */
-.oc-jump-warning-text {
+.oc-jump-notice__icon {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--ocj-amber);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 26px;
   text-align: center;
-  display: block;
-  margin: 1rem;
-  font-size: 13px;
 }
 
-/* Checkbox warning */
-.oc-jump-checkbox-warning {
-  color: red;
-  font-size: 14px;
-  text-align: center;
-  margin: 0 1rem;
-  font-weight: bold;
-}
-
-/* Footer info section */
-.oc-jump-footer-info {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 6px;
-  margin: 1rem;
-}
-
-.oc-jump-footer-img {
-  /* Uses existing openchat-item-title-img styles */
-  border-radius: 99rem;
-  width: 64px;
-}
-
-.oc-jump-footer-text {
+.oc-jump-notice__body {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.oc-jump-footer-name-wrapper {
-  padding-right: 1.5rem;
-}
-
-.oc-jump-footer-name {
-  color: #111;
-  font-size: 13px;
-  font-weight: bold;
-}
-
-.oc-jump-footer-member {
-  color: #111;
-  font-size: 13px;
-  font-weight: bold;
-}
-
-/* LINE open button */
-.oc-jump-line-button {
+.oc-jump-notice__title {
+  margin: 0;
   font-size: 16px;
-  padding: 20px 20px;
-  border-radius: 8px;
-  width: calc(100% - 2rem) !important;
-  margin: 1rem;
+  font-weight: 700;
+  color: #8a5800;
+  letter-spacing: .01em;
+}
+
+.oc-jump-notice__lead {
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: #9a7320;
+}
+
+/* =========================================================================
+   共通カード
+   ========================================================================= */
+.oc-jump-card {
+  background: var(--ocj-card);
+  border: 1px solid var(--ocj-border);
+  border-radius: var(--ocj-radius);
+  box-shadow: var(--ocj-shadow);
+  overflow: hidden;
+}
+
+/* =========================================================================
+   2-4. 部屋情報カード（バナー / 名前 / メンバー数 / 説明文）
+   ========================================================================= */
+.oc-jump-banner {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1.8;
+  object-fit: cover;
+  background: #efeded;
+}
+
+.oc-jump-room {
+  padding: 16px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.oc-jump-room__title {
+  margin: 0;
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--ocj-ink);
+  text-align: left;
+  white-space: normal;
+}
+
+.oc-jump-room__title .super-icon {
+  vertical-align: middle;
+  margin-right: 3px;
+}
+
+/* メンバー数チップ */
+.oc-jump-room__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 11px;
+  background: #f3f2ef;
+  border-radius: 999px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ocj-ink-soft);
+}
+
+.oc-jump-room__meta::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ocj-line-green);
+}
+
+/* 「このオープンチャットについて」見出し */
+.oc-jump-about__label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 4px 0 2px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  color: var(--ocj-ink-mute);
+}
+
+.oc-jump-about__label::before {
+  content: "";
+  width: 3px;
+  height: 13px;
+  border-radius: 2px;
+  background: var(--ocj-line-green);
+}
+
+/* 説明文本体: jump では全文を読ませるのが目的。左寄せ・行間広め・少し小さめ */
+.oc-jump-about__body {
+  margin: 0;
+  border-radius: var(--ocj-radius-sm);
+  background: #faf9f7;
+  border: 1px solid #efedea;
+  padding: 13px 15px;
+  max-height: none;
+}
+
+.oc-jump-about__body .talkroom_description {
+  margin: 0;
+  text-align: left;
+  line-height: 1.85;
+  font-size: 13.5px;
+  color: #2c2a27;
+}
+
+.oc-jump-about__body #talkroom-description-btn {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+/* =========================================================================
+   5. 禁止事項カード
+   ========================================================================= */
+.oc-jump-rules {
+  padding: 16px 18px 14px;
+}
+
+.oc-jump-rules__head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.oc-jump-rules__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--ocj-ink);
+  text-align: left;
+}
+
+.oc-jump-rules__lead {
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--ocj-ink-soft);
+}
+
+/* 公式ガイドライン画像（任意・JAのみ） */
+.oc-jump-rules__image {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 4px 0 12px;
+  border-radius: var(--ocj-radius-sm);
+  border: 1px solid var(--ocj-border);
+}
+
+/* 禁止項目リスト: 番号バッジ + 罫線区切り */
+.oc-jump-rule-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: ocjrule;
+}
+
+.oc-jump-rule-list > li {
+  counter-increment: ocjrule;
+  position: relative;
+  padding: 12px 0 12px 34px;
+  border-top: 1px solid #f0eeea;
+}
+
+.oc-jump-rule-list > li:first-child {
+  border-top: 0;
+  padding-top: 4px;
+}
+
+.oc-jump-rule-list > li::before {
+  content: counter(ocjrule);
+  position: absolute;
+  left: 0;
+  top: 11px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #eef7f0;
+  color: #1f9d54;
+  font-size: 11.5px;
+  font-weight: 700;
+  line-height: 22px;
+  text-align: center;
+}
+
+.oc-jump-rule-list > li:first-child::before {
+  top: 3px;
+}
+
+.oc-jump-rule-list > li b {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--ocj-ink);
+  line-height: 1.5;
+  margin-bottom: 2px;
+}
+
+.oc-jump-rule-list > li span {
+  display: block;
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: var(--ocj-ink-soft);
+}
+
+/* 出典クレジット */
+.oc-jump-source {
+  display: block;
+  margin: 14px 0 2px;
+  font-size: 11.5px;
+  color: var(--ocj-ink-mute);
+  text-align: left;
+}
+
+.oc-jump-source a {
+  color: var(--ocj-ink-soft);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* =========================================================================
+   6. 入室ボタン（LINEで開く）
+   ========================================================================= */
+.oc-jump-action {
+  padding-top: 2px;
+}
+
+.oc-jump-room-mini {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 2px 12px;
+}
+
+.oc-jump-room-mini img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex: none;
+  object-fit: cover;
+}
+
+.oc-jump-room-mini__name {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ocj-ink);
+  line-height: 1.3;
+}
+
+.oc-jump-room-mini__member {
+  font-size: 12px;
+  color: var(--ocj-ink-mute);
+}
+
+.oc-jump-line-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 16px 20px;
+  background: var(--ocj-line-green);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  border-radius: 12px;
+  box-shadow: var(--ocj-shadow-btn);
+  text-decoration: none;
+  transition: transform .12s ease, background-color .12s ease, box-shadow .12s ease;
+}
+
+.oc-jump-line-button:hover {
+  background: var(--ocj-line-green-press);
+}
+
+.oc-jump-line-button:active {
+  transform: translateY(1px) scale(.995);
+  box-shadow: 0 3px 10px rgba(6, 199, 85, .3);
 }
 
 .oc-jump-line-button-content {
@@ -148,136 +393,40 @@
   justify-content: center;
 }
 
-/* Horizontal rule styles */
-.hr-bottom {
-  margin: 1rem 0;
-  width: 100%;
+.oc-jump-line-button svg {
+  height: 15px;
+  fill: #fff;
+  margin-right: 5px;
 }
 
-/* Thai specific styles */
-.oc-jump-rule-title {
+/* =========================================================================
+   広告: カード地になじませる
+   ========================================================================= */
+.oc-jump-ad {
   display: block;
-  margin: 1rem;
-  font-size: 13px;
-  font-weight: bold;
-}
-
-.oc-jump-rule-description {
-  display: block;
-  margin: 1rem;
-  font-size: 13px;
-}
-
-.oc-jump-checkbox-label-th {
-  font-size: 14px;
-  cursor: pointer;
-}
-
-/* Additional styles for new classes */
-.oc-jump-member-count {
-  text-align: center;
-}
-
-.oc-jump-member-text {
-  color: #111;
-  font-weight: normal;
-}
-
-.oc-jump-chat-title {
-  text-align: center;
-}
-
-.oc-jump-banner-img {
-  aspect-ratio: 1.8;
-  border-radius: 0;
-}
-
-/* === Revamp 2026-05: 「説明文を読ませる」ための可読性向上 === */
-
-/* 説明文ボックス: jump では全文を読ませるのが目的。
-   room_page.css の .talkroom_description は text-align:center だが、
-   長文を読ませる用途では中央寄せは読みづらいので左寄せ・行間広めに上書きする。 */
-.oc-jump-section .talkroom_description_box {
   margin: 0;
-  max-height: none;
-}
-
-.oc-jump-section .talkroom_description {
-  text-align: left;
-  line-height: 1.8;
-  font-size: 15px;
-  color: #222;
-}
-
-.oc-jump-section #talkroom-description-btn {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-}
-
-/* 「この部屋について」など本文セクションの小見出し */
-.oc-jump-content-label {
-  display: block;
-  font-size: 13px;
-  font-weight: bold;
-  color: #555;
-  text-align: left;
-  margin: 0 0 0.25rem;
-}
-
-/* 禁止事項: 画像とテキストの両方を出す。テキストは公式項目の箇条書き。 */
-.oc-jump-rule-image {
-  margin: 0.5rem 0;
-}
-
-.oc-jump-rule-list {
-  margin: 1rem 2rem;
-  padding: 0;
-  list-style: none;
-  text-align: left;
-}
-
-.oc-jump-rule-list > li {
-  position: relative;
-  padding-left: 1.4em;
-  margin-bottom: 0.85rem;
-  font-size: 14px;
-  line-height: 1.6;
-  color: #222;
-}
-
-.oc-jump-rule-list > li::before {
-  content: "🚫";
-  position: absolute;
-  left: 0;
-  top: 0;
-  font-size: 0.95em;
-}
-
-.oc-jump-rule-list > li b {
-  display: block;
-  font-size: 14px;
-  font-weight: bold;
-  color: #111;
-  margin-bottom: 0.1rem;
-}
-
-.oc-jump-rule-list > li span {
-  display: block;
-  font-size: 13px;
-  color: #555;
-}
-
-/* 出典クレジット */
-.oc-jump-source {
-  display: block;
   text-align: center;
-  font-size: 12px;
-  color: #888;
-  margin: 0.5rem 2rem 1rem;
 }
 
-.oc-jump-source a {
-  color: #888;
-  text-decoration: underline;
+.oc-jump-ad .responsive-google-parent,
+.oc-jump-ad .rectangle2-ads-parent,
+.oc-jump-ad .rectangle3-ads-parent {
+  padding: 0;
+  margin: 0 auto;
+}
+
+.responsive-google-parent {
+  padding: 0;
+}
+
+/* =========================================================================
+   レスポンシブ微調整
+   ========================================================================= */
+@media screen and (min-width: 600px) {
+  .oc-jump-wrap {
+    padding: 20px 18px 36px;
+  }
+  .oc-jump-room__title {
+    font-size: 21px;
+  }
 }


### PR DESCRIPTION
## 概要

オープンチャット入室前の「参加確認」ページ（部屋を開く前に注意事項を確認する画面）を、これまで**日本語のみ**だったものを**繁体字中国語（台湾）・タイ語でも表示**できるようにし、あわせて見た目を信頼感のあるデザインに刷新しました。

この画面は「LINEで部屋を開く」前に、その部屋の説明文とLINE公式の注意事項を確認してもらうための中間ページです。

## 主な変更

### 1. 繁体字・タイ語に対応（これまで日本語だけだった）
- 台湾・タイのユーザーも、日本語版と同じ「参加確認」画面を見られるようになりました
- 各言語の注意事項は、それぞれの**LINE公式の案内をそのまま掲載**しています
  - 日本語：LINEオープンチャット「禁止規定」（15項目）
  - タイ語：LINE公式「投稿に関する基準」（8項目）
  - 繁体字：LINE台湾公式の「社群（オープンチャット）使用ルール」（7項目）
- ※言語によって項目の数や内容が異なるのは、LINE公式自体が地域ごとに異なる案内をしているためです

### 2. 見た目を刷新（簡素すぎる印象を改善）
- 部屋情報・説明文・注意事項をカード状に整理し、落ち着いた公式感のあるデザインに
- 部屋の説明文を読みやすい組版（左寄せ・ゆったりした行間）に変更
- ページの最大幅を、部屋の詳細ページなどサイト全体と統一

### 3. 内部的な整理
- 3言語で重複していたページの作りを、共通の部品（コンポーネント）に一本化。今後の修正が1か所で済むようになりました

## 確認したこと
- 日本語・タイ語・繁体字の3言語で、実際にページが表示されエラーが出ないことをローカルで確認
- 部屋ページの「LINEで開く」ボタンから、各言語の参加確認ページに正しく遷移すること
- ※広告枠はstaging環境では表示されないため、配置はコード上で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
