### PR TITLE
[STG] feat: ブログに広告を追加＋全画面広告（オファーウォール）の離脱影響を測る自動切替実験を開始

### DIFF
--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -101,6 +101,17 @@ class GoogleAdsense
     }
 
     /**
+     * Offerwall switchback 実験（oc-pdca 2026-06開始）: ISO週番号の偶奇で自動 ON/OFF を交代する。
+     * 奇数週 = 抑制ON（壁を出さない）/ 偶数週 = OFF（通常表示）。週の境界は月曜 0時 JST。
+     * 人手での切り替えは不要。分析時は GA4/AdSense の日次データを ISO 週の偶奇で分けて集計する。
+     * 実験終了時は呼び出し箇所（recommend_content.php）を固定値 true/false に置き換えること。
+     */
+    public static function isOfferwallSuppressionWeek(): bool
+    {
+        return ((int)date('W')) % 2 === 1;
+    }
+
+    /**
      * @param bool $suppressOfferwall true でこのページの Offerwall（プライバシーとメッセージ）のみ抑制する。
      *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
      */

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -100,9 +100,26 @@ class GoogleAdsense
         EOT;
     }
 
-    public static function gTag(?string $dataOverlays = null)
+    /**
+     * @param bool $suppressOfferwall true でこのページの Offerwall（プライバシーとメッセージ）のみ抑制する。
+     *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
+     */
+    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false)
     {
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
+
+        if ($suppressOfferwall) {
+            // adsbygoogle.js のロードより前に定義される必要があるため、スクリプトタグの直前で出力する。
+            // https://developers.google.com/funding-choices/fc-api-docs
+            echo <<<EOT
+            <script>
+                window.googlefc = window.googlefc || {};
+                googlefc.controlledMessagingFunction = function (message) {
+                    message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
+                };
+            </script>
+            EOT;
+        }
 
         $dataOverlaysAttr = $dataOverlays ? ('data-overlays="' . $dataOverlays . '" ') : '';
         $adClient = GoogleAdsenseConfig::$googleAdsenseClient;

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -35,6 +35,11 @@
                 </div>
             </div>
 
+            <?php // 広告: ブログ専用ユニットは未作成のため既存レスポンシブスロットを流用（レポートは他ページと合算される）。
+                  // SEO 流入の初見読者に Offerwall を出さないよう、blog では Offerwall のみタグ側で抑制する ?>
+            <?php \App\Views\Ads\GoogleAdsense::gTag(suppressOfferwall: true) ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
+
             <?php if (!empty($_faqHtml)): ?>
                 <div class="blog-faq"><?php echo $_faqHtml ?></div>
             <?php endif ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -63,7 +63,8 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
     <section class="recommend-ranking-section">
       <?php if (isset($recommend)) : ?>
         <?php if ($enableAdsense): ?>
-          <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+          <?php // Offerwall switchback 実験(oc-pdca): 奇数ISO週のみ Offerwall を抑制。広告自体は常に通常表示 ?>
+          <?php GAd::gTag(suppressOfferwall: GAd::isOfferwallSuppressionWeek()) ?>
         <?php endif ?>
         <ol class="openchat-item-list parent unset">
           <?php


### PR DESCRIPTION
## 問題の概要

1. SEO 目的で新設したブログに収益化が入っていなかった（広告タグ自体が無い状態）
2. サイト全体で表示している**オファーウォール（全画面の広告壁）**について、導入日（2025-02-15）に「おすすめ」ページの直帰率が **+10pt 悪化**したことが日次データ分析で確認された。一方で現在は Google の ML 最適化が表示頻度を自動調整しており、**今どれだけ離脱被害が残っているか・止めたらいくら収益が減るかは過去データから外挿できない**（オファーウォールは広告収益の約4割を稼ぐ主力でもある）

## 対処内容

### 1. ブログ記事に広告を1枠追加し、オファーウォールはブログでは常時非表示

- 記事末尾の CTA 直後にレスポンシブ広告を1枠配置（[`blog_article_content.php`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/oc-pdca/feat/blog-ads-offerwall-suppress/app/Views/blog_article_content.php)）。既存スロットを流用
- [Privacy & messaging API](https://developers.google.com/funding-choices/fc-api-docs) の `controlledMessagingFunction` + `MessageTypeEnum.OFFERWALL` で**オファーウォールだけ**を抑制（Cookie 同意等には影響なし）。検索から来た初見読者を壁で逃さない

### 2. おすすめページで「週替わり自動切替実験」を開始

- **奇数 ISO 週 = 壁を出さない / 偶数週 = 通常表示**（境界は月曜0時 JST）を [`GoogleAdsense::isOfferwallSuppressionWeek()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/oc-pdca/feat/blog-ads-offerwall-suppress/app/Views/Classes/Ads/GoogleAdsense.php) が自動判定。**人手での切替作業ゼロ**
- 対象は [`recommend_content.php`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/oc-pdca/feat/blog-ads-offerwall-suppress/app/Views/recommend_content.php) のみ（SEO クリックの46%を運ぶ主力ページ群）。**広告自体は常に通常表示**
- 4週間後に GA4 直帰率・AdSense リワード収益・Search Console CTR を ISO 週の偶奇で分けて比較し、常時非表示にすべきか・現状維持かをデータで判断する

### 影響範囲

- ブログ記事ページ・おすすめページのみ。staging / dev では広告関連の出力は従来どおり全て無効
- AdSense 管理画面の設定変更は不要（全てタグ側で完結）

## 検証

- `php -l` 全ファイル OK / ローカル実機で blog・recommend とも HTTP 200
- 本番フラグの CLI で W23（奇数）= 抑制ON、スニペット→adsbygoogle.js の出力順、偶数週相当（false）でスニペット非出力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
