### PR TITLE
[PROD] feat: ブログに広告を追加＋オファーウォール自動切替実験を開始（#323 の本番反映）

### DIFF
--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -101,6 +101,17 @@ class GoogleAdsense
     }
 
     /**
+     * Offerwall switchback 実験（oc-pdca 2026-06開始）: ISO週番号の偶奇で自動 ON/OFF を交代する。
+     * 奇数週 = 抑制ON（壁を出さない）/ 偶数週 = OFF（通常表示）。週の境界は月曜 0時 JST。
+     * 人手での切り替えは不要。分析時は GA4/AdSense の日次データを ISO 週の偶奇で分けて集計する。
+     * 実験終了時は呼び出し箇所（recommend_content.php）を固定値 true/false に置き換えること。
+     */
+    public static function isOfferwallSuppressionWeek(): bool
+    {
+        return ((int)date('W')) % 2 === 1;
+    }
+
+    /**
      * @param bool $suppressOfferwall true でこのページの Offerwall（プライバシーとメッセージ）のみ抑制する。
      *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
      */

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -100,9 +100,26 @@ class GoogleAdsense
         EOT;
     }
 
-    public static function gTag(?string $dataOverlays = null)
+    /**
+     * @param bool $suppressOfferwall true でこのページの Offerwall（プライバシーとメッセージ）のみ抑制する。
+     *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
+     */
+    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false)
     {
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
+
+        if ($suppressOfferwall) {
+            // adsbygoogle.js のロードより前に定義される必要があるため、スクリプトタグの直前で出力する。
+            // https://developers.google.com/funding-choices/fc-api-docs
+            echo <<<EOT
+            <script>
+                window.googlefc = window.googlefc || {};
+                googlefc.controlledMessagingFunction = function (message) {
+                    message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
+                };
+            </script>
+            EOT;
+        }
 
         $dataOverlaysAttr = $dataOverlays ? ('data-overlays="' . $dataOverlays . '" ') : '';
         $adClient = GoogleAdsenseConfig::$googleAdsenseClient;

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -35,6 +35,11 @@
                 </div>
             </div>
 
+            <?php // 広告: ブログ専用ユニットは未作成のため既存レスポンシブスロットを流用（レポートは他ページと合算される）。
+                  // SEO 流入の初見読者に Offerwall を出さないよう、blog では Offerwall のみタグ側で抑制する ?>
+            <?php \App\Views\Ads\GoogleAdsense::gTag(suppressOfferwall: true) ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
+
             <?php if (!empty($_faqHtml)): ?>
                 <div class="blog-faq"><?php echo $_faqHtml ?></div>
             <?php endif ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -63,7 +63,8 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
     <section class="recommend-ranking-section">
       <?php if (isset($recommend)) : ?>
         <?php if ($enableAdsense): ?>
-          <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+          <?php // Offerwall switchback 実験(oc-pdca): 奇数ISO週のみ Offerwall を抑制。広告自体は常に通常表示 ?>
+          <?php GAd::gTag(suppressOfferwall: GAd::isOfferwallSuppressionWeek()) ?>
         <?php endif ?>
         <ol class="openchat-item-list parent unset">
           <?php


### PR DESCRIPTION
#323 (stg) の本番反映。

- ブログ記事に広告1枠を追加し、オファーウォール（全画面の広告壁）はブログでは常時非表示
- おすすめページで「奇数ISO週=壁OFF / 偶数週=通常」の人手ゼロ自動切替実験を開始（4週間後に直帰率・収益・CTRで効果判定）

詳細は #323 を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)