### PR TITLE
[STG] fix: デプロイ作業と毎時データ更新が重なった際に処理が中断する問題を解消

### DIFF
--- a/app/Models/CommentRepositories/Api/ApiCommentPostRepository.php
+++ b/app/Models/CommentRepositories/Api/ApiCommentPostRepository.php
@@ -80,4 +80,38 @@ class ApiCommentPostRepository implements CommentPostRepositoryInterface
             compact('open_chat_id')
         );
     }
+
+    function getBanUsers(int $limit, int $offset): array
+    {
+        $query =
+            "SELECT
+                b.id,
+                b.user_id,
+                b.ip,
+                b.created_at,
+                IFNULL(
+                    (SELECT name FROM comment WHERE user_id = b.user_id ORDER BY comment_id DESC LIMIT 1),
+                    ''
+                ) AS name
+            FROM
+                ban_user AS b
+            ORDER BY
+                b.id DESC
+            LIMIT
+                :limit
+            OFFSET
+                :offset";
+
+        return SQLiteOcgraphSqlapi::fetchAll($query, compact('limit', 'offset'));
+    }
+
+    function getBanUserCount(): int
+    {
+        return (int) SQLiteOcgraphSqlapi::fetchColumn("SELECT COUNT(*) FROM ban_user", []);
+    }
+
+    function removeBanUser(int $banId): array|false
+    {
+        throw new \RuntimeException('Write operation not supported in API repository');
+    }
 }

--- a/app/Services/Cron/Utility/ClassPreloader.php
+++ b/app/Services/Cron/Utility/ClassPreloader.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cron\Utility;
+
+use App\Config\AppConfig;
+
+/**
+ * 長時間バッチ用のクラス先読み。
+ *
+ * cron 実行中にデプロイが走ると、開始時に読み込み済みの旧クラスと実行途中で
+ * 遅延オートロードされる新クラスが同一プロセス内に混在し、シグネチャ変更を
+ * 跨いだ呼び出しが ArgumentCountError 等で落ちる（実例: 2026-06-06 17:50、
+ * 17:30 開始の毎時処理に 17:33 のデプロイが重なり、旧 BlogService が
+ * 新 BlogSummaryDto を引数不足で生成してサイトマップ生成が中断）。
+ *
+ * 開始時点で自前コード（app/shared/shadow）の全クラスを読み込み、プロセス内の
+ * コードを開始時点のスナップショットに固定して混在を防ぐ。
+ *
+ * リンク不能なクラス（インターフェース実装漏れ等）の読み込みは try/catch で
+ * 捕捉できない compile-time fatal になるため、いきなり本プロセスへは読み込まず、
+ * サブプロセスで全クラスの読み込みを検証し、通ったものだけを本プロセスへ読み込む。
+ * 検証に落ちたクラスは従来どおり遅延ロードに任せる（使われた時点で同じ場所で落ちる
+ * だけで、バッチ全体は巻き込まない）。
+ *
+ * composer install --optimize-autoloader（本番デプロイが実行）で生成される
+ * classmap を前提とし、無ければ何もしない（開発環境では従来どおり遅延ロード）。
+ */
+class ClassPreloader
+{
+    /** リンク不能クラスの除外リトライ上限（通常は壊れたクラス数 + 1 回で収束する） */
+    private const MAX_PROBE_ATTEMPTS = 10;
+
+    /**
+     * @return int 読み込んだクラス数（classmap が無効・検証が収束しない場合は 0 で、従来の遅延ロードに任せる）
+     */
+    public static function preload(): int
+    {
+        try {
+            $classes = self::ownClasses();
+            if (!$classes) {
+                return 0;
+            }
+
+            $verified = self::probeInSubprocess($classes);
+
+            $count = 0;
+            foreach ($verified as $class) {
+                try {
+                    // interface / trait / enum でもオートロードは発火する
+                    class_exists($class);
+                    $count++;
+                } catch (\Throwable) {
+                    // サブプロセス検証後にデプロイでファイルが入れ替わった等の稀なケース。
+                    // 先読みは best-effort とし、バッチ本体は止めない
+                }
+            }
+
+            return $count;
+        } catch (\Throwable) {
+            return 0;
+        }
+    }
+
+    /**
+     * サブプロセスで classmap の自前クラスを順に読み込み、fatal にならず読めたものだけを返す。
+     * fatal で落ちた場合は、その直前まで出力されたクラス名から壊れたクラスを特定して除外し再試行する。
+     *
+     * @param string[] $classes
+     * @return string[] 本プロセスへ安全に読み込めるクラス名
+     */
+    private static function probeInSubprocess(array $classes): array
+    {
+        $autoload = AppConfig::ROOT_PATH . 'vendor/autoload.php';
+        $code = sprintf("require %s; %s::probe(\$argv[1] ?? '');", var_export($autoload, true), self::class);
+
+        $skip = [];
+        for ($attempt = 0; $attempt < self::MAX_PROBE_ATTEMPTS; $attempt++) {
+            $candidates = array_values(array_diff($classes, $skip));
+            if (!$candidates) {
+                return [];
+            }
+
+            $command = escapeshellarg(PHP_BINARY)
+                . ' -d display_errors=0 -r ' . escapeshellarg($code)
+                . ' -- ' . escapeshellarg(implode(',', $skip)) . ' 2>/dev/null';
+
+            $output = [];
+            $exitCode = 1;
+            exec($command, $output, $exitCode);
+
+            // 出力はクラス名のみのはずだが、fatal 時のハンドラ出力等の混入に備え
+            // 「期待順と一致する先頭部分」だけを成功とみなす
+            $verified = [];
+            foreach ($output as $i => $line) {
+                if (($candidates[$i] ?? null) !== trim($line)) {
+                    break;
+                }
+                $verified[] = $candidates[$i];
+            }
+
+            if ($exitCode === 0 && count($verified) === count($candidates)) {
+                return $verified;
+            }
+
+            // 最後に成功したクラスの次が fatal の原因。進捗が無い異常時は打ち切り
+            $broken = $candidates[count($verified)] ?? null;
+            if ($broken === null) {
+                return [];
+            }
+            $skip[] = $broken;
+        }
+
+        return [];
+    }
+
+    /**
+     * サブプロセス側のエントリ。読み込みに成功したクラス名を順に出力する（preload() からは呼ばない）。
+     *
+     * @param string $skipCsv 除外クラス名のカンマ区切り
+     */
+    public static function probe(string $skipCsv): void
+    {
+        $skip = $skipCsv === '' ? [] : explode(',', $skipCsv);
+
+        foreach (array_diff(self::ownClasses(), $skip) as $class) {
+            try {
+                class_exists($class);
+                echo $class, "\n";
+            } catch (\Throwable) {
+                // 捕捉可能な失敗は出力しない → 親プロセス側で除外される
+            }
+        }
+    }
+
+    /**
+     * classmap から自前コード（app/shared/shadow）のクラスのみ抽出する。
+     * vendor は対象外: デプロイで変わる頻度が低く、未使用の拡張依存クラス等を
+     * 巻き込むリスクの方が大きい。
+     *
+     * @return string[]
+     */
+    private static function ownClasses(): array
+    {
+        $classmapPath = AppConfig::ROOT_PATH . 'vendor/composer/autoload_classmap.php';
+        if (!is_file($classmapPath)) {
+            return [];
+        }
+
+        $classmap = include $classmapPath;
+        if (!is_array($classmap)) {
+            return [];
+        }
+
+        $targets = array_filter([
+            realpath(AppConfig::ROOT_PATH . 'app'),
+            realpath(AppConfig::ROOT_PATH . 'shared'),
+            realpath(AppConfig::ROOT_PATH . 'shadow'),
+        ]);
+
+        $classes = [];
+        foreach ($classmap as $class => $file) {
+            $path = realpath($file);
+            if ($path === false) {
+                continue;
+            }
+
+            foreach ($targets as $dir) {
+                if (str_starts_with($path, $dir . DIRECTORY_SEPARATOR)) {
+                    $classes[] = $class;
+                    break;
+                }
+            }
+        }
+
+        return $classes;
+    }
+}

--- a/app/Services/SitemapGenerator.php
+++ b/app/Services/SitemapGenerator.php
@@ -43,10 +43,12 @@ class SitemapGenerator
         $tmpDir = self::SITEMAP_DIR . ".tmp-{$langCode}/";
         $finalDir = self::SITEMAP_DIR . "{$langCode}/";
 
-        // 一時ディレクトリ作成
-        if (!is_dir($tmpDir)) {
-            mkdir($tmpDir, 0755, true);
+        // 一時ディレクトリ作成（前回クラッシュ時の中途ファイルが残っていると
+        // 本数が減った際に古いチャンクが最終ディレクトリへ混入するため、必ず作り直す）
+        if (is_dir($tmpDir)) {
+            $this->removeDirectory($tmpDir);
         }
+        mkdir($tmpDir, 0755, true);
 
         // 現在の言語用のインデックス
         $languageIndex = new SitemapIndex();

--- a/batch/cron/cron_crawling.php
+++ b/batch/cron/cron_crawling.php
@@ -6,6 +6,7 @@ use App\Exceptions\ApplicationException;
 use App\ServiceProvider\ApiOpenChatDeleterServiceProvider;
 use App\Services\Admin\AdminTool;
 use App\Services\Cron\SyncOpenChat;
+use App\Services\Cron\Utility\ClassPreloader;
 use App\Services\Cron\Utility\CronUtility;
 use ExceptionHandler\ExceptionHandler;
 use Shared\MimimalCmsConfig;
@@ -14,6 +15,9 @@ try {
     if (isset($argv[1]) && $argv[1]) {
         MimimalCmsConfig::$urlRoot = $argv[1];
     }
+
+    // 実行中にデプロイが重なっても新旧クラスが混在しないよう、開始時に全クラスを先読み
+    ClassPreloader::preload();
 
     if (!MimimalCmsConfig::$urlRoot) {
         app(ApiOpenChatDeleterServiceProvider::class)->register();

--- a/batch/exec/ocreview_api_data_import_background.php
+++ b/batch/exec/ocreview_api_data_import_background.php
@@ -6,6 +6,7 @@ use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Admin\AdminTool;
 use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
 use App\Services\Cron\OcreviewApiDataImporter;
+use App\Services\Cron\Utility\ClassPreloader;
 use App\Services\Cron\Utility\CronUtility;
 use ExceptionHandler\ExceptionHandler;
 use Shared\MimimalCmsConfig;
@@ -14,6 +15,9 @@ set_time_limit(3600 * 2);
 
 try {
     MimimalCmsConfig::$urlRoot = '';
+
+    // 実行中にデプロイが重なっても新旧クラスが混在しないよう、開始時に全クラスを先読み
+    ClassPreloader::preload();
 
     /**
      * @var SyncOpenChatStateRepositoryInterface $state

--- a/batch/exec/persist_ranking_position_background.php
+++ b/batch/exec/persist_ranking_position_background.php
@@ -6,6 +6,7 @@ use App\Exceptions\ApplicationException;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Admin\AdminTool;
 use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\Cron\Utility\ClassPreloader;
 use App\Services\Cron\Utility\CronUtility;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
 use App\Services\RankingPosition\Persistence\RankingPositionHourPersistence;
@@ -18,6 +19,9 @@ try {
     if (isset($argv[1]) && $argv[1]) {
         MimimalCmsConfig::$urlRoot = $argv[1];
     }
+
+    // 実行中にデプロイが重なっても新旧クラスが混在しないよう、開始時に全クラスを先読み
+    ClassPreloader::preload();
 
     $parentPid = isset($argv[2]) && $argv[2] ? (int)$argv[2] : null;
 


### PR DESCRIPTION
## 問題の概要

2026-06-06 17:50 に本番の毎時データ更新処理（cron）がエラーで中断した（Exception Detail #8766）。

### 原因: デプロイと cron 実行の競合（コードは正しいのに落ちる）

| 時刻 | 出来事 |
|---|---|
| 17:30:01 | 毎時処理が開始。この時点の**旧コード**で内部部品（ブログ記事一覧の読み取り処理）が初期化される |
| 17:32:48〜17:33:23 | #320（#319 の本番反映）のデプロイが完了し、サーバー上のファイルが新コードに置き換わる |
| 17:50:42 | クロール完了後のサイトマップ生成で、記事データの入れ物クラスだけが**新コード**から読み込まれ、旧コードからの呼び出しと引数が合わずクラッシュ |

PHP はクラスファイルを「最初に使った瞬間」に読み込むため、20分〜2時間動き続ける cron の実行中にデプロイが走ると、**読み込み済みの旧クラスと、途中から読み込まれる新クラスが同一プロセス内に混在**する。今回は #319 でブログ記事データに「更新日」引数が必須として追加されたため、旧コードからの生成が引数不足になった。

### 被害状況（実害なし・自然回復済み）

- クロール・ランキング更新等の本体処理は**全て完了後**に落ちたためデータ被害なし
- サイトマップはアトミック書き込み設計（一時ディレクトリ→リネーム）のため、公開中のファイルは無傷
- 17:35 開始の繁体字版・タイ語版の cron は新コードで正常実行され、18:30 の次回実行で日本語版も自然回復

## 対処内容

### 1. 長時間バッチ開始時に全クラスを先読みし、コードを開始時点に固定（再発防止の本丸）

毎時/日次 cron と長時間バックグラウンド処理2種の開始時に、自前コードの全クラス（約380個・約240ms）を読み込んでしまう `ClassPreloader` を追加。実行中にデプロイが走っても、そのプロセスは開始時点のコード一式で最後まで動くため、新旧混在クラッシュが起きなくなる。

- 本番デプロイが生成する最適化済みクラスマップを利用（無い開発環境では何もせず従来どおり）
- 実装漏れ等で読み込み自体が即死（try/catch で捕捉不能）になるクラスが紛れていても巻き込まれないよう、**サブプロセスで全クラスの読み込みを検証してから本体へ読み込む**。壊れたクラスだけ除外して続行する

### 2. 先読み検証で発覚した潜在バグの修正: 管理用照会が3.5ヶ月間壊れていた

検証ステップが [`ApiCommentPostRepository`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Models/CommentRepositories/Api/ApiCommentPostRepository.php) の実装漏れを検出。2/25 のシャドウバン管理機能追加でインターフェースに3メソッドが増えた際、アーカイブAPI用の実装が未対応のままで、読み込まれた瞬間に即死する状態だった（遅延初期化のため今まで発火していなかった）。閲覧系2メソッド（一覧・件数）は実装し、書き込み系1メソッドは既存方針どおり非対応例外とした。

### 3. サイトマップ生成のクラッシュ耐性を強化

生成途中でクラッシュした場合に一時ディレクトリへ残る中途ファイルが、次回実行時（チャンク数が減った場合）に古いファイルとして本番ディレクトリへ混入し得たため、一時ディレクトリを毎回作り直すよう変更。

## 検証

- 通常パス: 381クラスを236ms・10MBで先読み（毎時処理のオーバーヘッドとして無視できる規模）
- 故障パス: 故意にリンク不能クラスを混入 → 該当クラスのみ除外し残り381クラスを読み込み、プロセス生存を確認
- 開発環境パス: クラスマップ未生成時は何もしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

