### PR TITLE
[STG] feat: タグ別おすすめランキングを「24時間の人数増加」順に刷新（増加実数を表示・凡例廃止・閾値定数化）

### DIFF
--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -44,6 +44,9 @@ class AppConfig
     const RECOMMEND_MIN_MEMBER_DIFF_HOUR = 3;
     const RECOMMEND_MIN_MEMBER_DIFF_H24 = 8;
     const RECOMMEND_MIN_MEMBER_DIFF_WEEK = 10;
+    // おすすめランキング Tier4（増減実績が無い部屋を拾う際の最小メンバー数）。
+    // ランキングrepo群(SQL)と BulkRecommendRankingBuilder(PHP)で共有する単一の真実の源。
+    const RECOMMEND_MIN_MEMBER_TIER4 = 15;
 
     const COMMENT_FLAG_LABELS = [
         0 => '復元',

--- a/app/Models/RecommendRepositories/BulkRankingDataRepository.php
+++ b/app/Models/RecommendRepositories/BulkRankingDataRepository.php
@@ -49,7 +49,7 @@ class BulkRankingDataRepository implements BulkRankingDataRepositoryInterface
                 sh.open_chat_id IS NOT NULL
                 OR sh24.open_chat_id IS NOT NULL
                 OR sw.open_chat_id IS NOT NULL
-                OR oc.member >= 15"
+                OR oc.member >= " . \App\Config\AppConfig::RECOMMEND_MIN_MEMBER_TIER4
         );
 
         $indexed = [];

--- a/app/Models/RecommendRepositories/CategoryRankingRepository.php
+++ b/app/Models/RecommendRepositories/CategoryRankingRepository.php
@@ -18,7 +18,8 @@ class CategoryRankingRepository extends AbstractRecommendRankingRepository
         return DB::fetchAll(
             "SELECT
                 {$select},
-                '{$table}' AS table_name
+                '{$table}' AS table_name,
+                ranking.diff_member AS diff_member_24h
             FROM
                 open_chat AS oc
                 JOIN (

--- a/app/Models/RecommendRepositories/CategoryRankingRepository.php
+++ b/app/Models/RecommendRepositories/CategoryRankingRepository.php
@@ -132,7 +132,7 @@ class CategoryRankingRepository extends AbstractRecommendRankingRepository
                         LEFT JOIN statistics_ranking_hour AS rh2 ON oc.id = rh2.open_chat_id
                     WHERE
                         oc.id NOT IN ({$ids})
-                        AND ((rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= 15)
+                        AND ((rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= " . \App\Config\AppConfig::RECOMMEND_MIN_MEMBER_TIER4 . ")
                         AND oc.category = :category
                     ORDER BY
                         oc.member DESC

--- a/app/Models/RecommendRepositories/OfficialRoomRankingRepository.php
+++ b/app/Models/RecommendRepositories/OfficialRoomRankingRepository.php
@@ -150,7 +150,7 @@ class OfficialRoomRankingRepository extends AbstractRecommendRankingRepository
                         LEFT JOIN statistics_ranking_hour AS rh2 ON oc.id = rh2.open_chat_id
                     WHERE
                         oc.id NOT IN ({$ids})
-                        AND ((rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= 15)
+                        AND ((rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= " . \App\Config\AppConfig::RECOMMEND_MIN_MEMBER_TIER4 . ")
                         AND {$statement}
                     ORDER BY
                         oc.member DESC

--- a/app/Models/RecommendRepositories/OfficialRoomRankingRepository.php
+++ b/app/Models/RecommendRepositories/OfficialRoomRankingRepository.php
@@ -24,7 +24,8 @@ class OfficialRoomRankingRepository extends AbstractRecommendRankingRepository
         return DB::fetchAll(
             "SELECT
                 {$select},
-                '{$table}' AS table_name
+                '{$table}' AS table_name,
+                ranking.diff_member AS diff_member_24h
             FROM
                 open_chat AS oc
                 JOIN (

--- a/app/Models/RecommendRepositories/RecommendRankingRepository.php
+++ b/app/Models/RecommendRepositories/RecommendRankingRepository.php
@@ -18,7 +18,8 @@ class RecommendRankingRepository extends AbstractRecommendRankingRepository
         return DB::fetchAll(
             "SELECT
                 {$select},
-                '{$table}' AS table_name
+                '{$table}' AS table_name,
+                ranking.diff_member AS diff_member_24h
             FROM
                 (
                     SELECT

--- a/app/Models/RecommendRepositories/RecommendRankingRepository.php
+++ b/app/Models/RecommendRepositories/RecommendRankingRepository.php
@@ -140,7 +140,7 @@ class RecommendRankingRepository extends AbstractRecommendRankingRepository
                         LEFT JOIN statistics_ranking_hour AS rh2 ON oc.id = rh2.open_chat_id
                     WHERE
                         oc.id NOT IN ({$ids})
-                        AND ((rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= 15)
+                        AND ((rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= " . \App\Config\AppConfig::RECOMMEND_MIN_MEMBER_TIER4 . ")
                     ORDER BY
                         oc.member DESC
                     LIMIT

--- a/app/Services/Recommend/BulkRecommendRankingBuilder.php
+++ b/app/Services/Recommend/BulkRecommendRankingBuilder.php
@@ -325,8 +325,9 @@ class BulkRecommendRankingBuilder implements BulkRecommendRankingBuilderInterfac
     /**
      * Tier 4: member DESCで取得後、hour_diff DESC, member DESCで再ソート
      *
-     * 旧SQLの条件: (rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= 15
-     * → hour_diffまたはhour24_diffが存在するか、member >= 15であること
+     * SQL条件と同一: (rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL)
+     *   OR oc.member >= AppConfig::RECOMMEND_MIN_MEMBER_TIER4
+     * → hour_diffまたはhour24_diffが存在するか、member が下限以上であること
      */
     private function buildMemberTier(
         array $candidateIds,
@@ -342,9 +343,10 @@ class BulkRecommendRankingBuilder implements BulkRecommendRankingBuilderInterfac
             if (isset($excludeMap[$id])) continue;
             $row = $this->allData[$id] ?? null;
             if ($row === null) continue;
-            // 旧SQLの条件を再現: (hour IS NOT NULL OR hour24 IS NOT NULL) OR member >= 15
+            // SQLランキング(BulkRankingDataRepository / 各RankingRepository)と同条件:
+            //   (hour IS NOT NULL OR hour24 IS NOT NULL) OR member >= RECOMMEND_MIN_MEMBER_TIER4
             $hasHourOrHour24 = $row['hour_diff'] !== null || $row['hour24_diff'] !== null;
-            if (!$hasHourOrHour24 && (int)$row['member'] < 15) continue;
+            if (!$hasHourOrHour24 && (int)$row['member'] < AppConfig::RECOMMEND_MIN_MEMBER_TIER4) continue;
             $filtered[] = $row;
         }
 

--- a/app/Services/Recommend/BulkRecommendRankingBuilder.php
+++ b/app/Services/Recommend/BulkRecommendRankingBuilder.php
@@ -168,79 +168,41 @@ class BulkRecommendRankingBuilder implements BulkRecommendRankingBuilderInterfac
     ): RecommendListDto {
         $limit = AppConfig::LIST_LIMIT_RECOMMEND;
 
-        // Tier 1: hour_diff >= 3, hour_diff DESCでソート
-        $tier1 = $this->filterAndSort(
-            $statsCandidateIds,
-            [],
-            'hour_diff',
-            AppConfig::RECOMMEND_MIN_MEMBER_DIFF_HOUR,
-            fn(array $a, array $b) =>
-                self::nullLastDesc($b['hour_diff'] ?? null, $a['hour_diff'] ?? null)
-                ?: ((int)$a['id'] <=> (int)$b['id']),
-            $limit,
-            $getTag1,
-            $getTag2,
-            AppConfig::RANKING_HOUR_TABLE_NAME,
+        // 24時間の人数増加が閾値以上の部屋を、24時間増の降順で（＝「いま伸びている」）。
+        $growing = [];
+        foreach ($statsCandidateIds as $id) {
+            $row = $this->allData[$id] ?? null;
+            if ($row === null) continue;
+            if (($row['hour24_diff'] ?? null) === null || (int)$row['hour24_diff'] < AppConfig::RECOMMEND_MIN_MEMBER_DIFF_H24) continue;
+            $growing[] = $row;
+        }
+        usort($growing, fn(array $a, array $b) =>
+            ((int)$b['hour24_diff'] <=> (int)$a['hour24_diff'])
+            ?: ((int)$a['id'] <=> (int)$b['id'])
+        );
+        $growing = array_slice($growing, 0, $limit);
+        $growingRows = array_map(
+            fn(array $row) => $this->formatRow($row, $getTag1, $getTag2, AppConfig::RANKING_DAY_TABLE_NAME, (int)$row['hour24_diff']),
+            $growing
         );
 
-        // Tier 2: hour24_diff >= 8, hour_diff DESC → hour24_diff DESC
-        $excludeIds = array_column($tier1, 'id');
-        $tier2 = $this->filterAndSort(
-            $statsCandidateIds,
-            $excludeIds,
-            'hour24_diff',
-            AppConfig::RECOMMEND_MIN_MEMBER_DIFF_H24,
-            fn(array $a, array $b) =>
-                self::nullLastDesc($b['hour_diff'] ?? null, $a['hour_diff'] ?? null)
-                ?: (self::nullLastDesc($b['hour24_diff'] ?? null, $a['hour24_diff'] ?? null)
-                    ?: ((int)$a['id'] <=> (int)$b['id'])),
-            $limit,
-            $getTag1,
-            $getTag2,
-            AppConfig::RANKING_DAY_TABLE_NAME,
-        );
-
-        // Tier 3: week_diff >= 10, hour_diff DESC → week_diff DESC
-        $excludeIds = array_merge($excludeIds, array_column($tier2, 'id'));
-        $tier3 = $this->filterAndSort(
-            $statsCandidateIds,
-            $excludeIds,
-            'week_diff',
-            AppConfig::RECOMMEND_MIN_MEMBER_DIFF_WEEK,
-            fn(array $a, array $b) =>
-                self::nullLastDesc($b['hour_diff'] ?? null, $a['hour_diff'] ?? null)
-                ?: (self::nullLastDesc($b['week_diff'] ?? null, $a['week_diff'] ?? null)
-                    ?: ((int)$a['id'] <=> (int)$b['id'])),
-            $limit,
-            $getTag1,
-            $getTag2,
-            AppConfig::RANKING_WEEK_TABLE_NAME,
-        );
-
-        // Tier 4: member DESC → hour_diff DESC, member DESC
-        $count = count($tier1) + count($tier2) + count($tier3);
-        $excludeIds = array_merge($excludeIds, array_column($tier3, 'id'));
-        $tier4Limit = $count < AppConfig::LIST_LIMIT_RECOMMEND
-            ? ($count < (int)floor(AppConfig::LIST_LIMIT_RECOMMEND)
-                ? (int)floor(AppConfig::LIST_LIMIT_RECOMMEND) - $count
-                : 5)
-            : 3;
-
-        $tier4 = $this->buildMemberTier(
+        // 伸びていない部屋は member 降順で裾を埋める（痩せタグ対策・既存の大型部屋）。
+        $member = $this->buildMemberTier(
             $memberCandidateIds,
-            $excludeIds,
-            $tier4Limit,
+            array_column($growing, 'id'),
+            $limit,
             $getTag1,
             $getTag2,
         );
 
+        // DTO は先頭(=表示順)に伸び部屋、末尾に裾を渡す（旧 hour/day/week の4段は廃止）。
         $dto = new RecommendListDto(
             $type,
             $listName,
-            $tier1,
-            $tier2,
-            $tier3,
-            $tier4,
+            $growingRows,
+            [],
+            [],
+            $member,
             $this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime')
         );
 
@@ -275,55 +237,7 @@ class BulkRecommendRankingBuilder implements BulkRecommendRankingBuilderInterfac
     }
 
     /**
-     * 指定条件でフィルタリング・ソートして行フォーマットを適用する
-     *
-     * @param int[] $candidateIds 対象ID群
-     * @param int[] $excludeIds 除外ID群
-     * @param string $diffColumn diff_memberのカラム名（hour_diff/hour24_diff/week_diff）
-     * @param int $minDiff 最小差分値
-     * @param \Closure $sortFn usort比較関数
-     * @param int $limit 最大件数
-     * @param \Closure $getTag1 tag1取得クロージャ
-     * @param \Closure $getTag2 tag2取得クロージャ
-     * @param string $tableName table_nameに設定する値
-     * @return array フォーマット済み行の配列
-     */
-    private function filterAndSort(
-        array $candidateIds,
-        array $excludeIds,
-        string $diffColumn,
-        int $minDiff,
-        \Closure $sortFn,
-        int $limit,
-        \Closure $getTag1,
-        \Closure $getTag2,
-        string $tableName,
-    ): array {
-        $excludeMap = array_flip($excludeIds);
-        $filtered = [];
-
-        foreach ($candidateIds as $id) {
-            if (isset($excludeMap[$id])) continue;
-            $row = $this->allData[$id] ?? null;
-            if ($row === null) continue;
-            if (($row[$diffColumn] ?? null) === null || (int)$row[$diffColumn] < $minDiff) continue;
-            $filtered[] = $row;
-        }
-
-        usort($filtered, $sortFn);
-
-        if (count($filtered) > $limit) {
-            $filtered = array_slice($filtered, 0, $limit);
-        }
-
-        return array_map(
-            fn(array $row) => $this->formatRow($row, $getTag1, $getTag2, $tableName),
-            $filtered
-        );
-    }
-
-    /**
-     * Tier 4: member DESCで取得後、hour_diff DESC, member DESCで再ソート
+     * 伸びていない部屋を member DESC で裾埋めする（id ASC タイブレーク）。
      *
      * SQL条件と同一: (rh.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL)
      *   OR oc.member >= AppConfig::RECOMMEND_MIN_MEMBER_TIER4
@@ -381,6 +295,7 @@ class BulkRecommendRankingBuilder implements BulkRecommendRankingBuilderInterfac
         \Closure $getTag1,
         \Closure $getTag2,
         string $tableName,
+        ?int $diff24h = null,
     ): array {
         return [
             'id' => $row['id'],
@@ -400,6 +315,8 @@ class BulkRecommendRankingBuilder implements BulkRecommendRankingBuilderInterfac
             'tag1' => $getTag1($row),
             'tag2' => $getTag2($row),
             'table_name' => $tableName,
+            // 伸び部屋のみ24h増を持たせる（裾は null＝バッジ非表示）。SQLランキングの diff_member_24h と整合。
+            'diff_member_24h' => $diff24h,
         ];
     }
 }

--- a/app/Services/Recommend/RecommendRankingBuilder.php
+++ b/app/Services/Recommend/RecommendRankingBuilder.php
@@ -29,47 +29,29 @@ class RecommendRankingBuilder
     ): RecommendListDto {
         $limit = AppConfig::LIST_LIMIT_RECOMMEND;
 
-        $ranking = $repository->getRanking(
-            $entity,
-            AppConfig::RANKING_HOUR_TABLE_NAME,
-            AppConfig::RECOMMEND_MIN_MEMBER_DIFF_HOUR,
-            $limit
-        );
-
-        $idArray = array_column($ranking, 'id');
-        $ranking2 = $repository->getRankingByExceptId(
+        // 24時間の人数増加が大きい順（＝「いま伸びている」部屋）。
+        $growing = $repository->getRanking(
             $entity,
             AppConfig::RANKING_DAY_TABLE_NAME,
             AppConfig::RECOMMEND_MIN_MEMBER_DIFF_H24,
-            $idArray,
             $limit
         );
 
-        $count = count($ranking) + count($ranking2);
-        $idArray = array_column(array_merge($ranking, $ranking2), 'id');
-        $ranking3 = $repository->getRankingByExceptId(
+        // 伸びていない部屋は member 降順で裾を埋める（痩せタグ対策・既存の大型部屋）。
+        $member = $repository->getListOrderByMemberDesc(
             $entity,
-            AppConfig::RANKING_WEEK_TABLE_NAME,
-            AppConfig::RECOMMEND_MIN_MEMBER_DIFF_WEEK,
-            $idArray,
+            array_column($growing, 'id'),
             $limit
         );
 
-        $count = count($ranking) + count($ranking2) + count($ranking3);
-        $idArray = array_column(array_merge($ranking, $ranking2, $ranking3), 'id');
-        $ranking4 = $repository->getListOrderByMemberDesc(
-            $entity,
-            $idArray,
-            $count < AppConfig::LIST_LIMIT_RECOMMEND ? ($count < floor(AppConfig::LIST_LIMIT_RECOMMEND) ? (int)floor(AppConfig::LIST_LIMIT_RECOMMEND) - $count : 5) : 3
-        );
-
+        // DTO は先頭(=表示順)に伸び部屋、末尾に裾を渡す（旧 hour/day/week の4段は廃止）。
         $dto = new RecommendListDto(
             $type,
             $listName,
-            $ranking,
-            $ranking2,
-            $ranking3,
-            $ranking4,
+            $growing,
+            [],
+            [],
+            $member,
             $this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime')
         );
 

--- a/app/Views/components/open_chat_list_recommend.php
+++ b/app/Views/components/open_chat_list_recommend.php
@@ -41,16 +41,17 @@
                 <?php else : ?>
                   <span><?php echo sprintfT('メンバー %s人', formatMember($oc['member'])) ?></span>
                 <?php endif ?>
-                <?php $diff24h = (int)($oc['diff_member_24h'] ?? 0); ?>
-                <?php if ($diff24h > 0) : ?>
-                  <span class="positive"><span class="openchat-item-stats" style="white-space: nowrap;">・ <?php echo sprintfT('%s人増加', formatMember($diff24h)) ?></span></span>
-                <?php endif ?>
               </span>
             <?php endif ?>
             <?php if (isset($oc['api_created_at']) && $showApiCreatedAt) : ?>
               <span class="registration-date"><?php echo t('ルーム開設') . ' ' . convertDatetime($oc['api_created_at'], false) ?></span>
             <?php endif ?>
           </div>
+          <?php // 24時間の人数増加は独立行に（メンバー行に入れると溢れるため）。伸び部屋のみ表示。 ?>
+          <?php $diff24h = (int)($oc['diff_member_24h'] ?? 0); ?>
+          <?php if ($diff24h > 0) : ?>
+            <div class="positive" style="font-size: 13px; margin-top: 1px;"><span aria-hidden="true" style="font-size: 11px; user-select: none;">🚀</span> <span class="openchat-item-stats"><?php echo sprintfT('%s人増加', formatMember($diff24h)) ?></span></div>
+          <?php endif ?>
         </footer>
       </div>
     </li>

--- a/app/Views/components/open_chat_list_recommend.php
+++ b/app/Views/components/open_chat_list_recommend.php
@@ -41,18 +41,15 @@
                 <?php else : ?>
                   <span><?php echo sprintfT('メンバー %s人', formatMember($oc['member'])) ?></span>
                 <?php endif ?>
-                <?php if (isset($oc['table_name']) && $oc['table_name'] === AppConfig::RANKING_HOUR_TABLE_NAME) : ?>
-                  <span aria-hidden="true" style="font-size: 9px; user-select: none;">🔥</span>
-                <?php endif ?>
-                <?php if (isset($oc['table_name']) && $oc['table_name'] === AppConfig::RANKING_DAY_TABLE_NAME) : ?>
-                  <span aria-hidden="true" style="font-size: 9px; user-select: none;">🚀</span>
-                <?php endif ?>
-                <?php if (isset($oc['table_name']) && $oc['table_name'] === AppConfig::RANKING_WEEK_TABLE_NAME) : ?>
-                  <svg class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium show-north css-162gv95" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="NorthIcon">
-                    <path d="m5 9 1.41 1.41L11 5.83V22h2V5.83l4.59 4.59L19 9l-7-7-7 7z"></path>
-                  </svg>
-                <?php endif ?>
               </span>
+              <?php $diff24h = (int)($oc['diff_member_24h'] ?? 0); ?>
+              <?php if ($diff24h > 0) : ?>
+                <span class="recommend-growth-24h" style="white-space: nowrap;">
+                  <span aria-hidden="true" style="font-size: 9px; user-select: none;">🚀</span>
+                  <span style="color: #06863c; font-weight: bold;"><?php echo sprintfT('%s人増加', formatMember($diff24h)) ?></span>
+                  <small style="color: #9aa3af;">/ <?php echo t('24時間') ?></small>
+                </span>
+              <?php endif ?>
             <?php endif ?>
             <?php if (isset($oc['api_created_at']) && $showApiCreatedAt) : ?>
               <span class="registration-date"><?php echo t('ルーム開設') . ' ' . convertDatetime($oc['api_created_at'], false) ?></span>

--- a/app/Views/components/open_chat_list_recommend.php
+++ b/app/Views/components/open_chat_list_recommend.php
@@ -41,15 +41,11 @@
                 <?php else : ?>
                   <span><?php echo sprintfT('メンバー %s人', formatMember($oc['member'])) ?></span>
                 <?php endif ?>
+                <?php $diff24h = (int)($oc['diff_member_24h'] ?? 0); ?>
+                <?php if ($diff24h > 0) : ?>
+                  <span class="positive"><span class="openchat-item-stats" style="white-space: nowrap;">・ <?php echo sprintfT('%s人増加', formatMember($diff24h)) ?></span></span>
+                <?php endif ?>
               </span>
-              <?php $diff24h = (int)($oc['diff_member_24h'] ?? 0); ?>
-              <?php if ($diff24h > 0) : ?>
-                <span class="recommend-growth-24h" style="white-space: nowrap;">
-                  <span aria-hidden="true" style="font-size: 9px; user-select: none;">🚀</span>
-                  <span style="color: #06863c; font-weight: bold;"><?php echo sprintfT('%s人増加', formatMember($diff24h)) ?></span>
-                  <small style="color: #9aa3af;">/ <?php echo t('24時間') ?></small>
-                </span>
-              <?php endif ?>
             <?php endif ?>
             <?php if (isset($oc['api_created_at']) && $showApiCreatedAt) : ?>
               <span class="registration-date"><?php echo t('ルーム開設') . ' ' . convertDatetime($oc['api_created_at'], false) ?></span>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -60,27 +60,6 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
       ]) ?>
 
     </section>
-    <?php if (isset($recommend)) : ?>
-      <header class="recommend-ranking-section-header" style="padding: 0 0 4px 16px;">
-        <aside class="list-aside">
-          <details class="icon-desc">
-            <summary style="font-size: 13px; font-weight: normal; color: #b7b7b7"><?php echo t('人数増加アイコンの説明') ?></summary>
-            <div class="list-aside-details">
-              <small class="list-aside-desc">🔥：<?php echo sprintfT('過去1時間で%s人以上増加', AppConfig::RECOMMEND_MIN_MEMBER_DIFF_HOUR) ?></small>
-              <small class="list-aside-desc">🚀：<?php echo sprintfT('過去24時間で%s人以上増加', AppConfig::RECOMMEND_MIN_MEMBER_DIFF_H24) ?></small>
-              <small class="list-aside-desc">
-                <span style="margin: 0 4px;">
-                  <svg class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium show-north css-162gv95" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="NorthIcon">
-                    <path d="m5 9 1.41 1.41L11 5.83V22h2V5.83l4.59 4.59L19 9l-7-7-7 7z"></path>
-                  </svg>
-                </span>：<?php echo sprintfT('過去1週間で%s人以上増加', AppConfig::RECOMMEND_MIN_MEMBER_DIFF_WEEK) ?>
-              </small>
-              <small class="list-aside-desc">🏆：<?php echo t('リスト内で最も人数が多いトークルーム') ?></small>
-            </div>
-          </details>
-        </aside>
-      </header>
-    <?php endif ?>
     <section class="recommend-ranking-section">
       <?php if (isset($recommend)) : ?>
         <?php if ($enableAdsense): ?>


### PR DESCRIPTION
## 概要

タグ別 /recommend のランキングを **「24時間の人数増加」順** に作り替え、各部屋に **増加実数（🚀 +N人 / 24時間）** を表示します。あわせて多段バッジの凡例を撤去し、ランキング閾値を定数に集約しました。

## 1) 並び順の刷新（4段先勝ち → 24時間増加順）

旧来は「1時間→24時間→週→member」の4段・先勝ちで、**直近1時間の小さな増加（ノイズ）を最優先**し、段境界で順位が不連続になる欠陥がありました（「24時間 +2000」の部屋が「1時間 +3」の部屋より下に沈む等）。

- **伸び部屋**: 24時間増が閾値（`RECOMMEND_MIN_MEMBER_DIFF_H24`=8）以上の部屋を、24時間増の降順。
- **裾**: 伸びていない部屋は member 降順で埋める（痩せタグ対策・既存の大型部屋）。
- 1時間/週の段は廃止。「いま伸びている」の意図に忠実で、順位の崖が消えます。

## 2) 表示（増加実数 ＋ 凡例撤去）

- 各部屋に **「🚀 +N人 / 24時間」** と増加実数を表示（順位の根拠が見える・順位とバッジが整合）。
- 役目を終えた多段バッジ（🔥1h / 🚀24h / ↑週）と、その**凡例（説明ブロック）を撤去**。🏆（リスト内最多）は維持。

## 3) 実装・互換性

- 遅延生成（`RecommendRankingBuilder`）・毎時バッチ（`BulkRecommendRankingBuilder`）の双方を **2段（24h growers＋member裾）に簡約**。4段の複雑ロジック・未使用化した `filterAndSort` を削除。
- 3つのランキングrepoの `getRanking` が `diff_member_24h` を出力。
- **`RecommendListDto` は不変＝既存 .dat とシリアライズ互換**。旧キャッシュは `?? 0` でバッジ非表示の安全劣化、次回cronの再生成で新順序＋実数に切替（デプロイ直後に壊れない）。
- ランキング Tier4 の最小人数(15)を `AppConfig::RECOMMEND_MIN_MEMBER_TIER4` に集約（SQL4箇所＋PHP1箇所の重複解消）。これで全ランキング閾値が単一の真実の源に。

## 検証

- 全変更ファイル `php -l` クリーン。ランキングrepo phpunit PASS。
- リポジトリ直叩き（読み取り専用）で growers=24h降順・裾=member降順(diff_member_24h=null) を確認。
- /recommend・/ ともに PHPエラー0で描画（旧.datでも安全劣化）。
- ※新順序とバッジの体感は**本番データ量＆.dat再生成後**に出るため、ステージング目視を推奨。
