### PR TITLE
[PROD] fix: 毎時データ更新のたびに繰り返し発生していたエラー通知を解消

### DIFF
--- a/app/Models/Repositories/Api/ApiOpenChatPageRepository.php
+++ b/app/Models/Repositories/Api/ApiOpenChatPageRepository.php
@@ -97,6 +97,12 @@ class ApiOpenChatPageRepository implements OpenChatPageRepositoryInterface
         );
     }
 
+    public function isWithinIdRange(int $id): bool
+    {
+        $max = (int) SQLiteOcgraphSqlapi::fetchColumn("SELECT MAX(openchat_id) FROM openchat_master");
+        return $id <= $max;
+    }
+
     public function getOpenChatNamesByIds(array $ids): array
     {
         if (empty($ids)) {


### PR DESCRIPTION
## 問題の概要

2026-06-06 19:40 頃から、毎時のデータ更新処理が走るたびにエラー通知 (Exception Detail #8773, #8775 等) が繰り返し発生していた。

```
ErrorException: Class App\Models\Repositories\Api\ApiOpenChatPageRepository contains 1 abstract method
and must therefore be declared abstract or implement the remaining method
(App\Models\Repositories\OpenChatPageRepositoryInterface::isWithinIdRange)
```

### 原因

2つの修正の組み合わせで顕在化した実装漏れ:

1. **5/24 の修正 (615735f8)**: 削除済みルームの URL を 410 Gone で返す対応で、共通インターフェース [`OpenChatPageRepositoryInterface`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/main/app/Models/Repositories/OpenChatPageRepositoryInterface.php) に「過去に発番された ID 範囲内かを判定する処理」を追加。このとき本体側の実装クラスには追加したが、**検証用 API (`/ocapi/...`) 専用の実装クラス [`ApiOpenChatPageRepository`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/main/app/Models/Repositories/Api/ApiOpenChatPageRepository.php) への追加が漏れていた**
2. **昨日の PR #321**: cron 開始時に全クラスを先読み検証する `ClassPreloader` を導入。この検証がこの壊れたクラスを毎時ロードしようとして fatal となり、エラー通知が毎時飛ぶようになった

### 影響範囲

- 毎時処理のバッチ本体は ClassPreloader が壊れたクラスを除外して続行する設計のため**中断していない**（エラー通知のノイズが主な実害）
- ただし検証用 API ページ `/ocapi/{user}/{open_chat_id}` にアクセスすると実際に fatal する状態だった

## 対処内容

`ApiOpenChatPageRepository` に不足していた判定処理を追加。本体側実装と同じく「DB に存在する最大 ID 以下なら範囲内」とする形で、検証用 API の SQLite DB (`openchat_master`) に対して実装した。

## 動作確認

- クラスが fatal なくロードできることを確認
- 実データに対して範囲内 ID → true / 範囲外 ID → false を確認
- 既存の phpunit (`ApiOpenChatPageRepositoryTest`) 3件 グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)