### PR TITLE
[STG] refactor: ブログ/掲載分析を型付き(連想配列→DTO)化、掲載分析のロジック修正と潜在バグ予防を同梱

### DIFF
--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -200,6 +200,9 @@ class AppConfig
     const SITEMAP_DIR = __DIR__ . '/../../public/sitemap.xml';
     const TRANSLATION_FILE = __DIR__ . '/../../storage/translation.json';
 
+    /** Markdown ブログ記事の格納ディレクトリ（content/blog/{slug}.md） */
+    const BLOG_CONTENT_DIR = __DIR__ . '/../../content/blog/';
+
     const FURIGANA_CACHE_DIR = __DIR__ . '/../../storage/furigana';
 
     /** SQLite ocgraph_sqlapi database path (Japanese only, not multi-language) */

--- a/app/Controllers/Pages/BlogController.php
+++ b/app/Controllers/Pages/BlogController.php
@@ -6,7 +6,10 @@ namespace App\Controllers\Pages;
 
 use App\Config\AppConfig;
 use App\Services\Blog\BlogService;
+use App\Services\Blog\Dto\BlogSummaryDto;
+use App\Services\Blog\Dto\FaqItemDto;
 use App\Views\Schema\PageBreadcrumbsListSchema;
+use Shadow\Kernel\ViewInterface;
 use Spatie\SchemaOrg\Organization;
 use Spatie\SchemaOrg\Schema;
 
@@ -14,7 +17,7 @@ class BlogController
 {
     private const CSS = ['site_header', 'site_footer', 'room_list', 'blog'];
 
-    public function index(BlogService $blog, PageBreadcrumbsListSchema $breadcrumbsShema)
+    public function index(BlogService $blog, PageBreadcrumbsListSchema $breadcrumbsShema): ViewInterface
     {
         $_css = self::CSS;
         $_meta = meta()->setTitle('ブログ｜オープンチャットの運営・検索・トレンド情報');
@@ -32,10 +35,10 @@ class BlogController
             ->inLanguage('ja')
             ->publisher($this->publisher())
             ->blogPost(array_map(
-                static fn(array $a) => Schema::blogPosting()
-                    ->headline($a['title'])
-                    ->url(url('blog/' . $a['slug']))
-                    ->datePublished(new \DateTime($a['date'] ?: 'now')),
+                fn(BlogSummaryDto $a) => Schema::blogPosting()
+                    ->headline($a->title)
+                    ->url(url('blog/' . $a->slug))
+                    ->datePublished($this->toDate($a->date)),
                 $articles
             ))
             ->toScript();
@@ -43,51 +46,63 @@ class BlogController
         return view('blog_index_content', compact('_meta', '_css', '_breadcrumbsShema', '_schema', 'articles'));
     }
 
-    public function article(BlogService $blog, PageBreadcrumbsListSchema $breadcrumbsShema, string $slug)
+    public function article(BlogService $blog, PageBreadcrumbsListSchema $breadcrumbsShema, string $slug): ViewInterface|false
     {
         $article = $blog->get($slug);
         if (!$article) return false; // 404
 
         $_css = self::CSS;
-        $_meta = meta()->setTitle($article['title']);
-        $_meta->setDescription($article['description'])->setOgpDescription($article['description']);
+        $_meta = meta()->setTitle($article->title);
+        $_meta->setDescription($article->description)->setOgpDescription($article->description);
 
-        $_breadcrumbsShema = $breadcrumbsShema->generateSchema('ブログ', 'blog', $article['title']);
+        $_breadcrumbsShema = $breadcrumbsShema->generateSchema('ブログ', 'blog', $article->title);
 
         // リッチな BlogPosting 構造化データ。
         $_schema = Schema::blogPosting()
-            ->headline($article['title'])
-            ->description($article['description'])
+            ->headline($article->title)
+            ->description($article->description)
             ->image($_meta->image_url)
-            ->datePublished(new \DateTime($article['date'] ?: 'now'))
-            ->dateModified(new \DateTime(($article['updated'] ?: $article['date']) ?: 'now'))
+            ->datePublished($this->toDate($article->date))
+            ->dateModified($this->toDate($article->updated ?: $article->date))
             ->inLanguage('ja')
-            ->articleSection($article['category'])
-            ->wordCount((int)($article['wordCount'] ?? 0))
+            ->articleSection($article->category)
+            ->wordCount($article->wordCount)
             ->author($this->publisher())
             ->publisher($this->publisher())
             ->mainEntityOfPage(url('blog/' . $slug))
             ->toScript();
 
         // 本文に「よくある質問」があれば FAQPage（リッチリザルト）。
-        if (!empty($article['faq'])) {
+        if (!empty($article->faq)) {
             $_schema .= "\n" . Schema::fAQPage()->mainEntity(array_map(
-                static fn(array $f) => Schema::question()
-                    ->name($f['q'])
-                    ->acceptedAnswer(Schema::answer()->text($f['a'])),
-                $article['faq']
+                fn(FaqItemDto $f) => Schema::question()
+                    ->name($f->q)
+                    ->acceptedAnswer(Schema::answer()->text($f->a)),
+                $article->faq
             ))->toScript();
         }
 
-        $related = $blog->related($slug, $article['category']);
+        $related = $blog->related($slug, $article->category);
 
         // 本文 HTML は commonmark 済みの信頼ソース。View の自動エスケープ(非 _ 変数)を避けるため
-        // アンダースコア接頭辞で生出力。title 等のテキストは $article 側で自動エスケープされる。
-        $_html = $article['html'];
-        $_faqHtml = $article['faqHtml'];
-        unset($article['html'], $article['faqHtml'], $article['faq']);
+        // アンダースコア接頭辞で生出力する。$article のテキストは View 層で自動エスケープされる。
+        $_html = $article->html;
+        $_faqHtml = $article->faqHtml;
 
         return view('blog_article_content', compact('_meta', '_css', '_breadcrumbsShema', '_schema', 'article', '_html', '_faqHtml', 'related'));
+    }
+
+    /**
+     * frontmatter の日付文字列を安全にパースする。不正値でもページを落とさず「現在時刻」に倒す
+     * （1記事の日付 typo で /blog 一覧全体が 500 になるのを防ぐ）。
+     */
+    private function toDate(string $value): \DateTimeImmutable
+    {
+        try {
+            return new \DateTimeImmutable($value !== '' ? $value : 'now');
+        } catch (\Throwable) {
+            return new \DateTimeImmutable('now');
+        }
     }
 
     private function publisher(): Organization

--- a/app/Controllers/Pages/RankingBanLabsPageController.php
+++ b/app/Controllers/Pages/RankingBanLabsPageController.php
@@ -7,6 +7,7 @@ namespace App\Controllers\Pages;
 use App\Services\RankingBan\RakingBanPageService;
 use App\Services\Storage\FileStorageInterface;
 use App\Views\RankingBanSelectElementPagination;
+use Shadow\Kernel\ViewInterface;
 
 class RankingBanLabsPageController
 {
@@ -22,7 +23,7 @@ class RankingBanLabsPageController
         string $keyword,
         string $since,
         string $until
-    ) {
+    ): ViewInterface {
         $since = $this->validDate($since);
         $until = $this->validDate($until);
 
@@ -70,7 +71,7 @@ class RankingBanLabsPageController
         string $keyword,
         string $since,
         string $until
-    ) {
+    ): ViewInterface|false {
         header('X-Robots-Tag: noindex');
 
         $since = $this->validDate($since);
@@ -93,8 +94,8 @@ class RankingBanLabsPageController
             $until
         );
 
-        if (!$rankingBanData && $page > 1) return false;
-        if (!$rankingBanData && $page === 1) {
+        if ($rankingBanData === null && $page > 1) return false;
+        if ($rankingBanData === null) {
             $totalRecords = 0;
             $maxPageNumber = 0;
             return view(
@@ -109,8 +110,8 @@ class RankingBanLabsPageController
             );
         }
 
-        $totalRecords = $rankingBanData['totalRecords'];
-        $maxPageNumber = $rankingBanData['maxPageNumber'];
+        $totalRecords = $rankingBanData->totalRecords;
+        $maxPageNumber = $rankingBanData->maxPageNumber;
         $path = 'labs/publication-analytics';
         // クエリ順は JS 側 buildQuery と同一に保つ（CDNキャッシュキーの分裂防止）
         $params = compact('change', 'publish', 'percent', 'keyword', 'since', 'until');
@@ -121,11 +122,11 @@ class RankingBanLabsPageController
             $page,
             $totalRecords,
             $limit,
-            $rankingBanData['maxPageNumber'],
-            array_reverse($rankingBanData['labelArray'])
+            $maxPageNumber,
+            array_reverse($rankingBanData->labelArray)
         );
 
-        $openChatList =  $rankingBanData['openChatList'];
+        $openChatList = $rankingBanData->openChatList;
         $_pagerNavArg = [
             'path' => $path,
             'params' => $params,

--- a/app/Models/RankingBanRepositories/RankingBanPageRepository.php
+++ b/app/Models/RankingBanRepositories/RankingBanPageRepository.php
@@ -128,7 +128,7 @@ class RankingBanPageRepository
      * @param int $change 0:内容変更ありのみ, 1:変更なしのみ, 2:すべて
      * @param int $publish 0:掲載中のみ, 1:未掲載のみ, 2:すべて
      */
-    private function buildWhereClause(int $change, int $publish, int $percent)
+    private function buildWhereClause(int $change, int $publish, int $percent): string
     {
         $updatedAtValue = $change === 0
             ? "AND (rb.updated_at >= 1 OR (rb.update_items IS NOT NULL AND rb.update_items != ''))"

--- a/app/Services/Blog/BlogService.php
+++ b/app/Services/Blog/BlogService.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Services\Blog;
 
 use App\Config\AppConfig;
+use App\Services\Blog\Dto\BlogArticleDto;
+use App\Services\Blog\Dto\BlogSummaryDto;
+use App\Services\Blog\Dto\FaqItemDto;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\TaskList\TaskListExtension;
@@ -16,106 +19,131 @@ use League\CommonMark\MarkdownConverter;
  */
 class BlogService
 {
-    private const DIR = AppConfig::ROOT_PATH . 'content/blog/';
+    /** FAQ セクションの見出し（H2）。get() と extractFaq() で境界判定を共有する。 */
+    private const FAQ_HEADING = '/^##[ \t]+(?:よくある質問|FAQ|Q&A).*$/mu';
+
+    /** 任意の H2 見出し（"## " 直後にスペース必須なので ### 以降は除外）。FAQ セクションの終端検出に使う。 */
+    private const NEXT_H2 = '/^##[ \t]+\S/mu';
+
+    /** @var BlogSummaryDto[]|null 同一リクエスト内での list() 結果キャッシュ（毎回の glob + 全ファイル read を防ぐ）。 */
+    private ?array $listCache = null;
 
     /**
      * 記事一覧（frontmatter のみ・日付降順・draft 除外）。本文はレンダリングしない。
-     * @return array<int, array{slug:string,title:string,description:string,date:string,category:string}>
+     * @return BlogSummaryDto[]
      */
     public function list(): array
     {
+        if ($this->listCache !== null) return $this->listCache;
+
         $out = [];
-        foreach (glob(self::DIR . '*.md') ?: [] as $path) {
+        foreach (glob(AppConfig::BLOG_CONTENT_DIR . '*.md') ?: [] as $path) {
             [$fm] = $this->parse((string)file_get_contents($path));
             if (($fm['draft'] ?? '') === 'true') continue;
-            $out[] = [
-                'slug' => basename($path, '.md'),
-                'title' => $fm['title'] ?? basename($path, '.md'),
-                'description' => $fm['description'] ?? '',
-                'date' => $fm['date'] ?? '',
-                'category' => $fm['category'] ?? '',
-            ];
+            $slug = basename($path, '.md');
+            $out[] = new BlogSummaryDto(
+                slug: $slug,
+                title: $fm['title'] ?? $slug,
+                description: $fm['description'] ?? '',
+                date: $fm['date'] ?? '',
+                category: $fm['category'] ?? '',
+            );
         }
-        usort($out, static fn($a, $b) => strcmp($b['date'], $a['date']));
-        return $out;
+        usort($out, static fn(BlogSummaryDto $a, BlogSummaryDto $b) => strcmp($b->date, $a->date));
+        return $this->listCache = $out;
     }
 
     /**
      * 1 記事（frontmatter + 本文 HTML）。無ければ null。
-     * @return array{slug:string,title:string,description:string,date:string,updated:string,category:string,html:string}|null
      */
-    public function get(string $slug): ?array
+    public function get(string $slug): ?BlogArticleDto
     {
         if (!preg_match('/\A[a-z0-9\-]+\z/', $slug)) return null; // ディレクトリトラバーサル防止
-        $path = self::DIR . $slug . '.md';
+        $path = AppConfig::BLOG_CONTENT_DIR . $slug . '.md';
         if (!is_file($path)) return null;
 
         [$fm, $body] = $this->parse((string)file_get_contents($path));
         if (($fm['draft'] ?? '') === 'true') return null;
 
-        // FAQ セクション（## よくある質問 以降）を本文から分離し、専用スタイルで表示できるようにする。
-        $mainBody = $body;
-        $faqBody = '';
-        if (preg_match('/^##[ \t]*(?:よくある質問|FAQ|Q&A).*$/mu', $body, $m, PREG_OFFSET_CAPTURE)) {
-            $mainBody = rtrim(substr($body, 0, $m[0][1]));
-            $faqBody = substr($body, $m[0][1]);
-        }
+        // FAQ セクション（## よくある質問 〜 次の H2 直前）を本文から分離し、専用スタイルで表示する。
+        [$mainBody, $faqBody] = $this->splitFaq($body);
 
         $html = $this->render($mainBody);
         $faqHtml = $faqBody !== '' ? $this->render($faqBody) : '';
-        $plain = (string)preg_replace('/\s+/u', '', strip_tags($html . $faqHtml));
+        $plain = (string)(preg_replace('/\s+/u', '', strip_tags($html . $faqHtml)) ?? '');
 
-        return [
-            'slug' => $slug,
-            'title' => $fm['title'] ?? $slug,
-            'description' => $fm['description'] ?? '',
-            'date' => $fm['date'] ?? '',
-            'updated' => $fm['updated'] ?? ($fm['date'] ?? ''),
-            'category' => $fm['category'] ?? '',
-            'wordCount' => mb_strlen($plain),
-            'readingMinutes' => max(1, (int)ceil(mb_strlen($plain) / 500)),
-            'faq' => $this->extractFaq($body),
-            'html' => $html,
-            'faqHtml' => $faqHtml,
-        ];
+        return new BlogArticleDto(
+            slug: $slug,
+            title: $fm['title'] ?? $slug,
+            description: $fm['description'] ?? '',
+            date: $fm['date'] ?? '',
+            updated: $fm['updated'] ?? ($fm['date'] ?? ''),
+            category: $fm['category'] ?? '',
+            wordCount: mb_strlen($plain),
+            readingMinutes: max(1, (int)ceil(mb_strlen($plain) / 500)),
+            faq: $faqBody !== '' ? $this->extractFaq($faqBody) : [],
+            html: $html,
+            faqHtml: $faqHtml,
+        );
     }
 
     /**
      * 関連記事（同カテゴリ優先・日付降順・自身を除く）。
-     * @return array<int, array{slug:string,title:string,description:string,date:string,category:string}>
+     * @return BlogSummaryDto[]
      */
     public function related(string $slug, string $category, int $limit = 4): array
     {
-        $all = array_values(array_filter($this->list(), static fn($a) => $a['slug'] !== $slug));
-        usort($all, static function ($a, $b) use ($category) {
-            $sa = ($a['category'] === $category) ? 0 : 1;
-            $sb = ($b['category'] === $category) ? 0 : 1;
-            return ($sa <=> $sb) ?: strcmp($b['date'], $a['date']);
+        $all = array_values(array_filter($this->list(), static fn(BlogSummaryDto $a) => $a->slug !== $slug));
+        usort($all, static function (BlogSummaryDto $a, BlogSummaryDto $b) use ($category) {
+            $sa = ($a->category === $category) ? 0 : 1;
+            $sb = ($b->category === $category) ? 0 : 1;
+            return ($sa <=> $sb) ?: strcmp($b->date, $a->date);
         });
         return array_slice($all, 0, $limit);
     }
 
     /**
-     * 本文中の「## よくある質問 / FAQ」セクションから Q&A を抽出（FAQPage 構造化データ用）。
-     * ### を質問、続くテキストを回答（プレーン化）とする。無ければ空配列。
-     * @return array<int, array{q:string,a:string}>
+     * 本文を [本文(FAQ除く), FAQセクション(見出し含む)] に分割。FAQ が無ければ [body, '']。
+     * FAQ セクションは「## よくある質問」から「次の H2」直前まで。FAQ の後ろに別セクションが
+     * 続く場合はそれを本文側へ戻す（extractFaq() と同じ境界判定にして表示と構造化データを一致させる）。
+     * @return array{0:string,1:string}
      */
-    private function extractFaq(string $rawBody): array
+    private function splitFaq(string $body): array
     {
-        if (!preg_match('/^##[ \t]*(?:よくある質問|FAQ|Q&A).*$/mu', $rawBody, $m, PREG_OFFSET_CAPTURE)) {
-            return [];
+        if (!preg_match(self::FAQ_HEADING, $body, $m, PREG_OFFSET_CAPTURE)) {
+            return [$body, ''];
         }
-        $rest = substr($rawBody, $m[0][1] + strlen($m[0][0]));
-        if (preg_match('/^##[ \t]+\S/mu', $rest, $mm, PREG_OFFSET_CAPTURE)) {
-            $rest = substr($rest, 0, $mm[0][1]); // 次の H2 までを FAQ セクションとする
+        $start = $m[0][1];
+        $headingLen = strlen($m[0][0]);
+        $end = strlen($body);
+
+        // FAQ 見出しの後ろにさらに H2 があれば、そこを FAQ セクションの終端にする。
+        $rest = substr($body, $start + $headingLen);
+        if (preg_match(self::NEXT_H2, $rest, $mm, PREG_OFFSET_CAPTURE)) {
+            $end = $start + $headingLen + $mm[0][1];
         }
 
+        $faqBody = substr($body, $start, $end - $start);
+        $mainBody = rtrim(substr($body, 0, $start));
+        $tail = trim(substr($body, $end));
+        if ($tail !== '') $mainBody .= "\n\n" . $tail;
+
+        return [$mainBody, $faqBody];
+    }
+
+    /**
+     * FAQ セクション本文から Q&A を抽出（FAQPage 構造化データ用）。
+     * ### を質問、続くテキストを回答（プレーン化）とする。無ければ空配列。
+     * @return FaqItemDto[]
+     */
+    private function extractFaq(string $faqBody): array
+    {
         $faq = [];
-        if (preg_match_all('/^###[ \t]+(.+?)[ \t]*$([\s\S]*?)(?=^###[ \t]+|\z)/mu', $rest, $sets, PREG_SET_ORDER)) {
+        if (preg_match_all('/^###[ \t]+(.+?)[ \t]*$([\s\S]*?)(?=^###[ \t]+|\z)/mu', $faqBody, $sets, PREG_SET_ORDER)) {
             foreach ($sets as $s) {
                 $q = trim($s[1]);
-                $a = trim((string)preg_replace('/\s+/u', ' ', strip_tags($this->render($s[2]))));
-                if ($q !== '' && $a !== '') $faq[] = ['q' => $q, 'a' => $a];
+                $a = trim((string)(preg_replace('/\s+/u', ' ', strip_tags($this->render($s[2]))) ?? ''));
+                if ($q !== '' && $a !== '') $faq[] = new FaqItemDto(q: $q, a: $a);
             }
         }
         return $faq;
@@ -147,16 +175,18 @@ class BlogService
     {
         // 「結論」ボックス（Smart Brevity の要点先出し）: :::point ... ::: で囲んだ箇条書きを
         // ラベル付きカードにする。中身は Markdown として描画してから div で包む（html_input=allow で保持）。
-        $markdown = (string)preg_replace_callback(
+        $markdown = (string)(preg_replace_callback(
             '/^:::point[ \t]*\n(.*?)\n:::[ \t]*$/msu',
             fn($m) => "\n\n<div class=\"blog-point\"><p class=\"blog-point__label\">結論</p>"
                 . $this->render(trim($m[1])) . "</div>\n\n",
             $markdown
-        );
+        ) ?? $markdown);
 
         // CJK 特有の CommonMark バグ回避: 太字 ** が全角約物（（。、「等）に隣接すると emphasis を
         // 閉じ/開きできず「**」が文字のまま残る。太字は先に <strong> へ変換しておく（html_input=allow で保持）。
-        $markdown = (string)preg_replace('/\*\*([^*\n]{1,120}?)\*\*/u', '<strong>$1</strong>', $markdown);
+        // [^*\n] は '*' を跨がないので、長さ上限を付けずとも隣接ペアを正しく閉じる
+        // （上限を付けると、長い太字の閉じ ** と次の太字の開き ** が誤結合して本文が壊れる）。
+        $markdown = (string)(preg_replace('/\*\*([^*\n]+?)\*\*/u', '<strong>$1</strong>', $markdown) ?? $markdown);
 
         $environment = new Environment(['html_input' => 'allow', 'allow_unsafe_links' => false]);
         $environment->addExtension(new CommonMarkCoreExtension());

--- a/app/Services/Blog/Dto/BlogArticleDto.php
+++ b/app/Services/Blog/Dto/BlogArticleDto.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Blog\Dto;
+
+/**
+ * 1記事の全データ（frontmatter ＋ レンダリング済み本文）。
+ *
+ * $html / $faqHtml は commonmark 済みの信頼 HTML。View では _ 付き変数として
+ * 生出力する（DTO 自体を View に渡すと自動エスケープでこの 2 つも escape されるため、
+ * Controller 側で _html / _faqHtml に取り出してから渡す）。
+ */
+class BlogArticleDto
+{
+    /**
+     * @param FaqItemDto[] $faq
+     */
+    function __construct(
+        public string $slug,
+        public string $title,
+        public string $description,
+        public string $date,
+        public string $updated,
+        public string $category,
+        public int $wordCount,
+        public int $readingMinutes,
+        public array $faq,
+        public string $html,
+        public string $faqHtml,
+    ) {}
+}

--- a/app/Services/Blog/Dto/BlogSummaryDto.php
+++ b/app/Services/Blog/Dto/BlogSummaryDto.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Blog\Dto;
+
+/**
+ * 記事一覧・関連記事の表示用データ（frontmatter のみ・本文レンダリングなし）。
+ * View へ直接渡してプロパティ参照する（非 _ プロパティは View 層で自動エスケープされる）。
+ */
+class BlogSummaryDto
+{
+    function __construct(
+        public string $slug,
+        public string $title,
+        public string $description,
+        public string $date,
+        public string $category,
+    ) {}
+}

--- a/app/Services/Blog/Dto/FaqItemDto.php
+++ b/app/Services/Blog/Dto/FaqItemDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Blog\Dto;
+
+/**
+ * 本文の「よくある質問」セクションから抽出した Q&A 1件（FAQPage 構造化データ用）。
+ */
+class FaqItemDto
+{
+    function __construct(
+        public string $q,
+        public string $a,
+    ) {}
+}

--- a/app/Services/RankingBan/Dto/RankingBanPageDto.php
+++ b/app/Services/RankingBan/Dto/RankingBanPageDto.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\RankingBan\Dto;
+
+/**
+ * 掲載分析（labs/publication-analytics）の 1 ページ分の結果。
+ *
+ * @see \App\Services\RankingBan\RakingBanPageService::getAllOrderByDateTime()
+ */
+class RankingBanPageDto
+{
+    /**
+     * @param array     $openChatList 表示用ルーム行（components/open_chat_list_ranking_ban が描画）
+     * @param string[]  $labelArray   ページャ生成用の「消えた日時」一覧（降順）
+     */
+    function __construct(
+        public int $pageNumber,
+        public int $maxPageNumber,
+        public array $openChatList,
+        public int $totalRecords,
+        public array $labelArray,
+    ) {}
+}

--- a/app/Services/RankingBan/RakingBanPageService.php
+++ b/app/Services/RankingBan/RakingBanPageService.php
@@ -6,6 +6,7 @@ namespace App\Services\RankingBan;
 
 use App\Services\Traits\TraitPaginationRecordsCalculator;
 use App\Models\RankingBanRepositories\RankingBanPageRepository;
+use App\Services\RankingBan\Dto\RankingBanPageDto;
 
 class RakingBanPageService
 {
@@ -21,9 +22,9 @@ class RakingBanPageService
      * @param int $change 0:内容変更ありのみ, 1:変更なしのみ, 2:すべて
      * @param string $since 消えた日の開始 YYYY-MM-DD（検証済み・空文字なら条件なし）
      * @param string $until 消えた日の終了 YYYY-MM-DD（同上）
-     * @return array{ pageNumber:int,maxPageNumber:int,openChatList:array,totalRecords:int,labelArray:array }
+     * @return RankingBanPageDto|null ページ範囲外なら null
      */
-    public function getAllOrderByDateTime(int $change, int $publish, int $percent, string $keyword, int $pageNumber, int $limit, string $since = '', string $until = ''): array|false
+    public function getAllOrderByDateTime(int $change, int $publish, int $percent, string $keyword, int $pageNumber, int $limit, string $since = '', string $until = ''): ?RankingBanPageDto
     {
         $labelArray = $this->rankingBanPageRepository->findAllDatetimeColumn($change, $publish, $percent, $keyword, $since, $until);
 
@@ -32,7 +33,7 @@ class RakingBanPageService
         $maxPageNumber = $this->calcMaxPages($totalRecords, $limit);
         if ($pageNumber > $maxPageNumber) {
             // 現在のページ番号が最大ページ番号を超えている場合
-            return false;
+            return null;
         }
 
         // リストを取得する
@@ -55,12 +56,12 @@ class RakingBanPageService
             return $oc;
         }, $list);
 
-        return compact(
-            'pageNumber',
-            'maxPageNumber',
-            'openChatList',
-            'totalRecords',
-            'labelArray',
+        return new RankingBanPageDto(
+            pageNumber: $pageNumber,
+            maxPageNumber: $maxPageNumber,
+            openChatList: $openChatList,
+            totalRecords: $totalRecords,
+            labelArray: $labelArray,
         );
     }
 }

--- a/app/Services/SitemapGenerator.php
+++ b/app/Services/SitemapGenerator.php
@@ -28,6 +28,7 @@ class SitemapGenerator
         private OpenChatListRepositoryInterface $ocRepo,
         private RecommendUpdater $recommendUpdater,
         private FileStorageInterface $fileStorage,
+        private BlogService $blogService,
     ) {}
 
     function generate()
@@ -93,8 +94,8 @@ class SitemapGenerator
         if (MimimalCmsConfig::$urlRoot === '') {
             $sitemap->addItem($this->currentUrl . 'oc');
             $sitemap->addItem($this->currentUrl . 'blog');
-            foreach (app(BlogService::class)->list() as $a) {
-                $sitemap->addItem($this->currentUrl . 'blog/' . $a['slug'], lastmod: $a['date'] ?: $datetime);
+            foreach ($this->blogService->list() as $a) {
+                $sitemap->addItem($this->currentUrl . 'blog/' . $a->slug, lastmod: $a->date ?: $datetime);
             }
         }
 

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -11,14 +11,14 @@
                 <a href="<?php echo url('') ?>">トップ</a><span class="sep">›</span><a href="<?php echo url('blog') ?>">ブログ</a>
             </nav>
 
-            <h1 class="blog-title"><?php echo $article['title'] ?></h1>
+            <h1 class="blog-title"><?php echo $article->title ?></h1>
 
             <div class="blog-meta">
                 <span class="author">オプチャグラフ編集部</span>
-                <span>公開 <?php echo $article['date'] ?></span>
-                <?php if (($article['updated'] ?? '') && $article['updated'] !== $article['date']): ?><span>更新 <?php echo $article['updated'] ?></span><?php endif ?>
-                <span>約<?php echo (int)($article['readingMinutes'] ?? 1) ?>分</span>
-                <?php if ($article['category']): ?><span class="cat"><?php echo $article['category'] ?></span><?php endif ?>
+                <span>公開 <?php echo $article->date ?></span>
+                <?php if ($article->updated && $article->updated !== $article->date): ?><span>更新 <?php echo $article->updated ?></span><?php endif ?>
+                <span>約<?php echo $article->readingMinutes ?>分</span>
+                <?php if ($article->category): ?><span class="cat"><?php echo $article->category ?></span><?php endif ?>
             </div>
 
             <div class="blog-body">
@@ -42,9 +42,9 @@
                 <nav class="blog-related">
                     <div class="blog-related-h">関連記事</div>
                     <?php foreach ($related as $r): ?>
-                        <a href="<?php echo url('blog/' . $r['slug']) ?>">
-                            <div class="t"><?php echo $r['title'] ?></div>
-                            <?php if ($r['category']): ?><div class="c"><?php echo $r['category'] ?></div><?php endif ?>
+                        <a href="<?php echo url('blog/' . $r->slug) ?>">
+                            <div class="t"><?php echo $r->title ?></div>
+                            <?php if ($r->category): ?><div class="c"><?php echo $r->category ?></div><?php endif ?>
                         </a>
                     <?php endforeach ?>
                 </nav>

--- a/app/Views/blog_index_content.php
+++ b/app/Views/blog_index_content.php
@@ -5,7 +5,7 @@
 <body>
     <?php viewComponent('site_header') ?>
     <main style="overflow: hidden;">
-        <!-- $articles は View 層で自動エスケープ済み -->
+        <!-- $articles は BlogSummaryDto[]。プロパティ文字列は View 層で自動エスケープ済み -->
         <div class="blog">
             <nav class="blog-crumb">
                 <a href="<?php echo url('') ?>">トップ</a><span class="sep">›</span><span>ブログ</span>
@@ -19,13 +19,13 @@
                 <ul class="blog-cards">
                     <?php foreach ($articles as $a): ?>
                         <li>
-                            <a class="blog-card" href="<?php echo url('blog/' . $a['slug']) ?>">
-                                <div class="t"><?php echo $a['title'] ?></div>
+                            <a class="blog-card" href="<?php echo url('blog/' . $a->slug) ?>">
+                                <div class="t"><?php echo $a->title ?></div>
                                 <div class="m">
-                                    <?php if ($a['category']): ?><span class="cat"><?php echo $a['category'] ?></span><?php endif ?>
-                                    <span class="date"><?php echo $a['date'] ?></span>
+                                    <?php if ($a->category): ?><span class="cat"><?php echo $a->category ?></span><?php endif ?>
+                                    <span class="date"><?php echo $a->date ?></span>
                                 </div>
-                                <?php if ($a['description']): ?><p class="d"><?php echo $a['description'] ?></p><?php endif ?>
+                                <?php if ($a->description): ?><p class="d"><?php echo $a->description ?></p><?php endif ?>
                                 <div class="go">続きを読む</div>
                             </a>
                         </li>

--- a/app/Views/components/footer_inner.php
+++ b/app/Views/components/footer_inner.php
@@ -4,18 +4,18 @@
     <nav class="footer-link-box-outer">
         <section class="unset footer-link-box" style="padding: 0 1rem;">
             <ul class="footer-link-inner">
-                <li><a class="unset" href="<?php echo url('') ?>"><?php echo t('トップ') ?></a></il>
-                <li><a class="unset" href="<?php echo url('policy/privacy') ?>"><?php echo t('プライバシーポリシー') ?></a></il>
-                    <? if (\Shared\MimimalCmsConfig::$urlRoot === ''): ?>
-                <li><a class="unset" href="<?php echo url('policy/term') ?>">利用規約</a></il>
-                <? endif ?>
+                <li><a class="unset" href="<?php echo url('') ?>"><?php echo t('トップ') ?></a></li>
+                <li><a class="unset" href="<?php echo url('policy/privacy') ?>"><?php echo t('プライバシーポリシー') ?></a></li>
+                    <?php if (\Shared\MimimalCmsConfig::$urlRoot === ''): ?>
+                <li><a class="unset" href="<?php echo url('policy/term') ?>">利用規約</a></li>
+                <?php endif ?>
             </ul>
             <ul class="footer-link-inner">
-                <li><a class="unset" href="<?php echo url('policy') ?>"><?php echo t('オプチャグラフとは？') ?></a></il>
-                <? if (\Shared\MimimalCmsConfig::$urlRoot === ''): ?>
-                    <li><a class="unset" href="<?php echo url('labs') ?>">分析Labs</a></il>
-                    <li><a class="unset" href="<?php echo url('blog') ?>">ブログ</a></il>
-                <? endif ?>
+                <li><a class="unset" href="<?php echo url('policy') ?>"><?php echo t('オプチャグラフとは？') ?></a></li>
+                <?php if (\Shared\MimimalCmsConfig::$urlRoot === ''): ?>
+                    <li><a class="unset" href="<?php echo url('labs') ?>">分析Labs</a></li>
+                    <li><a class="unset" href="<?php echo url('blog') ?>">ブログ</a></li>
+                <?php endif ?>
             </ul>
         </section>
         <hr class="hr-bottom" style="margin: 0 1rem; padding: 3.5px 0; margin-top: 4px;">

--- a/app/Views/components/home_blog_shelf.php
+++ b/app/Views/components/home_blog_shelf.php
@@ -2,7 +2,7 @@
 
 /**
  * ホームの「読み物（ブログ）」棚。最新記事を最大4本、最大の入口（トップ）から回遊させる。
- * BlogService->list() は frontmatter のみの軽量読み（本文レンダリングなし）。ja 用。
+ * BlogService->list() は frontmatter のみの軽量読み（BlogSummaryDto[] を返す・本文なし）。ja 用。
  * viewComponent 経由なので自動エスケープは無く、表示値は h() でエスケープする。
  */
 
@@ -17,11 +17,11 @@ if (!$_posts) return;
     <ul class="hbs-list">
         <?php foreach ($_posts as $p) : ?>
             <li>
-                <a class="hbs-card unset" href="<?php echo url('blog/' . $p['slug']) ?>">
-                    <div class="hbs-card-t"><?php echo h($p['title']) ?></div>
+                <a class="hbs-card unset" href="<?php echo url('blog/' . $p->slug) ?>">
+                    <div class="hbs-card-t"><?php echo h($p->title) ?></div>
                     <div class="hbs-card-m">
-                        <?php if ($p['category']) : ?><span class="hbs-cat"><?php echo h($p['category']) ?></span><?php endif ?>
-                        <span class="hbs-date"><?php echo h($p['date']) ?></span>
+                        <?php if ($p->category) : ?><span class="hbs-cat"><?php echo h($p->category) ?></span><?php endif ?>
+                        <span class="hbs-date"><?php echo h($p->date) ?></span>
                     </div>
                 </a>
             </li>

--- a/app/Views/components/pager_nav_ranking_ban.php
+++ b/app/Views/components/pager_nav_ranking_ban.php
@@ -1,7 +1,7 @@
 <!-- @param string $path -->
 <!-- @param array $params -->
 <!-- @param int $pageNumber -->
-<!-- @param ing $maxPageNumber -->
+<!-- @param int $maxPageNumber -->
 <nav class="search-pager rb-pager">
     <?php
 

--- a/app/Views/ranking_ban_content.php
+++ b/app/Views/ranking_ban_content.php
@@ -344,6 +344,8 @@ viewComponent('head', compact('_css', '_meta')) ?>
 
             let aborter = null;
             let initial = true;
+            let gen = 0; // ロード世代。中断が間に合わず解決した古いfetchの遅延描画/二重pushStateを無効化する
+            const FB_KEY = 'rb-page1-404-fallback'; // page=1 で404が続くときの全体遷移ループ防止フラグ
 
             const setBusy = (busy) => {
                 results.setAttribute('aria-busy', busy ? 'true' : 'false');
@@ -360,6 +362,7 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 opts = opts || {};
                 if (aborter) aborter.abort();
                 aborter = new AbortController();
+                const myGen = ++gen;
                 updateSummary();
                 summaryCount.textContent = '— 集計中…';
                 setBusy(true);
@@ -369,12 +372,20 @@ viewComponent('head', compact('_css', '_meta')) ?>
                         if (res.ok) return res.text();
                         if (res.status === 404) {
                             if (s.page > 1) {
-                                // ページ範囲外: 1ページ目に戻して再取得
+                                // ページ範囲外: 1ページ目に戻して再取得。push の有無に関わらず
+                                // URL を1ページ目へ補正する（初回・popstate でアドレスバーが range 外のまま残るのを防ぐ）
                                 state.page = 1;
-                                load({ push: opts.push });
+                                history.replaceState(state, '', pageUrl(state));
+                                load({ push: false });
                                 return null;
                             }
-                            // page=1での404は通常起きない。通常遷移にフォールバック
+                            // page=1での404は通常起きない。1度だけ通常遷移にフォールバックし、
+                            // 連続404のときはエラー表示に切り替えて全体リロードのループを防ぐ
+                            if (sessionStorage.getItem(FB_KEY)) {
+                                sessionStorage.removeItem(FB_KEY);
+                                throw new Error('HTTP 404');
+                            }
+                            sessionStorage.setItem(FB_KEY, '1');
                             location.href = pageUrl(s);
                             return null;
                         }
@@ -383,6 +394,8 @@ viewComponent('head', compact('_css', '_meta')) ?>
                     })
                     .then((html) => {
                         if (html === null || html === undefined) return;
+                        if (myGen !== gen) return; // より新しいロードに追い越されていれば、この古い応答は破棄
+                        sessionStorage.removeItem(FB_KEY);
                         results.innerHTML = html;
                         initial = false;
                         setBusy(false);
@@ -398,6 +411,7 @@ viewComponent('head', compact('_css', '_meta')) ?>
                     })
                     .catch((err) => {
                         if (err && err.name === 'AbortError') return;
+                        if (myGen !== gen) return; // 古いロードのエラーは無視（最新のロードが状態を持つ）
                         initial = false;
                         setBusy(false);
                         summaryCount.textContent = '';


### PR DESCRIPTION
直近リリース（PR #314 / `7a37bf05`）で入った**ブログ機能**と**掲載分析**の、**型付けリファクタ（連想配列→DTO）がメイン**です。あわせて**掲載分析のロジック修正**と、**現状は未発火だが将来踏みうる潜在バグの予防**を含みます。表示仕様・挙動は変えていません。

## ♻️ リファクタ（メイン：連想配列 → 型付き値オブジェクト / DI / DRY）
- `BlogService` の戻り値を `BlogArticleDto` / `BlogSummaryDto` / `FaqItemDto` に型付け（`@return array{...}` と実体の乖離＝弱い型を解消）
- `RakingBanPageService::getAllOrderByDateTime` を `RankingBanPageDto|null` に型付け（`array|false` を解消）
- `SitemapGenerator` の `app(BlogService)` をコンストラクタDIに統一
- `content/blog` ディレクトリ定数を `AppConfig::BLOG_CONTENT_DIR` に集約
- `BlogService::list()` を1リクエスト内でメモ化（毎回の glob＋全ファイル read を回避）
- 細部：footer の短縮タグ `<?`／誤閉じ `</il>`、コントローラ戻り値型、`@param` typo

## 🔧 ロジック修正：掲載分析（`labs/publication-analytics`）
※実際に起こりうるエッジケースの修正
- 範囲外ページの共有/ブックマークURL・ブラウザバック時に、1ページ目へ補正してもアドレスバーが範囲外のまま残る → `history.replaceState` で補正
- page=1 の 404 で全体リロードが無限ループしうる箇所にガード追加
- 追い越された古い fetch の遅延描画・二重 pushState を、ロード世代トークンで破棄

## 🛡️ 潜在バグの予防：ブログ
※**いずれも現コンテンツでは未発火**。将来の記事で踏む前に塞ぐ
- 太字 `**`→`<strong>` の120字上限を撤廃（長い強調＋後続の強調で `**` が誤結合し本文が崩れうる）
- frontmatter の日付が不正な記事が1本でもあると `/blog` 一覧ごと500 → 安全パースで現在時刻フォールバック
- 「## よくある質問」の境界判定を表示用とFAQPage用で統一（FAQ後に節を足しても崩れない）

## ✅ 検証
- 変更PHP 17ファイルすべて `php -l` パス
- `BlogService` をスタンドアロン実行で確認：list/get/related が DTO を返す・FAQ抽出・太字描画・トラバーサル防止・メモ化が正常。FAQの後ろに節を足したケース／太字の誤結合ケースの修正も再現テスト済み
- 掲載分析の期間絞り込みSQL（件数とリストで同一WHEREが効く整合）はレビュー済み・挙動不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)
