### PR TITLE
[STG] fix: SNS共有・構造化データのページ種別が全ページ「サイト」になる不具合を修正

### DIFF
--- a/app/Views/Classes/Meta/Metadata.php
+++ b/app/Views/Classes/Meta/Metadata.php
@@ -27,7 +27,11 @@ class Metadata
 
     public function __construct()
     {
-        if (path('') ?? '/' === '/') {
+        // 演算子優先順位の修正: `===` は `??` より強く結合するため、
+        // 旧 `path('') ?? '/' === '/'` は `path('') ?? ('/' === '/')` = 実質 `path('')`
+        // と評価され（path() は常に非null文字列を返す）、全ページが 'website' に固定されていた。
+        // 本来の意図「トップ(=/)のみ website、下層は article」を括弧で復元する。
+        if ((path('') ?? '/') === '/') {
             $this->og_type = 'website';
         } else {
             $this->og_type = 'article';


### PR DESCRIPTION
## 問題の概要

すべてのページの OGP `og:type`（SNS 共有や検索クローラがページ種別を判定するメタ情報）が
「website」に固定されており、本来「article」であるべき個別ページ（/oc/{id} の各ルーム、
/recommend/{tag} の各テーマ一覧など）まで「サイトトップ」と同じ扱いになっていた。

### 技術的な原因

[`Metadata::__construct()`](app/Views/Classes/Meta/Metadata.php) のトップページ判定が
演算子の結合順位の誤りで機能していなかった。

```php
// 旧: === は ?? より強く結合するため path('') ?? ('/' === '/') = 実質 path()
if (path('') ?? '/' === '/') { ... }
```

`path()` は常に非 null の文字列（リクエストURI）を返すため `?? '/'` は決して発火せず、
条件式は常に truthy になり、全ページが `website` に分類されていた。

## 対処内容

括弧で意図どおりの評価順に修正し、「トップ（=/）のみ website、下層ページは article」を復元。

```php
if ((path('') ?? '/') === '/') { ... }
```

リポジトリ内の同種の `?? ... ===` 箇所は他すべて括弧付きで正しく、本箇所のみの不具合だった。
`php -l` 通過。表示への影響はなく、OGP/構造化データのページ種別の正確性のみが改善する。