### PR TITLE
[STG] feat: タイ版に「お得情報・通販セール(ดีล)」のオープンチャット一覧ページを新設

### DIFF
--- a/app/Services/Recommend/TagDefinition/Th/RecommendUpdaterTags.php
+++ b/app/Services/Recommend/TagDefinition/Th/RecommendUpdaterTags.php
@@ -20,7 +20,20 @@ class RecommendUpdaterTags implements RecommendUpdaterTagsInterface
 
     function getNameStrongTags(): array
     {
-        return [];
+        return [
+            // タイの強い検索需要「ดีล（=deal: お得情報・共同購入・通販セール）」を集約する
+            // /th/recommend ハブ。本番DBで name/desc に「ดีล」を含む部屋は約 369 件あり、
+            // 上位は WhatSale（Shopee/Lazada セール 7,823人・公式）, ดีลลับ โปรออนไลน์（5,065人）,
+            // 共同購入/プレオーダー系など EC・お得情報コミュニティが大半でブランドセーフ。
+            // 現状この需要は単一ルーム /th/oc/189451 だけに着地しており（/th/recommend に
+            // 受け皿が無い）、ハブ化で 2 枠目の検索露出を作り単一ルーム依存も分散させる。
+            //
+            // matchesTagDef は配列形式 [tag, keywords] のとき keywords のみで照合するため、
+            // 照合語にも「ดีล」を明示する。部分一致(mb_stripos)で ดีลลับ/กลุ่มดีล/บัตรดีล/
+            // ดีลสินค้า 等の派生語も同時に拾える。formatTag はタイ語を無加工で返すため
+            // ページ slug は「ดีล」になる。
+            ['ดีล', ['ดีล']],
+        ];
     }
 
     function getDescStrongTags(): array


### PR DESCRIPTION
## 概要（ユーザー影響）

タイ語ユーザーの検索需要が大きい「ดีล」（=deal：お得情報・共同購入・通販セール）について、
該当するオープンチャットをまとめた一覧ページ **/th/recommend/ดีล** を新設します。

これまでタイ版にはこのテーマの集約ページが無く、検索需要のほぼ全てが単一のルーム
（/th/oc/189451）だけに流入していました。一覧ページを設けることで検索結果にもう一つの
入口を作り、特定ルームへの一極集中も分散させます。

## 背景（データ）

- 本番DBで name/説明に「ดีล」を含む部屋は **約369件**。上位は Shopee/Lazada のセール情報
  （7,823人・公式エンブレム）、オンライン特価、共同購入・プレオーダー系など、EC・お得情報の
  コミュニティが大半で**ブランドセーフ**。
- 一方、タイSEOのクリックの大半が単一ルーム /th/oc/189451 に集中。検索需要（การดีล / กลุ่มดีล /
  นัดดีล など）に対して /th/recommend に受け皿ページが存在しなかった。
- タイ版は LINE 公式のクロール済みサブカテゴリ（2カテゴリ・約10タグ）しかタグ化しておらず、
  日本語版の 660+ タグのような独自テーマ集約の仕組みが未活用だった。

## 変更内容

[`Th\RecommendUpdaterTags::getNameStrongTags()`](app/Services/Recommend/TagDefinition/Th/RecommendUpdaterTags.php)
に `['ดีล', ['ดีล']]` を1エントリ追加するだけ。マッチング → recommend テーブル投入 →
ページ生成（200化）→ sitemap 自動登録 までは既存の言語別パイプラインに結線済み。

- `matchesTagDef` は配列形式 `[tag, keywords]` のとき keywords のみで照合するため、照合語に
  「ดีล」を明示。`mb_stripos` の部分一致で ดีลลับ / กลุ่มดีล / บัตรดีล / ดีลสินค้า などの派生語も同時に拾う。
- 大学系の「และการดีล」（出会い系隣接）も部分一致では拾うが、表示閾値（member数）を通るのは
  189451 等1〜2室のみで EC 系100室以上に埋もれる。大学特化ページは意図的に作らない方針。

## ⚠️ マージ後の必須手順（運用）

タイ版の recommend テーブルはユニークキーが無く、定期 cron の差分更新
（`updateRecommendTables()`）では新タグ定義が**既存の369室へ遡及適用されません**。
デプロイ後に一度だけフル再構築が必要です：

```bash
docker compose exec app php batch/exec/tag_update.php th
```

（`updateRecommendTables(false)` + 静的データ生成 + CDN purge を実行。管理GUIの
「全レコードに即時反映」でも可）。**これを実行するまで /th/recommend/ดีล は空ページ**に
なるため、必ず実施してください。

## 検証

- `php -l` 通過。
- タイ語マッチング（`mb_stripos` の OR/AND 展開）をサンプルのルーム名で再現確認：EC系（WhatSale /
  ดีลลับ / บัตรดีล / กลุ่มดีลสินค้า…）はMATCH、対照語（เกษตรกรมือใหม่ / K-POP…）はnon-match。
- 既存 /th/recommend/{tag}（เชียงใหม่ / สอบ）が タイ語タイトルで正常描画されることを本番で確認。
  新ページも同テンプレを使用。
- ※ recommend テーブルへの実反映と表示は上記フル再構築の実行後に確定。

## 効果検証（Check 予定：デプロイ+3週でindex化、+6週でclick寄与）

- GSC（country=tha）で /th/recommend/ดีล の impr / click / 平均掲載順位 / CTR。
- /th/oc/189451 への一極集中が分散したか（GA4 で /th/recommend の session/engRate）。
- 空ページ化していないか（impr>0 かつ掲載順位が付くか）を最優先で監視。