### PR TITLE
[STG] fix: 毎時処理が一度失敗すると毎時間エラー通知が出続ける問題を修正

### DIFF
--- a/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php
+++ b/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php
@@ -20,15 +20,25 @@ use Shared\MimimalCmsConfig;
  * ストレージファイルを監視し、ファイルが準備でき次第、順次DB反映を行う。
  *
  * 処理フロー:
- * 1. メインプロセス: startBackgroundPersistence() でバックグラウンドプロセスを起動
+ * 1. メインプロセス: startBackgroundPersistence() で残骸stateを一掃し起動マーカーを書いてから起動
  * 2. メインプロセス: ランキングダウンロード処理を実行（並列）
- * 3. バックグラウンド: persistAllCategoriesBackground() でストレージ監視＆DB反映
+ * 3. バックグラウンド: 自身のPIDをstateに登録後、persistAllCategoriesBackground() でストレージ監視＆DB反映
  * 4. メインプロセス: waitForBackgroundCompletion() でバックグラウンド完了を待機
+ *
+ * state (rankingPersistenceBackground) のライフサイクル:
+ * - ['launching' => 時刻, 'parentPid' => PID] … 親が起動直前に記録（残骸PIDの一掃を兼ねる）
+ * - ['pid' => PID, 'parentPid' => PID, 'startTime' => 時刻] … バックグラウンドが起動直後に登録
+ * - ['failed' => 時刻, 'message' => エラー内容] … バックグラウンドが異常終了時に記録
+ * - [] … 正常終了
  */
 class RankingPositionHourPersistence
 {
     /** バックグラウンドプロセスの最大待機時間（秒） */
     private const MAX_WAIT_SECONDS = 2400; // 最大40分待機
+
+    /** 起動マーカーからPID登録までの猶予時間（秒）
+     * プロセス起動 + オートロード + DB接続分。超過したら起動失敗とみなす */
+    private const LAUNCH_GRACE_SECONDS = 120;
 
     /** ストレージファイル待機中のログ出力間隔（ループ回数）
      * whileループは約1秒ごとに実行されるため、60回 ≒ 60秒 */
@@ -51,10 +61,28 @@ class RankingPositionHourPersistence
      * persist_ranking_position_background.php を別プロセスとして起動し、
      * DB反映処理をバックグラウンドで実行する。これにより、メインプロセスは
      * ランキングダウンロード処理を並行して実行できる。
+     *
+     * 起動前に前回の残骸state（異常終了で残った死んだPID等）を一掃して
+     * 起動マーカーを書き込む。これにより waitForBackgroundCompletion() が
+     * 過去の残骸PIDを今回のバックグラウンドと誤認することを防ぐ。
      */
     function startBackgroundPersistence(): void
     {
+        // 前回の生き残りプロセスがいれば強制終了（二重実行防止）
+        $bgState = $this->state->getArray(SyncOpenChatStateType::rankingPersistenceBackground);
+        $existingPid = $bgState['pid'] ?? null;
+        if ($existingPid && posix_getpgid((int)$existingPid) !== false) {
+            CronUtility::addCronLog("前回のバックグラウンドDB反映プロセス (PID: {$existingPid}) が残っているため強制終了します");
+            CronUtility::killProcess((int)$existingPid);
+        }
+
+        // 残骸stateを一掃して起動マーカーを書き込む（バックグラウンドがPID登録すると上書きされる）
         $parentPid = getmypid();
+        $this->state->setArray(SyncOpenChatStateType::rankingPersistenceBackground, [
+            'launching' => time(),
+            'parentPid' => $parentPid,
+        ]);
+
         $arg = escapeshellarg(\Shared\MimimalCmsConfig::$urlRoot);
         $parentPidArg = escapeshellarg((string)$parentPid);
         $path = AppConfig::ROOT_PATH . 'batch/exec/persist_ranking_position_background.php';
@@ -65,12 +93,14 @@ class RankingPositionHourPersistence
     /**
      * バックグラウンドプロセスの完了を待つ
      *
-     * PID監視により、バックグラウンドプロセスの状態を確認する。
-     * - PIDがクリアされた: 正常終了
-     * - プロセスが死んでいる: 異常終了
-     * - タイムアウト: 処理時間超過
+     * stateの内容により、バックグラウンドプロセスの状態を3状態で判定する。
+     * - 空: 正常終了（バックグラウンドがクリア済み）
+     * - launching: PID登録前（起動マーカーのみ）。猶予時間内なら待機、超過したら起動失敗
+     * - pidあり: 生存監視。プロセスが死んでいれば異常終了、処理時間超過ならタイムアウト
      *
-     * @throws \RuntimeException バックグラウンドプロセスが異常終了またはタイムアウトした場合
+     * 加えて failed マーカー（バックグラウンドが異常終了時に記録）があれば即座に異常終了と判定する。
+     *
+     * @throws \RuntimeException バックグラウンドプロセスが起動失敗・異常終了・タイムアウトした場合
      */
     function waitForBackgroundCompletion(): void
     {
@@ -81,9 +111,30 @@ class RankingPositionHourPersistence
             $bgState = $this->state->getArray(SyncOpenChatStateType::rankingPersistenceBackground);
             $pid = $bgState['pid'] ?? null;
             $startTime = $bgState['startTime'] ?? null;
+            $launching = $bgState['launching'] ?? null;
+            $failed = $bgState['failed'] ?? null;
 
-            // PIDがクリアされていたら正常終了
+            // バックグラウンドが異常終了を記録していたら即座にエラー
+            if ($failed) {
+                $message = $bgState['message'] ?? '詳細不明';
+                throw new \RuntimeException("バックグラウンドDB反映プロセスがエラーで終了: {$message}");
+            }
+
             if (!$pid) {
+                // 起動マーカーのみ = バックグラウンドがまだPID登録前。猶予時間内なら待機
+                if ($launching) {
+                    if (time() - (int)$launching > self::LAUNCH_GRACE_SECONDS) {
+                        throw new \RuntimeException(
+                            'バックグラウンドDB反映プロセスが起動しませんでした（起動待機タイムアウト '
+                                . self::LAUNCH_GRACE_SECONDS . '秒）'
+                        );
+                    }
+
+                    sleep(2);
+                    continue;
+                }
+
+                // stateが空 = バックグラウンドが正常終了してクリア済み
                 CronUtility::addVerboseCronLog('バックグラウンドDB反映完了を確認');
                 return;
             }

--- a/batch/exec/persist_ranking_position_background.php
+++ b/batch/exec/persist_ranking_position_background.php
@@ -20,9 +20,6 @@ try {
         MimimalCmsConfig::$urlRoot = $argv[1];
     }
 
-    // 実行中にデプロイが重なっても新旧クラスが混在しないよう、開始時に全クラスを先読み
-    ClassPreloader::preload();
-
     $parentPid = isset($argv[2]) && $argv[2] ? (int)$argv[2] : null;
 
     $startTime = OpenChatServicesUtility::getModifiedCronTime('now')->format('Y-m-d H:i');
@@ -48,12 +45,17 @@ try {
         }
     }
 
-    // PID、親PID、開始時刻を記録
+    // PID、親PID、開始時刻を記録（親が書いた起動マーカー launching はここで上書きされる）。
+    // クラス先読みより前に登録し、親の waitForBackgroundCompletion() が
+    // PID登録前のstateを読んで誤判定する時間窓を最小化する
     $state->setArray(StateType::rankingPersistenceBackground, [
         'pid' => getmypid(),
         'parentPid' => $parentPid,
         'startTime' => time(),
     ]);
+
+    // 実行中にデプロイが重なっても新旧クラスが混在しないよう、全クラスを先読み
+    ClassPreloader::preload();
 
     /**
      * @var RankingPositionHourPersistence $persistence
@@ -68,6 +70,21 @@ try {
 
     CronUtility::addVerboseCronLog('バックグラウンドDB反映プロセスが正常終了しました');
 } catch (\Throwable $e) {
+    // stateに自分のPIDが残っている場合のみ失敗マーカーに置き換える
+    // （新しいプロセスが既にstateを上書きしている場合は触らない）。
+    // 死んだPIDがstateに残り続けると、以降の毎時処理が過去の残骸PIDを
+    // 今回のバックグラウンドと誤認してエラーが自己再生するのを防ぐ
+    try {
+        if (isset($state) && (int)($state->getArray(StateType::rankingPersistenceBackground)['pid'] ?? 0) === getmypid()) {
+            $state->setArray(StateType::rankingPersistenceBackground, [
+                'failed' => time(),
+                'message' => mb_strimwidth($e->getMessage(), 0, 1000, '…'),
+            ]);
+        }
+    } catch (\Throwable) {
+        // stateの更新に失敗しても通知処理は継続する
+    }
+
     // killフラグによる強制終了の場合、開始から20時間以内ならDiscord通知しない
     $shouldNotify = true;
     if ($e instanceof ApplicationException && $e->getCode() === ApplicationException::RANKING_PERSISTENCE_TIMEOUT) {


### PR DESCRIPTION
## 問題の概要

毎時ランキング更新処理が一度異常終了すると、その後**何も問題がなくても毎時間2件のエラー通知（Exception Detail #91/#92のペア）が出続ける**自己再生ループが発生していた（STGで継続発生中）。

### 具体的な問題

毎時ランキング更新では、メインの処理がデータベース反映用のバックグラウンドプロセスを起動し、stateテーブル（`sync_open_chat_state`）に記録されたプロセスIDで完了を監視している。ここに2つの穴があった:

1. **異常終了したバックグラウンドプロセスのIDがstateに残り続ける** — エラー時にstateをクリアする処理がなく、死んだプロセスIDが残骸として残る（[`persist_ranking_position_background.php`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/batch/exec/persist_ranking_position_background.php)）
2. **監視処理が「起動直後でまだ登録前」と「過去の残骸」を区別できない** — 次の毎時処理で、新しいバックグラウンドがプロセスIDを登録する前に監視が始まると、残骸のIDを読んで「異常終了」と誤判定する（[`RankingPositionHourPersistence::waitForBackgroundCompletion()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Services/RankingPosition/Persistence/RankingPositionHourPersistence.php)）

誤判定でメイン処理が死ぬと、バックグラウンド側も「親プロセスの異常終了」を検出して死に、また残骸IDが残る——という形でエラーが毎時間自己再生していた。

直近の修正（#327相当のクラス先読み追加）でプロセスID登録前の処理が数秒に伸び、ダウンロードが速いSTGでこのレースが毎回顕在化した。本番はダウンロードに数分かかるため踏みにくいが、潜在的には同じ穴がある。

## 対処内容

stateのライフサイクルを明確化し、どの異常パターンでも次の毎時処理で自己回復するようにした:

1. **起動前に残骸を一掃** — メイン処理がバックグラウンド起動前にstateを起動マーカー（`launching` + 時刻）で上書きし、生き残りプロセスがいれば強制終了
2. **監視を3状態判定に** — 空=正常終了 / 起動マーカーのみ=登録待ち（猶予120秒） / プロセスIDあり=生存監視。過去の残骸を今回の処理と誤認しなくなる
3. **失敗時はstateを失敗マーカーに置き換え** — バックグラウンドのエラー時、stateに自分のIDが残っている場合のみ失敗マーカー（エラー内容入り）に置き換え。死んだIDが残らず、メイン側はエラー原因を即座に検知できる
4. **プロセスID登録をクラス先読みより前に移動** — 登録前の時間窓を最小化

## 検証

- 状態遷移6シナリオ（正常終了 / 失敗マーカー / 起動タイムアウト / 残骸PID検知 / 登録待ち→実行中→完了の遷移 / 自PIDガード）のスモークテストすべてPASS
- マルチエージェントレビュー（レース条件・回帰・異常系の3視点 + 指摘ごとの反証検証）で確定指摘0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)