### PR TITLE
[STG] fix: テーマ検索でiPhoneのキーボードがEnter後も閉じない問題を修正

### DIFF
--- a/app/Views/components/theme_discovery.php
+++ b/app/Views/components/theme_discovery.php
@@ -249,6 +249,16 @@ $shelves = array_values(array_filter([
 
             input.addEventListener('input', () => { render(input.value); save(input.value); });
 
+            // iOS Safari は <form> の submit を伴わないと Enter でキーボード(IME)が閉じない。
+            // 変換確定中(IME composition)の Enter は「確定」用なので除外し、確定後の Enter で
+            // 明示的に blur してソフトキーボードを閉じる（keyCode 229 = 変換中の保険）。
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229) {
+                    e.preventDefault();
+                    input.blur();
+                }
+            });
+
             // 戻る/進む（bfcache無効＝no-store時も含む）でのみ復元。通常遷移や別テーマでは復元しない。
             const nav = performance.getEntriesByType?.('navigation')?.[0];
             const isBackForward = nav ? nav.type === 'back_forward' : performance.navigation?.type === 2;


### PR DESCRIPTION
## 問題

おすすめ（テーマ別）ページの「テーマを探す」検索で、**iPhone の Safari で文字を変換確定して Enter を押してもキーボードが閉じない**。検索結果は出ているのにキーボードが画面を覆い続け、操作の邪魔になる。

## 原因

検索入力が `<form>` の外にある `<input type="search">` のため、iOS Safari は Enter（検索キー）に「送信先」がなく、ソフトキーボードを閉じない仕様。

## 対処

変換確定後の Enter で入力欄を明示的に `blur()` してキーボードを閉じる。日本語入力の変換中（IME composition）の Enter は「変換確定」用なので、`e.isComposing` と `keyCode === 229` で除外し、確定後の Enter のみ反応する。

- 対象: [`app/Views/components/theme_discovery.php`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/oc-pdca/fix/theme-discovery-ios-enter-blur/app/Views/components/theme_discovery.php)
- PC（変換確定→Enter）でも余計な改行・送信は起きず、単にフォーカスが外れるだけで無害。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
