### PR TITLE
[PROD] fix: トップとブログの表示崩れ・押せないリンクを解消しCSSの土台を整理（#319 の本番反映）

### DIFF
--- a/app/Controllers/Pages/BlogController.php
+++ b/app/Controllers/Pages/BlogController.php
@@ -39,7 +39,7 @@ class BlogController
                     ->headline($a->title)
                     ->url(url('blog/' . $a->slug))
                     ->datePublished($this->toDate($a->date))
-                    ->dateModified($this->toDate($a->updated ?: $a->date)),
+                    ->dateModified($this->modifiedDate($a->date, $a->updated)),
                 $articles
             ))
             ->toScript();
@@ -64,7 +64,7 @@ class BlogController
             ->description($article->description)
             ->image($_meta->image_url)
             ->datePublished($this->toDate($article->date))
-            ->dateModified($this->toDate($article->updated ?: $article->date))
+            ->dateModified($this->modifiedDate($article->date, $article->updated))
             ->inLanguage('ja')
             ->articleSection($article->category)
             ->wordCount($article->wordCount)
@@ -104,6 +104,15 @@ class BlogController
         } catch (\Throwable) {
             return new \DateTimeImmutable('now');
         }
+    }
+
+    /**
+     * dateModified 用：更新日をパースし、公開日より過去にならないようクランプする
+     * （frontmatter の入力ミスで dateModified < datePublished の不正な構造化データを出さない）。
+     */
+    private function modifiedDate(string $date, string $updated): \DateTimeImmutable
+    {
+        return max($this->toDate($date), $this->toDate($updated));
     }
 
     private function publisher(): Organization

--- a/app/Controllers/Pages/BlogController.php
+++ b/app/Controllers/Pages/BlogController.php
@@ -38,7 +38,8 @@ class BlogController
                 fn(BlogSummaryDto $a) => Schema::blogPosting()
                     ->headline($a->title)
                     ->url(url('blog/' . $a->slug))
-                    ->datePublished($this->toDate($a->date)),
+                    ->datePublished($this->toDate($a->date))
+                    ->dateModified($this->toDate($a->updated ?: $a->date)),
                 $articles
             ))
             ->toScript();

--- a/app/Services/Blog/BlogService.php
+++ b/app/Services/Blog/BlogService.php
@@ -46,6 +46,7 @@ class BlogService
                 title: $fm['title'] ?? $slug,
                 description: $fm['description'] ?? '',
                 date: $fm['date'] ?? '',
+                updated: $fm['updated'] ?? ($fm['date'] ?? ''),
                 category: $fm['category'] ?? '',
             );
         }

--- a/app/Services/Blog/BlogService.php
+++ b/app/Services/Blog/BlogService.php
@@ -46,11 +46,13 @@ class BlogService
                 title: $fm['title'] ?? $slug,
                 description: $fm['description'] ?? '',
                 date: $fm['date'] ?? '',
-                updated: $fm['updated'] ?? ($fm['date'] ?? ''),
+                // ?: で空文字の updated:（値なし行）も公開日へフォールバックさせる（?? だと '' が素通りする）
+                updated: ($fm['updated'] ?? '') ?: ($fm['date'] ?? ''),
                 category: $fm['category'] ?? '',
             );
         }
-        usort($out, static fn(BlogSummaryDto $a, BlogSummaryDto $b) => strcmp($b->date, $a->date));
+        // 一覧・トップ棚は更新日を表示するため、表示と並び順がズレないよう更新日降順（同日は公開日降順）
+        usort($out, static fn(BlogSummaryDto $a, BlogSummaryDto $b) => strcmp($b->updated, $a->updated) ?: strcmp($b->date, $a->date));
         return $this->listCache = $out;
     }
 
@@ -78,7 +80,8 @@ class BlogService
             title: $fm['title'] ?? $slug,
             description: $fm['description'] ?? '',
             date: $fm['date'] ?? '',
-            updated: $fm['updated'] ?? ($fm['date'] ?? ''),
+            // ?: で空文字の updated:（値なし行）も公開日へフォールバックさせる（list() と同じ規則）
+            updated: ($fm['updated'] ?? '') ?: ($fm['date'] ?? ''),
             category: $fm['category'] ?? '',
             wordCount: mb_strlen($plain),
             readingMinutes: max(1, (int)ceil(mb_strlen($plain) / 500)),
@@ -89,7 +92,7 @@ class BlogService
     }
 
     /**
-     * 関連記事（同カテゴリ優先・日付降順・自身を除く）。
+     * 関連記事（同カテゴリ優先・更新日降順・自身を除く）。
      * @return BlogSummaryDto[]
      */
     public function related(string $slug, string $category, int $limit = 4): array
@@ -98,7 +101,7 @@ class BlogService
         usort($all, static function (BlogSummaryDto $a, BlogSummaryDto $b) use ($category) {
             $sa = ($a->category === $category) ? 0 : 1;
             $sb = ($b->category === $category) ? 0 : 1;
-            return ($sa <=> $sb) ?: strcmp($b->date, $a->date);
+            return ($sa <=> $sb) ?: strcmp($b->updated, $a->updated);
         });
         return array_slice($all, 0, $limit);
     }

--- a/app/Services/Blog/Dto/BlogSummaryDto.php
+++ b/app/Services/Blog/Dto/BlogSummaryDto.php
@@ -15,6 +15,7 @@ class BlogSummaryDto
         public string $title,
         public string $description,
         public string $date,
+        public string $updated,
         public string $category,
     ) {}
 }

--- a/app/Services/SitemapGenerator.php
+++ b/app/Services/SitemapGenerator.php
@@ -95,7 +95,8 @@ class SitemapGenerator
             $sitemap->addItem($this->currentUrl . 'oc');
             $sitemap->addItem($this->currentUrl . 'blog');
             foreach ($this->blogService->list() as $a) {
-                $sitemap->addItem($this->currentUrl . 'blog/' . $a->slug, lastmod: $a->date ?: $datetime);
+                // lastmod は鮮度を反映する更新日（無ければ公開日）
+                $sitemap->addItem($this->currentUrl . 'blog/' . $a->slug, lastmod: $a->updated ?: ($a->date ?: $datetime));
             }
         }
 

--- a/app/Services/SitemapGenerator.php
+++ b/app/Services/SitemapGenerator.php
@@ -95,8 +95,15 @@ class SitemapGenerator
             $sitemap->addItem($this->currentUrl . 'oc');
             $sitemap->addItem($this->currentUrl . 'blog');
             foreach ($this->blogService->list() as $a) {
-                // lastmod は鮮度を反映する更新日（無ければ公開日）
-                $sitemap->addItem($this->currentUrl . 'blog/' . $a->slug, lastmod: $a->updated ?: ($a->date ?: $datetime));
+                // lastmod は鮮度を反映する更新日（BlogService が公開日へのフォールバック済み）。
+                // frontmatter の日付 typo 1件で毎時のサイトマップ生成全体が中断しないよう
+                // ここでパースを検証し、不正値は毎時更新時刻に倒す（BlogController::toDate と同趣旨）。
+                try {
+                    $lastmod = new \DateTimeImmutable($a->updated !== '' ? $a->updated : $datetime);
+                } catch (\Throwable) {
+                    $lastmod = new \DateTimeImmutable($datetime);
+                }
+                $sitemap->addItem($this->currentUrl . 'blog/' . $a->slug, lastmod: $lastmod);
             }
         }
 

--- a/app/Views/admin/admin_confirm_page.php
+++ b/app/Views/admin/admin_confirm_page.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="<?php echo fileUrl("style/mvp.css", urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_header.css", urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_footer.css", urlRoot: '') ?>">
     <title><?php echo $title ?? '確認' ?></title>

--- a/app/Views/admin/admin_message_page.php
+++ b/app/Views/admin/admin_message_page.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="<?php echo fileUrl("style/mvp.css", urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_header.css", urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_footer.css", urlRoot: '') ?>">
     <title><?php echo $title ?? 'admin' ?></title>

--- a/app/Views/admin/admin_page_template.php
+++ b/app/Views/admin/admin_page_template.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="<?php echo fileUrl("style/mvp.css", urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_header.css", urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_footer.css", urlRoot: '') ?>">
     <title><?php echo $title ?? 'admin' ?></title>

--- a/app/Views/admin/ads_register.php
+++ b/app/Views/admin/ads_register.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="<?php echo fileUrl("style/mvp.css", urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_header.css", urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_footer.css", urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/ads_element.css", urlRoot: '') ?>">

--- a/app/Views/admin/dash_my_list.php
+++ b/app/Views/admin/dash_my_list.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="<?php echo fileUrl("style/mvp.css", urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_header.css", urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/site_footer.css", urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl("style/room_list.css", urlRoot: '') ?>">

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -4,7 +4,7 @@
 
 <body>
     <?php viewComponent('site_header') ?>
-    <main style="overflow: hidden;">
+    <main class="blog-main" style="overflow: hidden;">
         <!-- $article のテキストは View 層で自動エスケープ済み。$_html/$_faqHtml は commonmark 済みの信頼ソースで生出力 -->
         <article class="blog blog-article">
             <nav class="blog-crumb">

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -4,7 +4,7 @@
 
 <body>
     <?php viewComponent('site_header') ?>
-    <main class="blog-main" style="overflow: hidden;">
+    <main class="no-pad blog-main">
         <!-- $article のテキストは View 層で自動エスケープ済み。$_html/$_faqHtml は commonmark 済みの信頼ソースで生出力 -->
         <article class="blog blog-article">
             <nav class="blog-crumb">
@@ -16,7 +16,8 @@
             <div class="blog-meta">
                 <span class="author">オプチャグラフ編集部</span>
                 <span>公開 <?php echo $article->date ?></span>
-                <?php if ($article->updated && $article->updated !== $article->date): ?><span>更新 <?php echo $article->updated ?></span><?php endif ?>
+                <?php // YYYY-MM-DD の文字列比較。> で「公開日より古い更新日」（入力ミス）を表示しない ?>
+                <?php if ($article->updated > $article->date): ?><span>更新 <?php echo $article->updated ?></span><?php endif ?>
                 <span>約<?php echo $article->readingMinutes ?>分</span>
                 <?php if ($article->category): ?><span class="cat"><?php echo $article->category ?></span><?php endif ?>
             </div>

--- a/app/Views/blog_index_content.php
+++ b/app/Views/blog_index_content.php
@@ -4,7 +4,7 @@
 
 <body>
     <?php viewComponent('site_header') ?>
-    <main class="blog-main" style="overflow: hidden;">
+    <main class="no-pad blog-main">
         <!-- $articles は BlogSummaryDto[]。プロパティ文字列は View 層で自動エスケープ済み -->
         <div class="blog">
             <nav class="blog-crumb">

--- a/app/Views/blog_index_content.php
+++ b/app/Views/blog_index_content.php
@@ -4,7 +4,7 @@
 
 <body>
     <?php viewComponent('site_header') ?>
-    <main style="overflow: hidden;">
+    <main class="blog-main" style="overflow: hidden;">
         <!-- $articles は View 層で自動エスケープ済み -->
         <div class="blog">
             <nav class="blog-crumb">

--- a/app/Views/blog_index_content.php
+++ b/app/Views/blog_index_content.php
@@ -23,7 +23,8 @@
                                 <div class="t"><?php echo $a->title ?></div>
                                 <div class="m">
                                     <?php if ($a->category): ?><span class="cat"><?php echo $a->category ?></span><?php endif ?>
-                                    <span class="date"><?php echo $a->date ?></span>
+                                    <?php // 一覧では鮮度が伝わる更新日を表示（公開日・更新日の両方は記事ページで表示） ?>
+                                    <span class="date"><?php echo $a->updated ?></span>
                                 </div>
                                 <?php if ($a->description): ?><p class="d"><?php echo $a->description ?></p><?php endif ?>
                                 <div class="go">続きを読む</div>

--- a/app/Views/components/head.php
+++ b/app/Views/components/head.php
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
     <link rel="stylesheet" href="<?php echo fileUrl('style/mvp.css', urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <?php foreach ($_css as $css) : ?>
         <link rel="stylesheet" href="<?php echo fileUrl("style/{$css}.css", urlRoot: '') ?>">
     <?php endforeach ?>

--- a/app/Views/components/home_blog_shelf.php
+++ b/app/Views/components/home_blog_shelf.php
@@ -22,7 +22,8 @@ if (!$_posts) return;
                     <div class="hbs-card-t"><?php echo h($p->title) ?></div>
                     <div class="hbs-card-m">
                         <?php if ($p->category) : ?><span class="hbs-cat"><?php echo h($p->category) ?></span><?php endif ?>
-                        <span class="hbs-date"><?php echo h($p->date) ?></span>
+                        <?php // 鮮度が伝わる更新日を表示（公開日は記事ページで表示） ?>
+                        <span class="hbs-date"><?php echo h($p->updated) ?></span>
                     </div>
                 </a>
             </li>

--- a/app/Views/components/home_blog_shelf.php
+++ b/app/Views/components/home_blog_shelf.php
@@ -11,7 +11,8 @@ if (!$_posts) return;
 ?>
 <article class="home-blog-shelf">
     <header class="hbs-head">
-        <h2 class="hbs-title"><span>読み物</span><span aria-hidden="true">📖</span></h2>
+        <?php // 見出しは他セクション（room_list.css .openchat-list-title=グラデ文字）とスタイルを共通化 ?>
+        <h2 class="hbs-title"><span class="openchat-list-title">読み物</span><span aria-hidden="true">📖</span></h2>
         <a class="hbs-more unset" href="<?php echo url('blog') ?>">ブログをもっと見る →</a>
     </header>
     <ul class="hbs-list">
@@ -29,11 +30,13 @@ if (!$_posts) return;
     </ul>
 </article>
 <style>
-    .home-blog-shelf { padding: 0 1rem; font-family: var(--font-family); }
-    .home-blog-shelf .hbs-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: .7rem; }
-    .home-blog-shelf .hbs-title { all: unset; display: flex; align-items: center; gap: 5px; font-size: 16px; font-weight: bold; color: #111; }
-    .home-blog-shelf .hbs-title span:last-child { font-size: 13px; }
-    .home-blog-shelf .hbs-more { font-size: 12.5px; font-weight: bold; color: #06c755; text-decoration: none; white-space: nowrap; }
+    /* 上下 .5rem は隣接セクション（.top-ranking の padding: .5rem 0）と同じ余白リズム */
+    .home-blog-shelf { padding: .5rem 1rem; font-family: var(--font-family); }
+    .home-blog-shelf .hbs-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+    .home-blog-shelf .hbs-title { all: unset; display: flex; align-items: center; gap: 5px; }
+    .home-blog-shelf .hbs-title span:last-child { font-size: 15px; }
+    /* タップ領域は padding で広げ、負マージンで見た目の位置は変えない */
+    .home-blog-shelf .hbs-more { font-size: 13.5px; font-weight: bold; color: #06c755; text-decoration: none; white-space: nowrap; padding: .6rem 0 .6rem .6rem; margin: -.6rem 0; }
     .home-blog-shelf .hbs-list { all: unset; display: grid; gap: 8px; }
     .home-blog-shelf .hbs-list li { all: unset; }
     .home-blog-shelf .hbs-card { display: block; padding: .8rem .95rem; border: 1px solid #ededf0; border-radius: 12px; text-decoration: none; transition: border-color .15s, box-shadow .15s; }

--- a/app/Views/components/oc_head.php
+++ b/app/Views/components/oc_head.php
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
     <link rel="stylesheet" href="<?php echo fileUrl('style/mvpmin.css', urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <?php foreach ($_css as $css) : ?>
         <link rel="stylesheet" href="<?php echo fileUrl("style/{$css}.css", urlRoot: '') ?>">
     <?php endforeach ?>

--- a/app/Views/components/policy_head.php
+++ b/app/Views/components/policy_head.php
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
     <link rel="stylesheet" href="<?php echo fileUrl('style/mvpmin.css', urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <?php foreach ($_css as $css) : ?>
         <link rel="stylesheet" href="<?php echo fileUrl("style/{$css}.css", urlRoot: '') ?>">
     <?php endforeach ?>

--- a/app/Views/errors/error.php
+++ b/app/Views/errors/error.php
@@ -314,7 +314,8 @@ try {
         <div style="margin: 0 -1rem; ">
             <?php viewComponent('site_header') ?>
         </div>
-        <header style="padding: 0;">
+        <?php // mvp.css は素の header を装飾しなくなったため、中央寄せはここで指定 ?>
+        <header style="padding: 0; text-align: center;">
             <?php if ($httpCode != 410 || !strpos(path(), 'oc/')) : ?>
                 <h1><?php echo $httpCode ?? '' ?></h1>
                 <h2><?php echo $httpStatusMessage ?? '' ?></h2>

--- a/app/Views/errors/invalid_cookie.php
+++ b/app/Views/errors/invalid_cookie.php
@@ -38,7 +38,8 @@ $_css = ['room_list', 'site_header', 'site_footer'];
     <!-- 固定ヘッダー -->
     <?php viewComponent('site_header') ?>
     <main>
-        <header>
+        <?php // mvp.css は素の header を装飾しなくなったため、中央寄せはここで指定 ?>
+        <header style="text-align: center;">
             <h1>400</h1>
             <h2>Bad Request</h2>
             <br>

--- a/app/Views/errors/invalid_cookie.php
+++ b/app/Views/errors/invalid_cookie.php
@@ -38,8 +38,8 @@ $_css = ['room_list', 'site_header', 'site_footer'];
     <!-- 固定ヘッダー -->
     <?php viewComponent('site_header') ?>
     <main>
-        <?php // mvp.css は素の header を装飾しなくなったため、中央寄せはここで指定 ?>
-        <header style="text-align: center;">
+        <?php // mvp.css は素の header を装飾しなくなったため、中央寄せと余白（旧 header{padding:3rem 1rem} 相当）はここで指定 ?>
+        <header style="text-align: center; padding: 0 1rem 3rem;">
             <h1>400</h1>
             <h2>Bad Request</h2>
             <br>

--- a/app/Views/errors/oc_error.php
+++ b/app/Views/errors/oc_error.php
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
     <link rel="stylesheet" href="<?php echo fileUrl('style/mvpmin.css', urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
     <?php foreach ($_css as $css) : ?>
         <link rel="stylesheet" href="<?php echo fileUrl("style/{$css}.css", urlRoot: '') ?>">
     <?php endforeach ?>

--- a/app/Views/term_content.php
+++ b/app/Views/term_content.php
@@ -23,6 +23,7 @@ use App\Config\AppConfig;
     <meta name="twitter:card" content="summary">
     <link rel="icon" type="image/png" href="<?php echo fileUrl('assets/icon-192x192.png', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/mvp.css', urlRoot: '') ?>">
+    <link rel="stylesheet" href="<?php echo fileUrl('style/unset.css', urlRoot: '') ?>">
 </head>
 
 <body>

--- a/public/style/blog.css
+++ b/public/style/blog.css
@@ -5,9 +5,11 @@
 
 /* mvp.css の main{padding:3rem 1rem} はブログでは過大
    （固定ヘッダーのスペーサー48px と合わせて上に約110pxの空白ができ、
-   横も .blog の 1.15rem と二重になる）。余白は .blog 側で一元管理する。 */
-.blog-main {
+   横も .blog の 1.15rem と二重になる）。mvp.css の main.no-pad と併用し、
+   余白はここで一元管理する（main.no-pad と同特異度のため後勝ちで上書き）。 */
+main.blog-main {
   padding: 14px 0 1.5rem;
+  overflow: hidden;
 }
 
 .blog {
@@ -87,11 +89,20 @@
 
 /* ---- 本文 ---- */
 .blog-body { font-size: 16px; line-height: 1.95; color: var(--text); }
-.blog-body > h2 {
-  font-size: 1.27rem; font-weight: 800; color: var(--ink);
-  line-height: 1.5; margin: 2.4rem 0 1rem; padding: 2px 0 2px 13px;
-  border-left: 4px solid var(--g); letter-spacing: -0.01em;
+
+/* H2級見出しの共通視覚言語（緑ボーダー左）。本文・FAQ・関連記事で一箇所だけ直せば揃う。
+   サイズ・余白だけ文脈ごとに個別指定する。 */
+.blog-body > h2,
+.blog-faq > h2,
+.blog-related-h {
+  font-weight: 800;
+  color: var(--ink);
+  line-height: 1.5;
+  padding: 2px 0 2px 13px;
+  border-left: 4px solid var(--g);
+  letter-spacing: -0.01em;
 }
+.blog-body > h2 { font-size: 1.27rem; margin: 2.4rem 0 1rem; }
 .blog-body > h2:first-child { margin-top: .6rem; }
 .blog-body h3 {
   font-size: 1.08rem; font-weight: 700; color: var(--ink);
@@ -189,10 +200,8 @@
 
 /* ---- FAQ ---- */
 .blog-faq { margin: 2.6rem 0 1rem; }
-.blog-faq > h2 {
-  font-size: 1.27rem; font-weight: 800; color: var(--ink);
-  margin: 0 0 1rem; padding-left: 13px; border-left: 4px solid var(--g);
-}
+/* 見出しのベースは上の共通グループ（緑ボーダー左）で定義 */
+.blog-faq > h2 { font-size: 1.27rem; margin: 0 0 1rem; }
 .blog-faq h3 {
   position: relative; font-size: 1.02rem; font-weight: 700; color: var(--ink);
   margin: 0; padding: 1rem 0 .55rem 1.9rem; line-height: 1.6;
@@ -215,8 +224,8 @@
 /* mvp.css のグローバル nav{display:flex} を打ち消す（カードは縦積み） */
 .blog-related { display: block; margin: 2.4rem 0 1rem; }
 .blog-related a { display: block; }
-/* 見出しの視覚言語を本文 h2・FAQ と統一（緑のボーダー左） */
-.blog-related-h { font-size: 1.1rem; font-weight: 800; color: var(--ink); margin: 0 0 .9rem; padding-left: 13px; border-left: 4px solid var(--g); }
+/* 見出しのベースは本文側の共通グループ（緑ボーダー左）で定義 */
+.blog-related-h { font-size: 1.1rem; margin: 0 0 .9rem; }
 .blog-related a {
   display: block; padding: .85rem 1rem; margin-bottom: .6rem;
   border: 1px solid var(--line); border-radius: 12px; text-decoration: none;
@@ -263,7 +272,7 @@
 .blog-card:hover .go::after { transform: translateX(3px); }
 
 @media (min-width: 600px) {
-  .blog-main { padding-top: 22px; }
+  main.blog-main { padding-top: 22px; }
   .blog-title { font-size: 1.95rem; }
   .blog-body { font-size: 16.5px; }
   .blog-cards { grid-template-columns: 1fr 1fr; }

--- a/public/style/blog.css
+++ b/public/style/blog.css
@@ -3,6 +3,13 @@
    「見出しが一目で分かる・押せる所が分かる・読みやすい」明快な情報設計。
    ============================================================ */
 
+/* mvp.css の main{padding:3rem 1rem} はブログでは過大
+   （固定ヘッダーのスペーサー48px と合わせて上に約110pxの空白ができ、
+   横も .blog の 1.15rem と二重になる）。余白は .blog 側で一元管理する。 */
+.blog-main {
+  padding: 14px 0 1.5rem;
+}
+
 .blog {
   --g: #06c755;
   --g-deep: #05a648;
@@ -208,7 +215,8 @@
 /* mvp.css のグローバル nav{display:flex} を打ち消す（カードは縦積み） */
 .blog-related { display: block; margin: 2.4rem 0 1rem; }
 .blog-related a { display: block; }
-.blog-related-h { font-size: 1.1rem; font-weight: 800; color: var(--ink); margin: 0 0 .9rem; }
+/* 見出しの視覚言語を本文 h2・FAQ と統一（緑のボーダー左） */
+.blog-related-h { font-size: 1.1rem; font-weight: 800; color: var(--ink); margin: 0 0 .9rem; padding-left: 13px; border-left: 4px solid var(--g); }
 .blog-related a {
   display: block; padding: .85rem 1rem; margin-bottom: .6rem;
   border: 1px solid var(--line); border-radius: 12px; text-decoration: none;
@@ -242,11 +250,20 @@
   border-radius: 999px; padding: 1px 9px; font-weight: 700; font-size: 11px;
 }
 .blog-card .date { font-size: 11.5px; color: var(--muted); }
-.blog-card .d { font-size: 13.5px; color: #5b6066; line-height: 1.7; margin: 0; }
+/* 説明文は3行で省略し、2カラム時のカード高さの凸凹を防ぐ */
+.blog-card .d {
+  font-size: 13.5px; color: #5b6066; line-height: 1.7; margin: 0;
+  display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+}
 .blog-card .go { margin-top: .7rem; font-size: 12.5px; font-weight: 700; color: var(--g-deep); }
-.blog-card .go::after { content: " →"; }
+.blog-card .go::after {
+  content: "→"; display: inline-block; margin-left: 4px;
+  transition: transform .15s;
+}
+.blog-card:hover .go::after { transform: translateX(3px); }
 
 @media (min-width: 600px) {
+  .blog-main { padding-top: 22px; }
   .blog-title { font-size: 1.95rem; }
   .blog-body { font-size: 16.5px; }
   .blog-cards { grid-template-columns: 1fr 1fr; }

--- a/public/style/mvp.css
+++ b/public/style/mvp.css
@@ -55,9 +55,12 @@ body {
   padding: 0;
 }
 
-footer,
-header,
-main {
+/* ページ骨格。
+   【サイト方針】素の <header> への直当ては廃止。コンポーネント内の <header> にまで漏れて、
+   各所で all: unset やインライン style による打ち消し（whack-a-mole）が必要になっていたため。
+   <footer> は body 直下（admin・エラーページが依存）に限定し、リスト項目内の <footer> 等には当てない。 */
+main,
+body > footer {
   margin: 0 auto;
   max-width: var(--width-content);
   padding: 3rem 1rem;
@@ -102,33 +105,9 @@ section aside:hover {
   display: none;
 }
 
-/* Headers */
-article header,
-div header,
-main header {
-  padding-top: 0;
-}
-
-header {
-  text-align: var(--justify-important);
-}
-
-header a b,
-header a em,
-header a i,
-header a strong {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-}
-
-header nav img {
-  margin: 1rem 0;
-}
-
-section header {
-  padding-top: 0;
-  width: 100%;
-}
+/* Headers
+   素の <header> 向けの装飾（padding / text-align: center 等）は撤去済み。
+   中央寄せが必要なページ（エラーページ等）は各自で指定する。 */
 
 /* Nav */
 nav {
@@ -486,6 +465,15 @@ blockquote footer {
 
 .unset {
   all: unset;
+}
+
+/* all: unset は UA スタイルの cursor: pointer まで消してしまうため、
+   インタラクティブ要素に限り操作感（カーソル）だけは標準に戻す */
+a.unset,
+button.unset,
+summary.unset,
+[role='button'].unset {
+  cursor: pointer;
 }
 
 .unset:active {

--- a/public/style/mvp.css
+++ b/public/style/mvp.css
@@ -66,6 +66,14 @@ body > footer {
   padding: 3rem 1rem;
 }
 
+/* main の骨格余白(3rem 1rem)が不要なページ用の共有オプトアウト。
+   ページごとの inline style での打ち消しをこれ以上増やさないため、
+   新規ページは <main class="no-pad"> を使い、余白はページ側 CSS で管理する
+   （例: blog.css の main.blog-main）。 */
+main.no-pad {
+  padding: 0;
+}
+
 hr {
   border: none;
   height: 1px;
@@ -463,32 +471,8 @@ blockquote footer {
   padding: 1.5rem 0;
 }
 
-.unset {
-  all: unset;
-}
-
-/* all: unset は UA スタイルの cursor: pointer まで消してしまうため、
-   インタラクティブ要素に限り操作感（カーソル）だけは標準に戻す */
-a.unset,
-button.unset,
-summary.unset,
-[role='button'].unset {
-  cursor: pointer;
-}
-
-.unset:active {
-  filter: none;
-  text-decoration: none;
-}
-
-.unset:hover {
-  filter: none;
-  text-decoration: none;
-}
-
-.unset:focus-visible {
-  outline: -webkit-focus-ring-color auto 1px;
-}
+/* .unset ユーティリティは unset.css に一元化（mvpmin.css との二重管理をやめた）。
+   本ファイルを <link> するページは直後に style/unset.css も読み込むこと。 */
 
 .list-aside-desc .css-162gv95 {
   user-select: none;

--- a/public/style/mvpmin.css
+++ b/public/style/mvpmin.css
@@ -16,32 +16,8 @@ hr {
   width: 100%;
 }
 
-.unset {
-  all: unset;
-}
-
-/* all: unset は UA スタイルの cursor: pointer まで消してしまうため、
-   インタラクティブ要素に限り操作感（カーソル）だけは標準に戻す */
-a.unset,
-button.unset,
-summary.unset,
-[role='button'].unset {
-  cursor: pointer;
-}
-
-.unset:active {
-  filter: none;
-  text-decoration: none;
-}
-
-.unset:hover {
-  filter: none;
-  text-decoration: none;
-}
-
-.unset:focus-visible {
-  outline: -webkit-focus-ring-color auto 1px;
-}
+/* .unset ユーティリティは unset.css に一元化（mvp.css との二重管理をやめた）。
+   本ファイルを <link> するページは直後に style/unset.css も読み込むこと。 */
 
 details {
   margin: 1.3rem 0;

--- a/public/style/mvpmin.css
+++ b/public/style/mvpmin.css
@@ -20,6 +20,15 @@ hr {
   all: unset;
 }
 
+/* all: unset は UA スタイルの cursor: pointer まで消してしまうため、
+   インタラクティブ要素に限り操作感（カーソル）だけは標準に戻す */
+a.unset,
+button.unset,
+summary.unset,
+[role='button'].unset {
+  cursor: pointer;
+}
+
 .unset:active {
   filter: none;
   text-decoration: none;

--- a/public/style/unset.css
+++ b/public/style/unset.css
@@ -1,0 +1,35 @@
+/* ============================================================
+   .unset ユーティリティ（all: unset の打ち消し一式）。
+   mvp.css / mvpmin.css のどちらを使うページでも必要なため、
+   両ファイルへのコピーをやめて本ファイルに一元化している。
+   読み込み順は mvp.css / mvpmin.css の直後・ページ別 CSS の前
+   （同特異度の打ち消しが順序に依存するため）。
+   ============================================================ */
+
+.unset {
+  all: unset;
+}
+
+/* all: unset は UA スタイルの cursor: pointer まで消してしまうため、
+   インタラクティブ要素に限り操作感（カーソル）だけは標準に戻す。
+   disabled なボタンは除外し、押せない物に pointer を出さない。 */
+a.unset,
+button.unset:not(:disabled),
+summary.unset,
+[role='button'].unset {
+  cursor: pointer;
+}
+
+.unset:active {
+  filter: none;
+  text-decoration: none;
+}
+
+.unset:hover {
+  filter: none;
+  text-decoration: none;
+}
+
+.unset:focus-visible {
+  outline: -webkit-focus-ring-color auto 1px;
+}


### PR DESCRIPTION
stg で検証済みの #319 を本番へ反映します。

## 内容

詳細は **#319** を参照してください。要約:

- トップ「読み物」の謎の空白・ブログ系リンクが押せる見た目にならない問題を解消（CSSの土台 mvp.css の設計整理）
- ブログ上部の過大な余白を適正化、モバイル本文幅を改善
- トップ・一覧のブログ日付を更新日基準に統一（構造化データ dateModified / サイトマップ lastmod も反映）
- frontmatter の日付入力ミスで毎時のサイトマップ生成が止まらないよう保護を追加
- multi-agent コードレビューで検出した10件を修正済み（詳細・検証手順は #319 の本文参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
