### PR TITLE
[PROD] ci: クラスの実装漏れを本番到達前にCIで検出できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,16 @@ jobs:
           echo "Initializing database and storage..."
           ./setup/local-setup.default.sh -y -n
 
+      # 本番デプロイは composer install --optimize-autoloader で全自前クラス入りの classmap を生成する。
+      # CI も同じ classmap にしないと ClassPreloader の全クラス検証が空振りし、
+      # インターフェース実装漏れ等のリンク不能クラスを検出できない（実例: #325 の修正対象は
+      # 5/24 混入だが、本番の毎時 cron でしか発火せず CI を素通りしていた）。
+      # 検証された fatal は storage/exception.log に記録され check-error-log.sh が CI を落とす。
+      - name: Optimize autoloader (本番と同じclassmapでクラス検証を有効化)
+        if: steps.skip.outputs.skip != 'true'
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T -u www-data app composer dump-autoload --optimize
+
       - name: Check if any frontend changed
         if: steps.skip.outputs.skip != 'true'
         id: any_frontend


### PR DESCRIPTION
## 問題の概要

#325 で修正したクラス実装漏れ（5/24 混入）は、**本番の毎時 cron でしか発火せず、CI を素通り**していた。

### なぜ CI で検出できなかったか

PR #321 で導入した `ClassPreloader` は、cron 開始時に全自前クラスをサブプロセスで読み込み検証する。CI も `cron_crawling.php` を実行するためこの検証が走る**はず**だったが、実際には空振りしていた:

| 環境 | composer install | classmap の自前クラス | preload 検証 |
|---|---|---|---|
| 本番デプロイ | `--optimize-autoloader` 付き | 全クラス入り | **382 クラス検証** |
| CI / 開発 | 素のまま | **0 件** | **何もしない** |

`ClassPreloader::ownClasses()` は `vendor/composer/autoload_classmap.php` から自前クラスを抽出するが、素の `composer install` では classmap に App 系クラスが 1 件も入らない（PSR-4 遅延解決に任せる）ため、preloader は設計上のフォールバック「classmap が無ければ何もしない」で即終了していた。

その結果、壊れたクラスは本番でのみ検証に引っかかり、毎時 cron のたびにエラー通知 (#8773, #8775 等) が飛び続けた。

## 対処内容

CI のセットアップ後に `composer dump-autoload --optimize` を 1 ステップ追加し、**CI の classmap を本番と同一にする**。

これにより検出チェーンが完成する:

1. CI が `cron_crawling.php` を実行 → `ClassPreloader` が全 382 クラスをサブプロセス検証
2. リンク不能クラス（インターフェース実装漏れ等）があれば fatal → 例外ハンドラが `storage/exception.log` に記録
3. 既存の `check-error-log.sh` がログ存在を検知して **CI が赤になる**

今回の実装漏れも、このステップがあれば PR の CI 時点で検出できていた。

## 動作確認

- ローカルで classmap 非最適化時 preload = 0 クラス / 最適化時 = 382 クラスを実測
- 例外ハンドラの fatal 書き込み先が `storage/exception.log`（= `check-error-log.sh` の監視対象）であることをコード確認 ([`MimimalCMS_ExceptionHandler.php`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/main/shared/MimimalCMS_ExceptionHandler.php) の `errorLog()` → `MimimalCmsConfig::$exceptionLogDirectory`)
- この PR 自身の CI が新ステップを含む ci.yml で実行され、全クラス健全な状態でグリーンになることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)