### PR TITLE
[STG] feat: ホーム「急上昇テーマ」を増加量順に改善＋トレンド取得SQLをリポジトリへ分離

### DIFF
--- a/app/Models/Repositories/Recommend/TrendingThemeRepository.php
+++ b/app/Models/Repositories/Recommend/TrendingThemeRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Repositories\Recommend;
+
+use App\Models\Repositories\DB;
+
+/**
+ * @see TrendingThemeRepositoryInterface
+ */
+class TrendingThemeRepository implements TrendingThemeRepositoryInterface
+{
+    public function fetchRisingRoomsByHour(): array
+    {
+        return DB::fetchAll(
+            "SELECT
+                t2.tag, t1.diff_member
+            FROM
+                recommend AS t2
+                JOIN statistics_ranking_hour AS t1 ON t1.open_chat_id = t2.id
+                LEFT JOIN statistics_ranking_hour24 AS t3 ON t3.open_chat_id = t1.open_chat_id
+            WHERE
+                t1.diff_member >= 4 AND t3.diff_member >= 4"
+        );
+    }
+
+    public function fetchRisingRoomsByHourAnd24h(): array
+    {
+        return DB::fetchAll(
+            "SELECT
+                t2.tag, t1.diff_member
+            FROM
+                recommend AS t2
+                JOIN statistics_ranking_hour AS t1 ON t1.open_chat_id = t2.id
+                LEFT JOIN statistics_ranking_hour24 AS t3 ON t3.open_chat_id = t1.open_chat_id
+            WHERE
+                t1.diff_member >= 3
+                AND t3.diff_member >= 10"
+        );
+    }
+
+    public function fetchRisingRoomsByDay(): array
+    {
+        return DB::fetchAll(
+            "SELECT
+                t2.tag, t1.diff_member
+            FROM
+                recommend AS t2
+                JOIN statistics_ranking_hour24 AS t1 ON t1.open_chat_id = t2.id
+                LEFT JOIN statistics_ranking_week AS t3 ON t3.open_chat_id = t1.open_chat_id
+            WHERE
+                t1.diff_member >= 6
+                OR (t3.diff_member >= 10 AND t1.diff_member >= 0)
+                OR (t3.diff_member >= 20)"
+        );
+    }
+}

--- a/app/Models/Repositories/Recommend/TrendingThemeRepositoryInterface.php
+++ b/app/Models/Repositories/Recommend/TrendingThemeRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Repositories\Recommend;
+
+/**
+ * トップページ「いま人数急増中のテーマ」の集計に使う、いま伸びている部屋の取得。
+ *
+ * recommend（部屋→タグ）と statistics_ranking_*（増減）を結合し、
+ * 各部屋の tag と増加量(diff_member)を返す。テーマ別の集計・並びは利用側
+ * (App\Services\Recommend\TopPageRecommendList) の責務とし、本リポジトリは取得のみを担う。
+ *
+ * 戻り値の各行: array{tag: ?string, diff_member: int|null}
+ */
+interface TrendingThemeRepositoryInterface
+{
+    /** 直近1hと24hの両方で増加している部屋。 */
+    public function fetchRisingRoomsByHour(): array;
+
+    /** 直近1hで増加し、かつ24hで強く増加している部屋。 */
+    public function fetchRisingRoomsByHourAnd24h(): array;
+
+    /** 24h（または週）で増加している部屋。 */
+    public function fetchRisingRoomsByDay(): array;
+}

--- a/app/Services/Recommend/TopPageRecommendList.php
+++ b/app/Services/Recommend/TopPageRecommendList.php
@@ -4,51 +4,23 @@ declare(strict_types=1);
 
 namespace App\Services\Recommend;
 
-use App\Models\Repositories\DB;
+use App\Models\Repositories\Recommend\TrendingThemeRepositoryInterface;
 use App\Services\Recommend\TagDefinition\Ja\RecommendTagFilters;
 
 class TopPageRecommendList
 {
+    public function __construct(
+        private TrendingThemeRepositoryInterface $trendingThemeRepository,
+    ) {}
+
     function getList(int $limit)
     {
-        // 「いま伸びている部屋」を tag と増加量(diff_member)つきで取得。
-        // 旧実装は tag のみ取得し「伸びている部屋の件数」順に並べていたため、
-        // 小規模な室を多数持つ大テーマが、少数でも大きく伸びているテーマより上位になりがちだった。
-        $hour = DB::fetchAll(
-            "SELECT
-                t2.tag, t1.diff_member
-            FROM
-                recommend AS t2
-                JOIN statistics_ranking_hour AS t1 ON t1.open_chat_id = t2.id
-                LEFT JOIN statistics_ranking_hour24 AS t3 ON t3.open_chat_id = t1.open_chat_id
-            WHERE
-                t1.diff_member >= 4 AND t3.diff_member >= 4"
-        );
-
-        $hour2 = DB::fetchAll(
-            "SELECT
-                t2.tag, t1.diff_member
-            FROM
-                recommend AS t2
-                JOIN statistics_ranking_hour AS t1 ON t1.open_chat_id = t2.id
-                LEFT JOIN statistics_ranking_hour24 AS t3 ON t3.open_chat_id = t1.open_chat_id
-            WHERE
-                t1.diff_member >= 3
-                AND t3.diff_member >= 10"
-        );
-
-        $hour24 = DB::fetchAll(
-            "SELECT
-                t2.tag, t1.diff_member
-            FROM
-                recommend AS t2
-                JOIN statistics_ranking_hour24 AS t1 ON t1.open_chat_id = t2.id
-                LEFT JOIN statistics_ranking_week AS t3 ON t3.open_chat_id = t1.open_chat_id
-            WHERE
-                t1.diff_member >= 6
-                OR (t3.diff_member >= 10 AND t1.diff_member >= 0)
-                OR (t3.diff_member >= 20)"
-        );
+        // 取得(SQL)はリポジトリに委譲し、本サービスはテーマ別の集計・並びに専念する。
+        // 旧実装は「伸びている部屋の件数」順だったが、小規模室を多数持つ大テーマが
+        // 少数でも大きく伸びているテーマより上位になりがちだったため、増加量合計順に改善。
+        $hour = $this->trendingThemeRepository->fetchRisingRoomsByHour();
+        $hour2 = $this->trendingThemeRepository->fetchRisingRoomsByHourAnd24h();
+        $hour24 = $this->trendingThemeRepository->fetchRisingRoomsByDay();
 
         $filter = RecommendTagFilters::getTopPageTagFilter();
 
@@ -65,9 +37,8 @@ class TopPageRecommendList
     /**
      * 「いま伸びている部屋」をテーマ別に集計し、急上昇テーマを返す。
      *
-     * - breadth: 伸びている部屋が $minCount 室以上あるテーマだけを採用（単発室のノイズ除去。旧実装の最小件数と同じ）。
-     * - intensity: 増加量(diff_member)の合計が大きい順に並べる（件数のみだった旧実装の改善点）。
-     *   同点は件数の多い順。
+     * - breadth: 伸びている部屋が $minCount 室以上あるテーマだけを採用（単発室のノイズ除去）。
+     * - intensity: 増加量(diff_member)の合計が大きい順に並べる。同点は件数の多い順。
      *
      * @param array<int,array{tag?:?string,diff_member?:int|null}> $rows
      * @param string[] $exclude 除外するタグ（トップページ用フィルタ＋既に上位段で採用済みのタグ）

--- a/app/Services/Recommend/TopPageRecommendList.php
+++ b/app/Services/Recommend/TopPageRecommendList.php
@@ -11,38 +11,35 @@ class TopPageRecommendList
 {
     function getList(int $limit)
     {
+        // 「いま伸びている部屋」を tag と増加量(diff_member)つきで取得。
+        // 旧実装は tag のみ取得し「伸びている部屋の件数」順に並べていたため、
+        // 小規模な室を多数持つ大テーマが、少数でも大きく伸びているテーマより上位になりがちだった。
         $hour = DB::fetchAll(
             "SELECT
-                t2.tag
+                t2.tag, t1.diff_member
             FROM
                 recommend AS t2
                 JOIN statistics_ranking_hour AS t1 ON t1.open_chat_id = t2.id
                 LEFT JOIN statistics_ranking_hour24 AS t3 ON t3.open_chat_id = t1.open_chat_id
             WHERE
-                t1.diff_member >= 4 AND t3.diff_member >= 4
-            ORDER BY
-                t1.id ASC",
-            args: [\PDO::FETCH_COLUMN, 0]
+                t1.diff_member >= 4 AND t3.diff_member >= 4"
         );
 
         $hour2 = DB::fetchAll(
             "SELECT
-                t2.tag
+                t2.tag, t1.diff_member
             FROM
                 recommend AS t2
                 JOIN statistics_ranking_hour AS t1 ON t1.open_chat_id = t2.id
                 LEFT JOIN statistics_ranking_hour24 AS t3 ON t3.open_chat_id = t1.open_chat_id
             WHERE
                 t1.diff_member >= 3
-                AND t3.diff_member >= 10
-            ORDER BY
-                t1.id ASC",
-            args: [\PDO::FETCH_COLUMN, 0]
+                AND t3.diff_member >= 10"
         );
 
         $hour24 = DB::fetchAll(
             "SELECT
-                t2.tag
+                t2.tag, t1.diff_member
             FROM
                 recommend AS t2
                 JOIN statistics_ranking_hour24 AS t1 ON t1.open_chat_id = t2.id
@@ -50,20 +47,47 @@ class TopPageRecommendList
             WHERE
                 t1.diff_member >= 6
                 OR (t3.diff_member >= 10 AND t1.diff_member >= 0)
-                OR (t3.diff_member >= 20)
-            ORDER BY
-                t1.id ASC",
-            args: [\PDO::FETCH_COLUMN, 0]
+                OR (t3.diff_member >= 20)"
         );
 
         $filter = RecommendTagFilters::getTopPageTagFilter();
 
-        $tags = array_filter(sortAndUniqueArray($hour), fn ($e) => $e && !in_array($e, $filter));
-        $tags1 = array_filter(sortAndUniqueArray($hour2, 3), fn ($e) => $e && !in_array($e, $filter) && !in_array($e, $tags));
+        // breadth(伸び室の件数)で足切りしつつ、intensity(増加量合計)で並べる。
+        $tags = $this->rankByMomentum($hour, 2, $filter);
+        $tags1 = $this->rankByMomentum($hour2, 3, array_merge($filter, $tags));
         $hourTags = array_merge($tags, $tags1);
 
-        $tags2 = array_filter(sortAndUniqueArray($hour24, 4), fn ($e) => $e && !in_array($e, $filter) && !in_array($e, $hourTags));
+        $tags2 = $this->rankByMomentum($hour24, 4, array_merge($filter, $hourTags));
 
         return ['hour' => $hourTags, 'hour24' => array_slice($tags2, 0, $limit)];
+    }
+
+    /**
+     * 「いま伸びている部屋」をテーマ別に集計し、急上昇テーマを返す。
+     *
+     * - breadth: 伸びている部屋が $minCount 室以上あるテーマだけを採用（単発室のノイズ除去。旧実装の最小件数と同じ）。
+     * - intensity: 増加量(diff_member)の合計が大きい順に並べる（件数のみだった旧実装の改善点）。
+     *   同点は件数の多い順。
+     *
+     * @param array<int,array{tag?:?string,diff_member?:int|null}> $rows
+     * @param string[] $exclude 除外するタグ（トップページ用フィルタ＋既に上位段で採用済みのタグ）
+     * @return string[] 増加量合計の降順のタグ名
+     */
+    private function rankByMomentum(array $rows, int $minCount, array $exclude): array
+    {
+        $excludeSet = array_flip($exclude);
+        $count = [];
+        $sum = [];
+        foreach ($rows as $row) {
+            $tag = (string)($row['tag'] ?? '');
+            if ($tag === '' || isset($excludeSet[$tag])) continue;
+            $count[$tag] = ($count[$tag] ?? 0) + 1;
+            $sum[$tag] = ($sum[$tag] ?? 0) + max(0, (int)($row['diff_member'] ?? 0));
+        }
+
+        $tags = array_keys(array_filter($count, fn($c) => $c >= $minCount));
+        usort($tags, fn($a, $b) => ($sum[$b] <=> $sum[$a]) ?: ($count[$b] <=> $count[$a]));
+
+        return $tags;
     }
 }

--- a/shared/MimimalCmsConfig.php
+++ b/shared/MimimalCmsConfig.php
@@ -49,6 +49,7 @@ class MimimalCmsConfig
         \App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepositoryInterface::class => \App\Models\Repositories\OpenChatDataForUpdaterWithCacheRepository::class,
         \App\Models\Repositories\SimilarSizeRoomRepositoryInterface::class => \App\Models\Repositories\SimilarSizeRoomRepository::class,
         \App\Models\Repositories\Recommend\RecommendGrowthRepositoryInterface::class => \App\Models\Repositories\Recommend\RecommendGrowthRepository::class,
+        \App\Models\Repositories\Recommend\TrendingThemeRepositoryInterface::class => \App\Models\Repositories\Recommend\TrendingThemeRepository::class,
 
         \App\Models\CommentRepositories\CommentListRepositoryInterface::class => \App\Models\CommentRepositories\CommentListRepository::class,
         \App\Models\CommentRepositories\CommentLogRepositoryInterface::class => \App\Models\CommentRepositories\CommentLogRepository::class,


### PR DESCRIPTION
## 概要

ホームの **「いま人数急増中のテーマ」** の並びを改善し、あわせてその集計に使う **生SQLをサービス層からリポジトリへ分離**しました（同じ `TopPageRecommendList` に対する変更のため1つにまとめています）。

## 1) 並び順の改善（件数順 → 増加量順）

旧来は「そのテーマで伸びている部屋の**件数**順」で、小規模な部屋を多数持つ大テーマが上位を占めやすく、**少数でも大きく伸びている（＝本当に急上昇している）テーマが埋もれる**傾向がありました。

- **breadth（足切り）**は従来どおり: 伸びている部屋が一定数（2/3/4室）以上あるテーマのみ採用（単発室ノイズ除去）。
- **intensity（並び）**: 増加量(diff_member)の合計が大きい順。同点は件数順。
- ホームの急上昇テーマ表示と、/recommend の「テーマを探す」🚀急上昇棚（同じ topPageDto を共有）の両方に反映。
- ※体感差は本番データ量でのみ顕在化（ローカル閑散データでは該当テーマが少なく旧=新）。**ステージング/本番で要目視確認**。

## 2) SQLをリポジトリへ分離（アーキテクチャ整理）

サービス層に直書きされていた3つの生SQLを、新設 `TrendingThemeRepository`(+Interface) へ移設。サービス(`TopPageRecommendList`)は集計・並び(`rankByMomentum`)に専念し、取得はリポジトリの責務に分離。DIは `MimimalCmsConfig` に登録。

- `app/Models/Repositories/Recommend/TrendingThemeRepository{,Interface}.php` 新設（`RecommendGrowthRepository` と同じMySQL集計リポジトリ層）。
- `TopPageRecommendList` はコンストラクタで Interface を受け取り `DB::` 直呼びを撤去。
- 実機でトップの「急上昇テーマ」が描画される（repo＋DI解決）ことを確認済み。
