### PR TITLE
[STG] fix: 改称した人気タグ（ChatGPT・ポケモン・BNK等）の旧URLが転送されず検索流入を取りこぼす不具合を修正

### DIFF
--- a/app/Controllers/Pages/RecommendOpenChatPageController.php
+++ b/app/Controllers/Pages/RecommendOpenChatPageController.php
@@ -22,6 +22,31 @@ class RecommendOpenChatPageController
         private RecommendGrowthRepositoryInterface $recommendGrowthRepository,
     ) {}
 
+    /**
+     * リダイレクト表を大文字小文字を無視して引く。
+     *
+     * ルータ(shadow/Kernel/Dispatcher/RequestParser)が URI を strtolower 済みのため、
+     * URL の $tag は常に小文字で渡る。一方 redirects のキーは元の表記を保つので、
+     * 大文字を含むキー(例: BNK / Pokemon / Signal / GMM / ChatGPT / NBA)が
+     * case-sensitive な isset() でヒットせず、301 ではなく 410 を返していた。
+     * getValidTag() と同じく case-insensitive で照合し、旧URLのSEO資産を取りこぼさない。
+     *
+     * @param array<string,string> $redirects
+     * @return string|null 転送先タグ。該当なしは null。
+     */
+    private static function lookupRedirect(array $redirects, string $tag): ?string
+    {
+        if (isset($redirects[$tag]))
+            return $redirects[$tag];
+
+        $lowerTag = strtolower($tag);
+        foreach ($redirects as $key => $value) {
+            if (strtolower($key) === $lowerTag)
+                return $value;
+        }
+        return null;
+    }
+
     function index(
         RecommendPageList $recommendPageList,
         StaticDataFile $staticDataGeneration,
@@ -30,16 +55,18 @@ class RecommendOpenChatPageController
         AppConfig::$listLimitTopRanking = 5;
         if (MimimalCmsConfig::$urlRoot === '') {
             $redirectTags = RecommendTagFilters::redirectTags();
-            if (isset($redirectTags[$tag]))
-                return redirect('recommend/' . urlencode($redirectTags[$tag]), 301);
+            $redirectTo = self::lookupRedirect($redirectTags, $tag);
+            if ($redirectTo !== null)
+                return redirect('recommend/' . urlencode($redirectTo), 301);
 
             $extractTag = RecommendUtility::getValidTag($tag);
         } else {
             // th/tw: タグ定義刷新で改称した旧サブカテゴリ由来タグ({lang}.jsonのredirects)を
             // 301で新タグへ引き継ぎ、既存のGoogleランキング/被リンク資産を保全する。
             $redirects = JsonRecommendUpdaterTags::forLocale(MimimalCmsConfig::$urlRoot)->getMetadata('redirects');
-            if (isset($redirects[$tag]))
-                return redirect(url('recommend/' . urlencode($redirects[$tag])), 301);
+            $redirectTo = self::lookupRedirect($redirects, $tag);
+            if ($redirectTo !== null)
+                return redirect(url('recommend/' . urlencode($redirectTo)), 301);
             $extractTag = $tag;
         }
 


### PR DESCRIPTION
## 問題の概要

おすすめタグのうち、過去に名称を変更したタグの**旧URLが新タグページへ転送されず、「ページが恒久削除された(410)」として扱われていた**。Google はこれらの旧URLをインデックスから外すため、確認できただけでタイ版で約650表示/90日分（BNK・ポケモン・Signal・GMM・Fitness 等）、加えて台湾版（NBA・Netflix）・日本版（ChatGPT・PRODUCE 101 JAPAN 等）の検索流入とSEO評価を取りこぼしていた。

### 原因

ルーティングがURLを小文字化する一方、**転送表の照合が大文字・小文字を区別していた**ため、大文字を含むタグ名の旧URLが転送表にヒットせず410を返していた。日本語・タイ語など非ASCIIや小文字のみのタグ名は影響を受けないため発見が遅れていた（例: `trade`→転送OK / `Signal`→同じ転送先なのに410）。

## 対処内容

[`RecommendOpenChatPageController`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/oc-pdca/fix/recommend-redirect-case/app/Controllers/Pages/RecommendOpenChatPageController.php) の転送表の照合を、タグ判定（`getValidTag`）と同様に大文字・小文字を無視するよう修正（日本・タイ・台湾の3版共通）。

本番の実データで、修正後に旧URLが正しい新タグページ（BNK→BNK48 / ChatGPT→生成AI・ChatGPT / Signal→เทรด / NBA→籃球・NBA 等、いずれも200）へ301転送されることを検証済み。

**影響範囲**: コントローラのみ。タグ定義(JSON)やDBの再構築は不要。
