### PR TITLE
[STG] fix: タイ語・繁体字版ヘッダーのサイト名を統一し、タイ版スマホのメニュー崩れを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,16 +248,12 @@ Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) 
 
 ## Frontend Components
 
-### Separate Repositories
+React ソースは**このリポ内 `frontend/`**（別リポではない）。各サブdirが Vite+TS: `ranking`(ランキング) / `oc-app`(個別ルーム) / `all-room-stats` / `stats-graph` / `comments`。
 
-- Ranking pages: https://github.com/mimimiku778/Open-Chat-Graph-Frontend
-- Graph display: https://github.com/mimimiku778/Open-Chat-Graph-Frontend-Stats-Graph
-- Comments: https://github.com/mimimiku778/Open-Chat-Graph-Comments
-
-### Integration
-
-- React components embedded in PHP templates
-- Pre-built JavaScript bundles (no build process in main repo)
+- **ビルド**: `cd frontend/<name> && npm run build` → `public/js/...` にハッシュ付きバンドル出力（成果物は **gitignore**、コミット不要）。手ビルドはローカル確認用。
+- **PHP参照**: `getFilePath('js/react','main-*.js')`（内部 glob、`app/Helpers/functions.php`）でハッシュ名を解決 → HTML側の手修正は不要。
+- **翻訳**: 各 `frontend/<name>/src/config/translation.ts` は PHP の `storage/translation.json` と**別物**。両方直す。
+- **デプロイ**: `deploy.yml` が `frontend/<name>/**` の変更を検知し自動で `npm ci && npm run build` → 配信。
 
 ## Creating New Pages (MVC Pattern)
 

--- a/frontend/ranking/src/components/SiteHeader.tsx
+++ b/frontend/ranking/src/components/SiteHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box, Button, SvgIcon } from '@mui/material'
 import SiteHeaderSearch from './SiteHeaderSearch'
-import { rankingArgDto, siteUrl } from '../config/config'
+import { rankingArgDto, siteUrl, langCode } from '../config/config'
 import { t } from '../config/translation'
 
 export function BetaIcon() {
@@ -32,7 +32,7 @@ export function BetaIcon() {
 export function SiteTitleBtn() {
   return (
     <Button href={rankingArgDto.baseUrl} sx={{ p: 0, display: 'flex' }}>
-      <div className="header_site_title">
+      <div className={`header_site_title${langCode === 'th' ? ' thi' : ''}`}>
         <img src={`${siteUrl}/assets/icon-192x192.png`} alt="" />
         <h1>{t('オプチャグラフ')}</h1>
       </div>

--- a/frontend/ranking/src/config/translation.ts
+++ b/frontend/ranking/src/config/translation.ts
@@ -2,8 +2,8 @@ import { langCode } from './config'
 
 const translation = {
   オプチャグラフ: {
-    tw: 'LINE社群圖表',
-    th: 'OpenChat กราฟ',
+    tw: 'LINE社群成長統計',
+    th: 'LINE OPENCHAT\nสถิติการเติบโต',
   },
   検索: {
     tw: '搜尋',

--- a/storage/translation.json
+++ b/storage/translation.json
@@ -9,7 +9,7 @@
     "th": "LINE OPENCHAT\nสถิติการเติบโต"
   },
   "header_site_title": {
-    "th": "header_site_title",
+    "th": "header_site_title thi",
     "tw": "header_site_title"
   },
   "カテゴリーから探す": {


### PR DESCRIPTION
## 概要

タイ語/繁体字版で、ランキングページのヘッダーに表示されるサイト名がホームページと食い違って**古い名称のまま**だった。さらにタイ版はスマホ幅でサイト名が1行に潰れ、カテゴリーボタンと重なって**メニューが崩れて**いた。

## 修正

- **サイト名を統一**（ランキングReact側の名称をホームPHP側の新ブランド名に合わせる）
  - 繁体字: `LINE社群圖表` → `LINE社群成長統計`
  - タイ語: `OpenChat กราฟ` → `LINE OPENCHAT สถิติการเติบโต`
- **タイ版スマホのメニュー崩れを修正**（サイト名を2行表示に）
  - ホーム(PHP): `storage/translation.json` の `header_site_title` から `thi` クラスが欠落していた回帰を修正
  - ランキング(React): タイ語のとき `thi` クラスを付与して2行化

## 補足

- `CLAUDE.md`: 「Reactは別リポ・ビルドなし」という誤記を修正。ソースは `frontend/` 内にあり、`deploy.yml` がデプロイ時に自動ビルドする旨を追記。
- ビルド成果物（`public/js/react/`）は gitignore のためコミットに含まれない。デプロイ時に自動ビルドされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
