### PR TITLE
[STG] fix: スキーマ同期で不足している PRIMARY KEY を自動追加（タグ3テーブルが silent に非ユニークだった問題の恒久対策）

### DIFF
--- a/app/Services/Schema/Dto/ParsedTable.php
+++ b/app/Services/Schema/Dto/ParsedTable.php
@@ -18,6 +18,8 @@ final class ParsedTable
      * @param array<string,string>  $indexes         索引名 => 索引定義原文 (PRIMARY/CONSTRAINT は含めない)
      * @param list<string>          $columnOrder     スキーマ上の列出現順 (AFTER 句生成に使う)
      * @param string                $createStatement IF NOT EXISTS 化した完全な CREATE TABLE 文 (末尾セミコロン除去)
+     * @param ?string               $primaryKey      PRIMARY KEY 定義原文 (例: "PRIMARY KEY (`id`)")。無ければ null。
+     *                                                既存テーブルに PRIMARY が無い場合の「不足PKの追加」に使う。
      */
     public function __construct(
         public readonly string $name,
@@ -25,5 +27,6 @@ final class ParsedTable
         public readonly array $indexes,
         public readonly array $columnOrder,
         public readonly string $createStatement,
+        public readonly ?string $primaryKey = null,
     ) {}
 }

--- a/app/Services/Schema/README.md
+++ b/app/Services/Schema/README.md
@@ -19,11 +19,19 @@
 - `CREATE TABLE IF NOT EXISTS` (新規テーブル)
 - `ALTER TABLE ... ADD COLUMN ...` (不足カラム)
 - `ALTER TABLE ... ADD KEY/UNIQUE KEY ...` (不足索引)
+- `ALTER TABLE ... ADD PRIMARY KEY (...)` (不足PK: スキーマがPRIMARY KEYを定義し、実テーブルに
+  PRIMARYが無い場合のみ。**追加のみ**＝既存PKの変更/削除はしない)
 
 削除・変更系(`DROP` / `MODIFY` / `CHANGE`)は**構造的に作らない**(コードパスが無い)。
 冪等性は「実DBに足りない分だけ追加する」差分判定で担保。スキーマに無くDBにある要素(ドリフト)は
 **警告ログのみ・削除しない**。→ 仮にバグがあってもデータは失われない。破壊的変更・型変更・
-PRIMARY/FOREIGN KEY 追加は手動運用。
+FOREIGN KEY 追加は手動運用。
+
+> **不足PRIMARY KEYの追加について**: スキーマ刷新で既存テーブルに `PRIMARY KEY` を入れても、従来は
+> sync が反映できず silent に非ユニークのまま残る不具合があった(例: th/tw のタグ3テーブル)。
+> 現在は「PRIMARYが無いテーブルにスキーマ定義のPKを ADD」する。重複値があると ADD は失敗するが、
+> silent drift より明示エラーの方が安全(`--dry-run` で事前確認可能)。旧来の非ユニーク索引が残っていても
+> PK追加自体は可能で、冗長索引はドリフト警告で可視化される(削除は手動)。
 
 ### ロック競合・失敗時の挙動
 

--- a/app/Services/Schema/SchemaDiffer.php
+++ b/app/Services/Schema/SchemaDiffer.php
@@ -59,12 +59,21 @@ final class SchemaDiffer
             }
         }
 
-        // --- 不足索引を ADD (PRIMARY/CONSTRAINT は ParsedTable に含まれない) ---
+        // --- 不足索引を ADD (PRIMARY は別途下で扱う / CONSTRAINT は ParsedTable に含まれない) ---
         // indexDef は "UNIQUE KEY `x` (...)" 形式。ALTER TABLE ... ADD <indexDef> は MySQL/MariaDB 両対応。
         foreach ($expected->indexes as $indexName => $indexDef) {
             if (!isset($existingIdxSet[$indexName])) {
                 $ddls[] = "ALTER TABLE {$qualified} ADD {$indexDef}";
             }
+        }
+
+        // --- 不足している PRIMARY KEY を ADD (スキーマが定義しており、実テーブルに PRIMARY が無い時だけ) ---
+        // 「加算のみ」の方針を維持: 既存 PRIMARY の変更/削除はしない。スキーマ刷新で PRIMARY KEY を
+        // 入れても sync が既存テーブルへ反映できず silent に非ユニークのまま残る不具合を防ぐ。
+        // 重複値があると ADD は失敗するが、それは silent drift より明示エラーの方が安全（dry-run で事前確認可能）。
+        // 旧来の非ユニーク索引 (例 `id`) が残っていても PRIMARY 追加自体は可能（冗長索引はドリフト警告で可視化）。
+        if ($expected->primaryKey !== null && !isset($existingIdxSet['PRIMARY'])) {
+            $ddls[] = "ALTER TABLE {$qualified} ADD {$expected->primaryKey}";
         }
 
         // --- ドリフト検出 (削除はしない、警告のみ) ---

--- a/app/Services/Schema/SchemaParser.php
+++ b/app/Services/Schema/SchemaParser.php
@@ -52,13 +52,14 @@ final class SchemaParser
                 $bodyLines[] = trim($raw);
             }
 
-            [$columns, $indexes, $order] = $this->parseBody($bodyLines);
+            [$columns, $indexes, $order, $primaryKey] = $this->parseBody($bodyLines);
             $tables[$tableName] = new ParsedTable(
                 $tableName,
                 $columns,
                 $indexes,
                 $order,
                 $this->buildCreateStatement($rawLines),
+                $primaryKey,
             );
         }
 
@@ -67,13 +68,14 @@ final class SchemaParser
 
     /**
      * @param list<string> $bodyLines トリム済みの CREATE TABLE 本体行
-     * @return array{0: array<string,string>, 1: array<string,string>, 2: list<string>}
+     * @return array{0: array<string,string>, 1: array<string,string>, 2: list<string>, 3: ?string}
      */
     private function parseBody(array $bodyLines): array
     {
         $columns = [];
         $indexes = [];
         $order = [];
+        $primaryKey = null;
 
         foreach ($bodyLines as $line) {
             $def = rtrim($line, ',');
@@ -81,8 +83,10 @@ final class SchemaParser
                 continue;
             }
 
-            // PRIMARY KEY は加算対象外 (新規は CREATE 本体が持つ。既存への PRIMARY 追加は破壊的になりうるので手動)
+            // PRIMARY KEY: 定義を保持する。新規 CREATE は本体が持つので不要だが、
+            // 既存テーブルに PRIMARY が無い場合に「不足PKの追加」として ADD するために使う。
             if (preg_match('/^PRIMARY\s+KEY/i', $def)) {
+                $primaryKey = $def;
                 continue;
             }
             // FOREIGN KEY / CONSTRAINT は非スコープ
@@ -101,7 +105,7 @@ final class SchemaParser
             }
         }
 
-        return [$columns, $indexes, $order];
+        return [$columns, $indexes, $order, $primaryKey];
     }
 
     /**

--- a/app/Services/Schema/test/SchemaDifferTest.php
+++ b/app/Services/Schema/test/SchemaDifferTest.php
@@ -171,4 +171,77 @@ class SchemaDifferTest extends TestCase
             }
         }
     }
+
+    /** primaryKey 付きの ParsedTable (既存 table() に PRIMARY KEY 定義を足したもの) */
+    private function tableWithPk(): ParsedTable
+    {
+        return new ParsedTable(
+            name: 'oc_sitemap_lastmod',
+            columns: [
+                'open_chat_id'    => '`open_chat_id` int(11) NOT NULL',
+                'lastmod'         => '`lastmod` datetime NOT NULL',
+                'member_snapshot' => '`member_snapshot` int(11) NOT NULL',
+            ],
+            indexes: [
+                'lastmod' => 'KEY `lastmod` (`lastmod`)',
+            ],
+            columnOrder: ['open_chat_id', 'lastmod', 'member_snapshot'],
+            createStatement: 'CREATE TABLE IF NOT EXISTS `oc_sitemap_lastmod` (...)',
+            primaryKey: 'PRIMARY KEY (`open_chat_id`)',
+        );
+    }
+
+    public function test_missing_primary_key_is_added(): void
+    {
+        // スキーマは PRIMARY KEY を定義するが、実テーブルに PRIMARY が無い（旧 `id` 非ユニーク索引のみ等）
+        // → 不足PKとして ADD PRIMARY KEY を生成する（加算のみ。silent な非ユニーク残存を防ぐ）
+        $d = $this->differ->diff(
+            self::DB,
+            $this->tableWithPk(),
+            tableExists: true,
+            existingColumns: ['open_chat_id', 'lastmod', 'member_snapshot'],
+            existingIndexes: ['lastmod'], // PRIMARY が無い
+        );
+
+        $this->assertContains(
+            'ALTER TABLE `testdb`.`oc_sitemap_lastmod` ADD PRIMARY KEY (`open_chat_id`)',
+            $d->ddls,
+        );
+        // 破壊的キーワードは出さない
+        foreach ($d->ddls as $ddl) {
+            $this->assertDoesNotMatchRegularExpression('/\b(DROP|MODIFY|CHANGE)\b/i', $ddl);
+        }
+    }
+
+    public function test_existing_primary_key_is_not_re_added(): void
+    {
+        // 既に PRIMARY がある → ADD PRIMARY KEY は生成しない（冪等）
+        $d = $this->differ->diff(
+            self::DB,
+            $this->tableWithPk(),
+            tableExists: true,
+            existingColumns: ['open_chat_id', 'lastmod', 'member_snapshot'],
+            existingIndexes: ['PRIMARY', 'lastmod'],
+        );
+
+        foreach ($d->ddls as $ddl) {
+            $this->assertStringNotContainsString('ADD PRIMARY KEY', $ddl);
+        }
+    }
+
+    public function test_no_primary_key_in_schema_means_no_pk_ddl(): void
+    {
+        // primaryKey=null（従来どおり PK 非定義）なら、PRIMARY 不在でも ADD PRIMARY KEY は出さない
+        $d = $this->differ->diff(
+            self::DB,
+            $this->table(),
+            tableExists: true,
+            existingColumns: ['open_chat_id', 'lastmod', 'member_snapshot'],
+            existingIndexes: ['lastmod'],
+        );
+
+        foreach ($d->ddls as $ddl) {
+            $this->assertStringNotContainsString('ADD PRIMARY KEY', $ddl);
+        }
+    }
 }

--- a/app/Services/Schema/test/SchemaParserTest.php
+++ b/app/Services/Schema/test/SchemaParserTest.php
@@ -55,6 +55,20 @@ class SchemaParserTest extends TestCase
         $t = $this->parse($sql)['t'];
         $this->assertSame([], $t->indexes);
         $this->assertArrayNotHasKey('PRIMARY', $t->indexes);
+        // PRIMARY KEY は indexes には入らないが、不足PK追加のため primaryKey に原文を保持する
+        $this->assertSame('PRIMARY KEY (`id`)', $t->primaryKey);
+    }
+
+    public function test_table_without_primary_key_has_null_primary_key(): void
+    {
+        $sql = <<<SQL
+        CREATE TABLE `np` (
+          `a` int(11) NOT NULL,
+          KEY `a` (`a`)
+        ) ENGINE=InnoDB;
+        SQL;
+
+        $this->assertNull($this->parse($sql)['np']->primaryKey);
     }
 
     public function test_unique_key_with_using_btree_and_composite(): void


### PR DESCRIPTION
## 背景（実際に踏んだ不具合）

タグ定義テーブル（recommend / oc_tag / oc_tag2）はスキーマ上 `PRIMARY KEY(id)` を持つはずだが、
本番では **ja だけ PRIMARY KEY 付き、th と tw は PRIMARY KEY 無し（非ユニークな `id` 索引のみ）** という
不整合が起きていた。

原因は `sync_mysql_schema`（`SchemaParser` / `SchemaDiffer`）が **PRIMARY KEY を加算対象から完全に除外**して
いたこと（ドリフト警告すら出さない）。このためスキーマファイルで `PRIMARY KEY(id)` を定義しても、
**既に存在する本番テーブルには反映されず、silent に非ユニークのまま**残っていた（`CREATE TABLE IF NOT EXISTS`
は既存テーブルをスキップするため、新規環境でしか PK が入らない）。

## 対処（「加算のみ」の設計は維持）

- `SchemaParser`: PRIMARY KEY 定義を捨てず `ParsedTable::$primaryKey` に保持。
- `SchemaDiffer`: スキーマが PRIMARY KEY を定義し、実テーブルに PRIMARY が無い時だけ
  `ALTER TABLE ... ADD PRIMARY KEY (...)` を生成。**既存PKの変更/削除はしない**（`DROP`/`MODIFY`/`CHANGE` は従来どおり非生成）。
  - 重複値があると ADD は失敗するが、silent drift より明示エラーの方が安全（`--dry-run` で事前確認可能）。
  - 旧来の非ユニーク索引が残っていても PK 追加は可能。冗長索引はドリフト警告で可視化（削除は手動）。

## テスト
- `SchemaDifferTest`: 不足PK追加 / 既存PKは再追加しない / PK非定義なら出さない / 破壊的キーワード非生成。
- `SchemaParserTest`: PRIMARY KEY 原文の捕捉 / 非PKテーブルは `primaryKey=null`。
- `app/Services/Schema/README.md` の挙動説明を更新。
- ※ 本番3DB（ja/th/tw）のタグ3テーブルは別途手動で `PRIMARY KEY(id)` 付与済み。本PRは**今後のドリフト再発防止**（コードでの恒久対策）。

## 検証
- `php -l` 全通過。Parser/Differ は純粋クラスのため、スキーマ実ファイル(tw)で
  parse→diff のスタンドアロン検証で「不足PK→ADD PRIMARY KEY / 既存PK→冪等 / 新規→CREATEのみ / 非破壊」を確認。
