### PR TITLE
[STG] fix(SEO): ルームページの「更新日」を実際に内容が変わった日に統一（全室が毎日更新される誤シグナルを解消）

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -142,7 +142,12 @@ class OpenChatPageController
             $_meta->title,
             $_meta->description,
             new \DateTime($oc['created_at']),
-            new \DateTime($_statsDto->endDate),
+            // dateModified は「ページ内容が実際に変わった日」(oc_sitemap_lastmod.lastmod) を優先する。
+            // 統計テーブルの最新日(endDate)を使うと、生きている全室が毎日 dateModified を更新し
+            // 「307,895室すべてが常時更新」に見えて鮮度シグナルが希釈される。lastmod は
+            // メンバー数が有意に動いた日 or メタ変更日のみ進むため、room ごとに安定する。
+            // oc_sitemap_lastmod 未登録の room (API/SQLite 経路含む) は従来どおり endDate にフォールバック。
+            new \DateTime($oc['lastmod'] ?? $_statsDto->endDate),
             $oc,
         );
 

--- a/app/Models/Repositories/OpenChatPageRepository.php
+++ b/app/Models/Repositories/OpenChatPageRepository.php
@@ -68,7 +68,8 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
                 rh24.percent_increase AS rh24_percent_increase,
                 tg.tag AS tag1,
                 tg2.tag AS tag2,
-                tg3.tag AS tag3
+                tg3.tag AS tag3,
+                lm.lastmod AS lastmod
             FROM
                 open_chat AS oc
                 LEFT JOIN statistics_ranking_hour AS rh ON oc.id = rh.open_chat_id
@@ -76,6 +77,7 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
                 LEFT JOIN recommend AS tg ON oc.id = tg.id
                 LEFT JOIN oc_tag AS tg2 ON oc.id = tg2.id
                 LEFT JOIN oc_tag2 AS tg3 ON oc.id = tg3.id
+                LEFT JOIN oc_sitemap_lastmod AS lm ON oc.id = lm.open_chat_id
             WHERE
                 oc.id = :id";
 


### PR DESCRIPTION
## 問題の概要

各オープンチャットのルームページ（/oc/{id}）が Google に渡す構造化データの「更新日（dateModified）」が、**生きている全307,895室すべてで毎日「昨日／今日」を指していました**。実際にはほとんどの部屋は内容が変わっていないのに、毎日更新されているように見え、Google への鮮度シグナルが薄まっていました。

実機確認（修正前）:
- `/oc/150000` → `dateModified: 2026-06-03`
- `/oc/178367` → `dateModified: 2026-06-03`
- （統計テーブルの最新日 = 毎日進むため、全室がこの値になる）

## 対処内容

更新日の出所を、既存の `oc_sitemap_lastmod.lastmod`（メンバー数が有意に動いた日 or メタ情報が変わった日のみ進む。PR #264 のサイトマップ lastmod 基盤）に切り替え、**部屋ごとに安定した更新日**を出すようにしました。実際に動きのあった部屋だけが新しい日付になります。

- [`OpenChatPageRepository::getOpenChatByIdWithTag`](app/Models/Repositories/OpenChatPageRepository.php) に `oc_sitemap_lastmod` を LEFT JOIN し `lastmod` を取得
- [`OpenChatPageController`](app/Controllers/Pages/OpenChatPageController.php) で `dateModified` を `$oc['lastmod'] ?? endDate` に変更
- 公開日（datePublished＝created_at）は不変。`Dataset.temporalCoverage` も意図的に不変（データ収集範囲を表すため）

## 安全性

- `oc_sitemap_lastmod` 未登録の部屋・API/SQLite 経路は従来どおり `endDate` にフォールバック＝**リグレッション無し**
- 完全可逆（2 hunk を revert すれば元に戻る）
- `php -l` clean。本番 ja サイトマップで lastmod が seed 済（24,039室が安定 floor 日付＋実変更室が個別日付）を確認済のため、ja では即効果あり。tw/th も同基盤で動作

## 背景（PDCA）

「コンテンツは膨大なのに流入が伸びない」「GSC 拡張の認識数が増えない」の調査サイクルで、`/oc` の更新日が常時更新の希釈シグナルになっていることを特定。本 PR はその希釈除去（補助シグナル改善）。本命の流入レバー（JA /recommend の順位天井突破等）は別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)