### PR TITLE
共通部品（ヘッダ・フッタ・検索）の配色を一元管理化（見た目の変更なし・ダークモード準備 第3弾）

### DIFF
--- a/app/Controllers/Pages/RecommendOpenChatPageController.php
+++ b/app/Controllers/Pages/RecommendOpenChatPageController.php
@@ -109,7 +109,7 @@ class RecommendOpenChatPageController
             ->setDescription($pageDesc)
             ->setOgpDescription($pageDesc);
 
-        $_css = ['components/room_list', 'components/site_header', 'components/site_footer', 'pages/recommend_page'];
+        $_css = ['components/room_list', 'components/site_header', 'components/site_footer', 'components/theme_discovery', 'pages/recommend_page'];
 
         $_breadcrumbsShema = $this->breadcrumbsShema->generateSchema(
             $extractTag,

--- a/app/Views/components/theme_discovery.php
+++ b/app/Views/components/theme_discovery.php
@@ -38,7 +38,8 @@ $shelves = array_values(array_filter([
     <h2 class="theme-disco__title" id="theme-disco-title"><?php echo t('テーマを探す') ?></h2>
 
     <div class="theme-disco__search">
-        <svg class="theme-disco__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" style="position:absolute;left:14px;top:50%;width:20px;height:20px;transform:translateY(-50%);fill:#9aa3af;pointer-events:none"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z" /></svg>
+        <?php // スタイルは components/theme_discovery.css（.theme-disco__icon）に集約 ?>
+        <svg class="theme-disco__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z" /></svg>
         <input id="theme-disco-input" class="theme-disco__input" type="search" inputmode="search" enterkeyhint="search"
             autocomplete="off" autocapitalize="off" spellcheck="false"
             placeholder="<?php echo t('テーマ名で検索') ?>" aria-label="<?php echo t('テーマ名で検索') ?>">
@@ -72,51 +73,9 @@ $shelves = array_values(array_filter([
         JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
     ) ?></script>
 
-    <style>
-        /* サイトのグローバル section{display:flex;justify-content:center} を打ち消す（既存 .recommend-ranking-section と同様） */
-        .theme-disco{display:block;text-align:left;margin-top:10px;padding:18px 1rem 6px;border-top:1px solid #eef0f3}
-        .theme-disco--search-only{border-top:0;margin-top:6px;padding-top:2px}
-        .theme-disco__title{margin:0 0 12px;padding:0;display:flex;align-items:center;font-size:15px;font-weight:700;color:#0f1620;letter-spacing:.02em}
-        .theme-disco__title::before{content:"";flex:0 0 auto;width:3px;height:15px;background:#06c755;border-radius:2px;margin-right:8px}
-        .theme-disco__search{position:relative;display:block;width:100%}
-        .theme-disco__icon{position:absolute;left:14px;top:50%;transform:translateY(-50%);width:20px;height:20px;fill:#9aa3af;pointer-events:none}
-        /* font-size は必ず16px以上: iOS Safari のフォーカス時オートズーム回避 */
-        .theme-disco__input{display:block;width:100%;box-sizing:border-box;height:48px;margin:0;padding:0 44px 0 44px;font-size:16px;color:#0f1620;background:#f6f8fa;border:1.5px solid #e4e8ee;border-radius:12px;outline:none;-webkit-appearance:none;appearance:none;transition:border-color .15s,background .15s,box-shadow .15s}
-        .theme-disco__input::placeholder{color:#9aa3af}
-        /* type=search のネイティブ取消ボタンを抑止（自作✕と二重表示になるため）。iOS は元々非表示 */
-        .theme-disco__input::-webkit-search-cancel-button{-webkit-appearance:none;appearance:none;display:none}
-        .theme-disco__input:focus{background:#fff;border-color:#06c755;box-shadow:0 0 0 3px rgba(6,199,85,.14)}
-        .theme-disco__clear{position:absolute;right:6px;top:0;bottom:0;width:40px;display:flex;align-items:center;justify-content:center;color:#9aa3af;font-size:20px;line-height:1;cursor:pointer;-webkit-user-select:none;user-select:none}
-        .theme-disco__clear:hover{color:#5b6573}
-        .theme-disco__clear[hidden]{display:none}
-        .theme-disco__spinner{width:20px;height:20px;border:2.5px solid #d7dde6;border-top-color:#06c755;border-radius:50%;animation:theme-disco-spin .7s linear infinite;margin:8px 2px}
-        @keyframes theme-disco-spin{to{transform:rotate(360deg)}}
-        .theme-disco__results{display:flex;flex-wrap:wrap;align-items:flex-start;align-content:flex-start;gap:8px;margin-top:14px}
-        .theme-disco__shelves{display:flex;flex-direction:column;gap:16px;margin-top:16px}
-        /* [hidden] を確実に優先（display:flex に勝たせる） */
-        .theme-disco__results[hidden],.theme-disco__shelves[hidden]{display:none}
-        .theme-disco__shelf{animation:theme-disco-fade .4s ease both;animation-delay:calc(var(--i,0)*60ms)}
-        @keyframes theme-disco-fade{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
-        @media (prefers-reduced-motion:reduce){.theme-disco__shelf{animation:none}}
-        .theme-disco__shelf-label{display:flex;align-items:center;gap:6px;font-size:12px;font-weight:700;color:#5b6573;margin-bottom:9px}
-        .theme-disco__shelf-ico{font-size:13px;line-height:1}
-        .theme-disco__chips{display:flex;flex-wrap:wrap;gap:8px}
-        .theme-disco-chip{display:inline-flex;align-items:center;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-decoration:none;font-size:14px;font-weight:500;color:#28303c;background:#f6f8fa;border:1px solid #e4e8ee;border-radius:999px;padding:8px 14px;line-height:1.15;transition:transform .08s ease,background .12s,border-color .12s}
-        .theme-disco-chip:hover{background:#eef1f5;border-color:#d7dde6}
-        .theme-disco-chip:active{transform:scale(.96)}
-        .theme-disco-chip--hot{color:#067a37;background:#eefcf3;border-color:#bfead0;font-weight:700}
-        .theme-disco-chip--hot:hover{background:#e2f9ea;border-color:#a6e0bd}
-        .theme-disco__empty{font-size:13px;color:#9aa3af;padding:6px 2px}
-        /* テーマ0件時のフォールバック（一致するオープンチャット＝部屋。チップでなくリスト行で“部屋”と分かる見せ方） */
-        .theme-disco__rooms{display:block;width:100%}
-        .theme-disco__note{font-size:13px;color:#9aa3af;padding:2px 2px 0}
-        .theme-disco__rooms-h{display:flex;align-items:center;gap:6px;font-size:12px;font-weight:700;color:#5b6573;margin:10px 0 8px}
-        .theme-disco__rooms-h::before{content:"💬";font-size:12px}
-        .theme-disco__room{display:flex;flex-direction:column;gap:2px;padding:9px 11px;margin-bottom:8px;background:#fff;border:1px solid #eef0f3;border-radius:10px;text-decoration:none}
-        .theme-disco__room:active{background:#f6f8fa}
-        .theme-disco__room-name{font-size:14px;font-weight:600;color:#1f2937;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-        .theme-disco__room-meta{font-size:12px;color:#5b6573}
-    </style>
+    <?php /* スタイルは style/components/theme_discovery.css に外部化済み。
+             本コンポーネントを使うページはコントローラの $_css に
+             'components/theme_discovery' を追加すること。 */ ?>
     <script>
         (() => {
             const input = document.getElementById('theme-disco-input');

--- a/app/Views/recent_comment.php
+++ b/app/Views/recent_comment.php
@@ -77,7 +77,7 @@ viewComponent('head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']) ?
         }
 
         .button01.prev a {
-            border: solid 1px var(--border-color);
+            border: solid 1px var(--c-border);
             border-radius: var(--border-radius);
         }
 

--- a/app/Views/recent_content.php
+++ b/app/Views/recent_content.php
@@ -5,7 +5,7 @@
 <body class="body">
     <style>
         hr {
-            border-bottom: solid 1px var(--border-color);
+            border-bottom: solid 1px var(--c-border);
             margin: 12px 0;
         }
 

--- a/public/style/components/ads_element.css
+++ b/public/style/components/ads_element.css
@@ -1,3 +1,10 @@
+/* ============================================================
+   自社広告要素（kokoku-*）
+   色は style/tokens.css のトークン（--c-* / --icon-*）を参照する。
+   --padding / --paragraph-color はこのコンポーネント内のローカル変数
+   （512px 以上で値を切り替えるためのスイッチ）。
+   ============================================================ */
+
 .kokoku-element {
   all: unset;
   display: flex;
@@ -13,9 +20,8 @@
     sans-serif;
   word-break: break-all;
   --padding: 0 1rem;
-  --paragraph-color: #aaa;
-  /* aspect-ratio: 1; */
-  color: #111;
+  --paragraph-color: var(--c-text-4);
+  color: var(--c-text-1);
   margin: auto;
 }
 
@@ -43,8 +49,7 @@
 .kokoku-img-box {
   width: 100%;
   display: flex;
-  /* aspect-ratio: 1.2; */
-  background: rgb(250, 250, 250);
+  background: var(--c-bg-sub);
 }
 
 .kokoku-img {
@@ -85,7 +90,7 @@
   margin-top: 2px;
   margin-left: 4px;
   border-radius: 7px;
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   font-size: 11px;
   font-weight: bold;
   user-select: none;
@@ -116,12 +121,12 @@
   display: block;
   width: fit-content;
   font-size: 11px;
-  color: #aaa;
+  color: var(--c-text-4);
   line-height: 1.3;
 }
 
 .kokoku-pr-icon {
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   font-size: 10px;
   padding: 1px 2px;
   border-radius: 2px;
@@ -136,7 +141,7 @@
   display: block;
   height: 15px;
   width: 15px;
-  background: rgb(240, 240, 240);
+  background: var(--c-surface-3);
   position: absolute;
   right: 0;
   top: 0;
@@ -150,13 +155,13 @@
   width: 13px;
   margin: auto;
   background-repeat: no-repeat;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 32 32' id='info'%3E%3Cg fill='%2306c755'%3E%3Cpath d='M16 0C7.164 0 0 7.164 0 16s7.164 16 16 16 16-7.164 16-16S24.836 0 16 0zm0 30C8.28 30 2 23.72 2 16S8.28 2 16 2s14 6.28 14 14-6.28 14-14 14zm0-18a2 2 0 0 0-2 2v10a2 2 0 0 0 4 0V14a2 2 0 0 0-2-2zm-2-3.968a2 2 1080 1 0 4 0 2 2 1080 1 0-4 0z'%3E%3C/path%3E%3C/g%3E%3C/svg%3E");
+  background-image: var(--icon-info-brand);
 }
 
 @media screen and (min-width: 512px) {
   .kokoku-element {
     --padding: 0;
-    --paragraph-color: #777;
+    --paragraph-color: var(--c-text-3);
     aspect-ratio: unset;
     margin: 1rem auto 0.5rem auto;
   }
@@ -166,13 +171,8 @@
     padding: 0 16.5%;
   }
 
-  /*   .kokoku-img,
-  .kokoku-img-box {
-    border-radius: 7px;
-  }
- */
   .kokoku-title-button:hover {
-    background: rgb(250, 250, 250);
+    background: var(--c-bg-sub);
   }
 
   .kokoku-title:hover,

--- a/public/style/components/room_list.css
+++ b/public/style/components/room_list.css
@@ -3,7 +3,7 @@
 }
 
 .ht-top-header {
-  background-color: var(--border-color);
+  background-color: var(--c-border);
   margin: 0rem -1rem 0rem -1rem;
 }
 
@@ -27,7 +27,7 @@
 
 .ranking-page-main {
   padding-top: 0rem;
-  border-bottom: solid 1px var(--border-color);
+  border-bottom: solid 1px var(--c-border);
 }
 
 .article-news {
@@ -139,9 +139,9 @@
 }
 
 .ellipse-btn:focus-visible {
-  outline: 3px solid var(--headline);
-  background-color: var(--background);
-  color: var(--headline);
+  outline: 3px solid var(--c-text-1);
+  background-color: var(--c-bg-bright);
+  color: var(--c-text-1);
 }
 
 .ellipse-btn.add-openchat {
@@ -165,8 +165,8 @@
 .add-openchat-message.success {
   display: block;
   margin-top: 1rem;
-  color: var(--background);
-  background-color: var(--headline);
+  color: var(--c-bg-bright);
+  background-color: var(--c-text-1);
 }
 
 .openchat-list-title-area {
@@ -250,7 +250,7 @@
 .refresh-icon {
   height: 12px;
   aspect-ratio: 1/1;
-  background-image: var(--refresh);
+  background-image: var(--icon-refresh);
   margin: auto 0;
 }
 
@@ -836,7 +836,7 @@
   display: flex;
   background-color: #fff;
   border-radius: 8px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--c-border);
   border-color: #efefef;
   box-sizing: border-box;
   margin: 0 auto;
@@ -902,9 +902,9 @@
   display: inline-flex;
   align-items: center;
   width: fit-content;
-  color: var(--headline);
-  background-color: var(--background);
-  border: solid 1px var(--border-color);
+  color: var(--c-text-1);
+  background-color: var(--c-bg-bright);
+  border: solid 1px var(--c-border);
   border-radius: var(--border-radius);
   padding: 0 1em;
   height: 48px;
@@ -928,8 +928,8 @@
   margin-left: 4px;
   width: 5px;
   height: 5px;
-  border-top: 2px solid var(--headline);
-  border-right: 2px solid var(--headline);
+  border-top: 2px solid var(--c-text-1);
+  border-right: 2px solid var(--c-text-1);
   transform: rotate(45deg);
   margin-bottom: 2px;
 }
@@ -947,7 +947,7 @@
 
 .button01 a:focus-visible {
   transition: 0s;
-  outline: 2px solid var(--tertiary);
+  outline: 2px solid var(--c-outline-highlight);
   background-color: rgba(227, 246, 245, 0.7);
 }
 
@@ -971,7 +971,7 @@
   margin-top: 12px;
   justify-content: space-evenly;
   flex-wrap: nowrap;
-  border-bottom: solid 1px var(--border-color);
+  border-bottom: solid 1px var(--c-border);
 }
 
 .list-btn {
@@ -1207,7 +1207,7 @@
   }
 
   .recent-comment-list .openchat-item:hover > .link-overlay.hover {
-    background: var(--hover);
+    background: var(--c-bg-sub);
   }
 
   main summary:hover {
@@ -1216,7 +1216,7 @@
   }
 
   .top-ranking-readMore:hover {
-    background-color: var(--hover);
+    background-color: var(--c-bg-sub);
   }
 
   .openchat-list-title-result-area {
@@ -1247,16 +1247,16 @@
   }
 
   .page-select form:hover {
-    background-color: var(--hover);
+    background-color: var(--c-bg-sub);
   }
 
   .button01 a:hover {
     filter: none;
-    background-color: var(--hover);
+    background-color: var(--c-bg-sub);
   }
 
   .list-btn:hover:not(:disabled) {
-    background-color: var(--hover);
+    background-color: var(--c-bg-sub);
   }
 
   .super-icon {
@@ -1517,7 +1517,7 @@
 
 @media screen and (min-width: 512px) {
   .news-summary:hover {
-    background-color: var(--hover);
+    background-color: var(--c-bg-sub);
   }
 }
 

--- a/public/style/components/search_form.css
+++ b/public/style/components/search_form.css
@@ -1,11 +1,16 @@
+/* ============================================================
+   検索フォーム（トップページ等の大きな検索ボックス）
+   色は style/tokens.css のトークン（--c-* / --icon-*）を参照する。
+   ============================================================ */
+
 .search-form2 {
   all: unset;
   width: 100%;
   font-size: 1.1rem;
   -webkit-box-align: center;
   align-items: center;
-  border: 1px solid var(--color-bg-secondary);
-  background-color: rgb(255, 255, 255);
+  border: 1px solid var(--c-border-3);
+  background-color: var(--c-bg);
   border-radius: 99rem;
   display: flex;
   position: relative;
@@ -20,7 +25,7 @@
   align-items: center;
   width: 24px;
   height: 24px;
-  background-image: var(--search);
+  background-image: var(--icon-search);
 }
 
 .search-form2 input {
@@ -28,14 +33,14 @@
   padding: 0.9rem 1rem 0.9rem 2.9rem;
   width: 100%;
   font-size: inherit;
-  background: #0000;
+  background: transparent;
   outline: 0;
   border: none;
   resize: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: transparent;
 }
 
 .search-form2:has(input:focus) {
   outline: 0;
-  box-shadow: 0px 0px 0px 1px #06c755;
+  box-shadow: 0px 0px 0px 1px var(--c-brand);
 }

--- a/public/style/components/site_footer.css
+++ b/public/style/components/site_footer.css
@@ -1,7 +1,7 @@
-:root {
-  --border-color: #efefef;
-  --hover: rgb(250, 250, 250);
-}
+/* ============================================================
+   サイト共通フッター（リンク・コピーライト・シェアボタン）
+   色は style/tokens.css のトークン（--c-*）を参照する。
+   ============================================================ */
 
 .footer-elem-outer {
   all: unset;
@@ -20,7 +20,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .footer-link-inner {
@@ -52,7 +52,7 @@
   display: flex;
   gap: 4px;
   font-size: 11px;
-  color: #aaa;
+  color: var(--c-text-4);
   margin: 0 auto;
   margin-top: 8px;
   flex-direction: column;
@@ -63,7 +63,7 @@
 }
 
 .copyright a {
-  color: #b7b7b7;
+  color: var(--c-text-5);
   font-weight: normal;
 }
 
@@ -71,7 +71,7 @@
   margin: 3px 0;
   text-decoration: none;
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .app_link a {
@@ -82,7 +82,7 @@
   font-size: 11px;
   margin-bottom: 4px;
   letter-spacing: 0.06px;
-  color: #b7b7b7;
+  color: var(--c-text-5);
 }
 
 .open-btn2 {
@@ -92,7 +92,8 @@
   align-items: center;
 }
 
-/* シェアボタン */
+/* ---------- シェアボタン ---------- */
+
 .share-nav {
   display: flex;
   width: 100%;
@@ -105,7 +106,7 @@
 .share-nav h3 {
   all: unset;
   font-size: 13px;
-  color: #111;
+  color: var(--c-text-1);
   display: block;
   margin: 0 auto;
   line-height: 1.5;
@@ -152,7 +153,7 @@
 
 .share-menu-icon-twitter {
   background-image: url('/assets/twitter_x.svg');
-  background-color: #000000;
+  background-color: var(--c-sns-x);
   border-radius: 6px;
 }
 
@@ -161,10 +162,12 @@
 }
 
 .share-menu-icon-hatena {
-  background-color: #00a4de;
+  background-color: var(--c-sns-hatena);
   background-image: url('/assets/hatena.svg');
   border-radius: 6px;
 }
+
+/* ---------- URLコピー ---------- */
 
 .copy-btn {
   display: flex;
@@ -175,7 +178,7 @@
   min-height: 48px;
   width: 100%;
   border-radius: 99rem;
-  border: 1px solid rgb(189, 189, 189);
+  border: 1px solid var(--c-border-strong);
   font-weight: normal;
   box-sizing: border-box;
 }
@@ -208,16 +211,17 @@
   height: 16px;
 }
 
+/* コピー完了ツールチップ */
 .description1 {
   z-index: 100;
   display: none;
   position: fixed;
   padding: 10px;
   font-size: 13px;
-  color: #fff;
+  color: var(--c-text-inverse);
   font-weight: bold;
   border-radius: 4px;
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: var(--c-overlay);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   width: 87.5%;
@@ -278,6 +282,8 @@
   animation-fill-mode: both;
 }
 
+/* ---------- レスポンシブ ---------- */
+
 @media screen and (min-width: 512px) {
   .footer-link-inner a {
     font-size: 14px;
@@ -293,6 +299,7 @@
     gap: 1.5rem;
   }
 
+  .open-btn2 a:hover,
   .footer-link-box a:hover {
     -webkit-text-decoration: underline 1px currentColor;
     text-decoration: underline 1px currentColor;
@@ -319,10 +326,7 @@
   }
 
   .copy-btn:hover:not(.copy-btn-copied) {
-    background-color: var(--hover);
-  }
-
-  .footer-link-box {
+    background-color: var(--c-bg-sub);
   }
 
   .app-dl {
@@ -340,7 +344,7 @@
     top: 100%;
     left: 50%;
     border: 15px solid transparent;
-    border-top: 15px solid rgba(0, 0, 0, 0.8);
+    border-top: 15px solid var(--c-overlay);
     margin-left: -15px;
     cursor: auto;
   }
@@ -373,24 +377,5 @@
   .copy-btn-title {
     width: fit-content;
     font-size: 12px;
-  }
-}
-
-@media screen and (min-width: 512px) {
-  .footer-link-inner a {
-    font-size: 14px;
-    line-height: 1.9;
-  }
-
-  .open-btn2 a:hover,
-  .footer-link-box a:hover {
-    -webkit-text-decoration: underline 1px currentColor;
-    text-decoration: underline 1px currentColor;
-  }
-}
-
-@media screen and (max-width: 360px) {
-  .footer-link-inner a {
-    font-size: 11.5px;
   }
 }

--- a/public/style/components/site_header.css
+++ b/public/style/components/site_header.css
@@ -1,19 +1,19 @@
+/* ============================================================
+   サイト共通ヘッダー
+   色は style/tokens.css のトークン（--c-* / --icon-*）を参照する。
+   構成: 変数 / レイアウト基礎 / ヘッダー / 検索 / 増減表示 /
+         リンクアイコン / チェックボックス / バッジ / 広告枠 / 罫線
+   ============================================================ */
+
 :root {
-  --refresh: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23b7b7b7' d='M256 0C179.9 0 111.7 33.4 64.9 86.2L0 21.3V192h170.7l-60.2-60.2C145.6 90.5 197.5 64 256 64c106 0 192 85.9 192 192s-86 192-192 192c-53 0-101-21.5-135.8-56.2L75 437c46.4 46.3 110.4 75 181 75 141.4 0 256-114.6 256-256S397.4 0 256 0zm-21.3 106.7v170.7h128v-42.7h-85.3v-128h-42.7z' /%3E%3C/svg%3E");
-  --search: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 27' class='search-icon'%3E%3Cpath d='M11.56,3.43a8.26,8.26,0,0,0,0,16.52,8.18,8.18,0,0,0,5-1.72l4.7,4.7a1.1,1.1,0,0,0,1.56,0,1.09,1.09,0,0,0,0-1.55l0,0-4.7-4.7a8.18,8.18,0,0,0,1.72-5A8.28,8.28,0,0,0,11.56,3.43Zm0,2.2A6.06,6.06,0,1,1,5.5,11.69,6,6,0,0,1,11.56,5.63Z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E");
-  --link-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='%23b7b7b7' viewBox='0 0 20 20'%3E%3Cpath d='M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a%0A1 1 0 102 0V4a1 1 0 00-1-1h-5z'/%3E%3Cpath d='M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z'/%3E%3Cdeepl-alert xmlns=''/%3E%3Cdeepl-alert xmlns=''/%3E%3Cdeepl-alert xmlns=''/%3E%3C/svg%3E");
-  --link-icon-brue: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='%2316c2c1' viewBox='0 0 20 20'%3E%3Cpath d='M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a%0A1 1 0 102 0V4a1 1 0 00-1-1h-5z'/%3E%3Cpath d='M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z'/%3E%3Cdeepl-alert xmlns=''/%3E%3Cdeepl-alert xmlns=''/%3E%3Cdeepl-alert xmlns=''/%3E%3C/svg%3E");
-  --link-icon777: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='%23b7b7b7' viewBox='0 0 20 20'%3E%3Cpath d='M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a%0A1 1 0 102 0V4a1 1 0 00-1-1h-5z'/%3E%3Cpath d='M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z'/%3E%3Cdeepl-alert xmlns=''/%3E%3Cdeepl-alert xmlns=''/%3E%3Cdeepl-alert xmlns=''/%3E%3C/svg%3E");
-  --background: #fffffe;
-  --secondary: #e3f6f5;
-  --tertiary: #bae8e8;
-  --headline: #111;
   --width: 812px;
   --max-width: 812px;
   --font-family:
     -apple-system, system-ui, blinkmacsystemfont, Helvetica Neue, helvetica, Hiragino Sans, arial,
     sans-serif;
 }
+
+/* ---------- レイアウト基礎 ---------- */
 
 * {
   box-sizing: border-box;
@@ -56,7 +56,8 @@ body::before {
   padding-top: 4px;
 }
 
-/* ヘッダー */
+/* ---------- ヘッダー ---------- */
+
 .body {
   max-width: var(--width);
   margin: 0 auto;
@@ -71,7 +72,7 @@ body::before {
   left: 0;
   right: 0;
   margin: 0 auto;
-  background-color: rgba(255, 255, 255, 0.85);
+  background-color: var(--c-header-backdrop);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   width: 100%;
@@ -153,7 +154,7 @@ body::before {
   white-space: nowrap;
   font-weight: bold;
   font-size: 15px;
-  color: #111;
+  color: var(--c-text-1);
   line-height: 1.75;
   font-family: var(--font-family);
 }
@@ -165,7 +166,7 @@ body::before {
   white-space: pre;
   font-weight: bold;
   font-size: 13px;
-  color: #111;
+  color: var(--c-text-1);
   line-height: 1.3;
   font-family: var(--font-family);
 }
@@ -193,7 +194,7 @@ body::before {
 /* カテゴリーボタン（文字小さめ・左右パディング詰め・幅縮小） */
 .category-button {
   height: 36px;
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   border-radius: 7px;
   display: flex;
   text-decoration: unset;
@@ -205,7 +206,7 @@ body::before {
   width: fit-content;
   margin: auto;
   line-height: 24px;
-  color: #111;
+  color: var(--c-text-1);
   font-weight: bold;
   padding: 0 0.65rem;
   font-family: var(--font-family);
@@ -215,9 +216,9 @@ body::before {
 /* ブログボタン（緑文字・日本語のみ） */
 .blog-button {
   height: 36px;
-  border: 1px solid #bfe9cf;
+  border: 1px solid var(--c-btn-blog-border);
   border-radius: 7px;
-  background: #f1faf4;
+  background: var(--c-btn-blog-bg);
   display: flex;
   text-decoration: unset;
 }
@@ -226,14 +227,15 @@ body::before {
   font-size: 12.5px;
   margin: auto;
   line-height: 24px;
-  color: #05a648;
+  color: var(--c-btn-blog-text);
   font-weight: bold;
   padding: 0 0.7rem;
   font-family: var(--font-family);
   text-wrap: nowrap;
 }
 
-/* 検索フォーム */
+/* ---------- 検索フォーム ---------- */
+
 .header-button {
   all: unset;
   display: flex;
@@ -253,7 +255,7 @@ body::before {
   margin: auto;
   width: 24px;
   height: 24px;
-  background-image: var(--search);
+  background-image: var(--icon-search);
 }
 
 .search-form {
@@ -278,7 +280,7 @@ body::before {
   margin: auto;
   height: fit-content;
   border-radius: 7px;
-  background: #f5f5f5;
+  background: var(--c-surface);
   position: relative;
   padding: 0.3em 0.7em 0.3em 2.3em;
   width: 100%;
@@ -300,7 +302,7 @@ body::before {
   width: 19px;
   height: 19px;
   margin: 0;
-  background-image: var(--search);
+  background-image: var(--icon-search);
 }
 
 .search-form input {
@@ -331,16 +333,20 @@ body::before {
   display: flex;
 }
 
+/* ---------- メンバー数の増減表示 ---------- */
+
 .positive .openchat-item-stats {
-  color: #4d73ff;
+  color: var(--c-accent-blue);
 }
 
 .negative .openchat-item-stats {
-  color: #ff5d6d;
+  color: var(--c-down);
 }
 
+/* ---------- 外部リンクアイコン ---------- */
+
 .line-link-icon {
-  background-image: var(--link-icon-brue);
+  background-image: var(--icon-external-teal);
   background-repeat: no-repeat;
   width: 16px;
   height: 16px;
@@ -352,7 +358,7 @@ body::before {
 }
 
 .line-link-icon777 {
-  background-image: var(--link-icon777);
+  background-image: var(--icon-external-gray);
   background-repeat: no-repeat;
   width: 16px;
   height: 16px;
@@ -369,7 +375,8 @@ body::before {
   height: 12px;
 }
 
-/* チェックボックス */
+/* ---------- チェックボックス ---------- */
+
 .checkbox-label {
   all: unset;
   display: flex;
@@ -378,7 +385,7 @@ body::before {
   cursor: pointer;
   user-select: none;
   box-sizing: border-box;
-  color: #303030;
+  color: var(--c-text-dim);
   font-size: 11px;
 }
 
@@ -406,19 +413,19 @@ body::before {
   min-width: 20px;
   /* 生成ボタンサイズ */
   vertical-align: -0.8rem;
-  color: #fff;
+  color: var(--c-text-inverse);
   cursor: pointer;
   display: inline-block;
   outline: none;
   border-radius: 10%;
 }
 
-/* Checkbox */
+/* チェックマーク（before/after の白い線） */
 .checkbox-label input[type='checkbox']:before,
 .checkbox-label input[type='checkbox']:after {
   position: absolute;
   content: '';
-  background: #fff;
+  background: var(--c-text-inverse);
 }
 
 .checkbox-label input[type='checkbox']:before {
@@ -471,31 +478,17 @@ body::before {
   bottom: 7px;
 }
 
-/* Colors */
+/* ブランド緑グラデーションの枠・塗り */
 .checkbox-label input[type='checkbox'] {
   border: 2px solid;
-  border-image: linear-gradient(
-    332deg,
-    #0dc95a,
-    #11d871 23.96%,
-    #11d593 55.46%,
-    #12cfcd 83.85%,
-    #16c2c1
-  );
+  border-image: var(--c-brand-gradient);
   border-image-slice: 1;
   mask: linear-gradient(black, black);
 }
 
 .checkbox-label input[type='checkbox']:checked,
 .checkbox-label input[type='checkbox']:indeterminate {
-  background: linear-gradient(
-    332deg,
-    #0dc95a,
-    #11d871 23.96%,
-    #11d593 55.46%,
-    #12cfcd 83.85%,
-    #16c2c1
-  );
+  background: var(--c-brand-gradient);
 }
 
 .admin-check-label {
@@ -503,6 +496,8 @@ body::before {
   font-size: 12px;
   font-weight: 700;
 }
+
+/* ---------- 公式・スペシャル・鍵バッジ ---------- */
 
 .super-icon {
   width: 21px;
@@ -559,7 +554,7 @@ body::before {
   }
 
   .header-button:hover {
-    background-color: var(--hover);
+    background-color: var(--c-bg-sub);
   }
 
   .header_site_title:focus-visible {
@@ -580,6 +575,8 @@ body::before {
   }
 }
 
+/* ---------- 更新時刻表示 ---------- */
+
 .site_header .refresh-time {
   margin-left: 9px;
   display: flex;
@@ -589,32 +586,23 @@ body::before {
 .site_header .refresh-icon {
   height: 11px;
   aspect-ratio: 1/1;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23b7b7b7' d='M256 0C179.9 0 111.7 33.4 64.9 86.2L0 21.3V192h170.7l-60.2-60.2C145.6 90.5 197.5 64 256 64c106 0 192 85.9 192 192s-86 192-192 192c-53 0-101-21.5-135.8-56.2L75 437c46.4 46.3 110.4 75 181 75 141.4 0 256-114.6 256-256S397.4 0 256 0zm-21.3 106.7v170.7h128v-42.7h-85.3v-128h-42.7z' /%3E%3C/svg%3E");
+  background-image: var(--icon-refresh);
   margin: auto 0;
 }
 
 .site_header .refresh-time time {
   margin: auto 0;
   margin-left: 2px;
-  color: #b7b7b7;
+  color: var(--c-text-5);
   font-size: 12px;
   font-family:
     'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
   display: inline-block;
 }
-/* 
-.grippy-host {
-  display: none;
-}
 
-.right-side-rail-dismiss-btn {
-  display: none;
-}
+/* ---------- 広告枠（全ページ共通のためこのファイルに置く。
+              ads_element.css は広告説明ページ専用） ---------- */
 
-.left-side-rail-dismiss-btn {
-  display: none;
-}
- */
 .rectangle-ads {
   width: auto;
   aspect-ratio: 16/9;
@@ -667,16 +655,8 @@ body::before {
 
 .adsbygoogle {
   display: block;
-  background: rgb(250, 250, 250);
+  background: var(--c-bg-sub);
 }
-
-/* ins.adsbygoogle[data-ad-status='unfilled'] {
-  display: none !important;
-}
-
-ins.adsbygoogle[data-anchor-status='dismissed'] {
-  display: none !important;
-} */
 
 .rectangle2-ads {
   width: auto;
@@ -690,10 +670,12 @@ ins.adsbygoogle[data-anchor-status='dismissed'] {
   }
 }
 
+/* ---------- 罫線 ---------- */
+
 .hr-top {
   all: unset;
   display: block;
-  border-bottom: 1px solid #efefef;
+  border-bottom: 1px solid var(--c-border);
   margin: 0 auto;
   margin-bottom: -4px;
   padding: 4.5px 0;
@@ -703,7 +685,7 @@ ins.adsbygoogle[data-anchor-status='dismissed'] {
 .hr-bottom {
   all: unset;
   display: block;
-  border-top: 1px solid #efefef;
+  border-top: 1px solid var(--c-border);
   margin: 0 auto;
   margin-top: -4px;
   padding: 4.5px 0;

--- a/public/style/components/theme_discovery.css
+++ b/public/style/components/theme_discovery.css
@@ -1,0 +1,319 @@
+/* ============================================================
+   テーマ発見セクション（components/theme_discovery.php）
+   /recommend 着地客の回遊導線: 全幅検索 + 急上昇/人気/近いカテゴリの棚。
+   色は style/tokens.css のトークン（--c-*）を参照する。
+   ============================================================ */
+
+/* サイトのグローバル section{display:flex;justify-content:center} を打ち消す
+   （既存 .recommend-ranking-section と同様） */
+.theme-disco {
+  display: block;
+  text-align: left;
+  margin-top: 10px;
+  padding: 18px 1rem 6px;
+  border-top: 1px solid var(--c-cool-border-soft);
+}
+
+.theme-disco--search-only {
+  border-top: 0;
+  margin-top: 6px;
+  padding-top: 2px;
+}
+
+.theme-disco__title {
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--c-cool-text-deep);
+  letter-spacing: 0.02em;
+}
+
+.theme-disco__title::before {
+  content: '';
+  flex: 0 0 auto;
+  width: 3px;
+  height: 15px;
+  background: var(--c-brand);
+  border-radius: 2px;
+  margin-right: 8px;
+}
+
+/* ---------- 検索ボックス ---------- */
+
+.theme-disco__search {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.theme-disco__icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  fill: var(--c-cool-text-weak);
+  pointer-events: none;
+}
+
+/* font-size は必ず16px以上: iOS Safari のフォーカス時オートズーム回避 */
+.theme-disco__input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  height: 48px;
+  margin: 0;
+  padding: 0 44px 0 44px;
+  font-size: 16px;
+  color: var(--c-cool-text-deep);
+  background: var(--c-cool-surface);
+  border: 1.5px solid var(--c-border-2);
+  border-radius: 12px;
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    box-shadow 0.15s;
+}
+
+.theme-disco__input::placeholder {
+  color: var(--c-cool-text-weak);
+}
+
+/* type=search のネイティブ取消ボタンを抑止（自作✕と二重表示になるため）。iOS は元々非表示 */
+.theme-disco__input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+}
+
+.theme-disco__input:focus {
+  background: var(--c-bg);
+  border-color: var(--c-brand);
+  box-shadow: 0 0 0 3px var(--c-brand-ring);
+}
+
+.theme-disco__clear {
+  position: absolute;
+  right: 6px;
+  top: 0;
+  bottom: 0;
+  width: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--c-cool-text-weak);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.theme-disco__clear:hover {
+  color: var(--c-cool-text);
+}
+
+.theme-disco__clear[hidden] {
+  display: none;
+}
+
+.theme-disco__spinner {
+  width: 20px;
+  height: 20px;
+  border: 2.5px solid var(--c-cool-border);
+  border-top-color: var(--c-brand);
+  border-radius: 50%;
+  animation: theme-disco-spin 0.7s linear infinite;
+  margin: 8px 2px;
+}
+
+@keyframes theme-disco-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ---------- 結果・棚 ---------- */
+
+.theme-disco__results {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  align-content: flex-start;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.theme-disco__shelves {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+/* [hidden] を確実に優先（display:flex に勝たせる） */
+.theme-disco__results[hidden],
+.theme-disco__shelves[hidden] {
+  display: none;
+}
+
+.theme-disco__shelf {
+  animation: theme-disco-fade 0.4s ease both;
+  animation-delay: calc(var(--i, 0) * 60ms);
+}
+
+@keyframes theme-disco-fade {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-disco__shelf {
+    animation: none;
+  }
+}
+
+.theme-disco__shelf-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c-cool-text);
+  margin-bottom: 9px;
+}
+
+.theme-disco__shelf-ico {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.theme-disco__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* ---------- テーマチップ ---------- */
+
+.theme-disco-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--c-cool-text-strong);
+  background: var(--c-cool-surface);
+  border: 1px solid var(--c-border-2);
+  border-radius: 999px;
+  padding: 8px 14px;
+  line-height: 1.15;
+  transition:
+    transform 0.08s ease,
+    background 0.12s,
+    border-color 0.12s;
+}
+
+.theme-disco-chip:hover {
+  background: var(--c-cool-surface-hover);
+  border-color: var(--c-cool-border);
+}
+
+.theme-disco-chip:active {
+  transform: scale(0.96);
+}
+
+.theme-disco-chip--hot {
+  color: var(--c-chip-hot-text);
+  background: var(--c-chip-hot-bg);
+  border-color: var(--c-chip-hot-border);
+  font-weight: 700;
+}
+
+.theme-disco-chip--hot:hover {
+  background: var(--c-chip-hot-bg-hover);
+  border-color: var(--c-chip-hot-border-hover);
+}
+
+.theme-disco__empty {
+  font-size: 13px;
+  color: var(--c-cool-text-weak);
+  padding: 6px 2px;
+}
+
+/* ---------- テーマ0件時のフォールバック
+     （一致するオープンチャット＝部屋。チップでなくリスト行で“部屋”と分かる見せ方） ---------- */
+
+.theme-disco__rooms {
+  display: block;
+  width: 100%;
+}
+
+.theme-disco__note {
+  font-size: 13px;
+  color: var(--c-cool-text-weak);
+  padding: 2px 2px 0;
+}
+
+.theme-disco__rooms-h {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c-cool-text);
+  margin: 10px 0 8px;
+}
+
+.theme-disco__rooms-h::before {
+  content: '💬';
+  font-size: 12px;
+}
+
+.theme-disco__room {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 11px;
+  margin-bottom: 8px;
+  background: var(--c-bg);
+  border: 1px solid var(--c-cool-border-soft);
+  border-radius: 10px;
+  text-decoration: none;
+}
+
+.theme-disco__room:active {
+  background: var(--c-cool-surface);
+}
+
+.theme-disco__room-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--c-cool-text-heading);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-disco__room-meta {
+  font-size: 12px;
+  color: var(--c-cool-text);
+}

--- a/public/style/pages/room_page.css
+++ b/public/style/pages/room_page.css
@@ -417,7 +417,7 @@ html {
 .refresh-icon {
   height: 12px;
   aspect-ratio: 1/1;
-  background-image: var(--refresh);
+  background-image: var(--icon-refresh);
 }
 
 .openchat-list-date time {

--- a/public/style/tokens.css
+++ b/public/style/tokens.css
@@ -34,6 +34,31 @@
   --grad-green-3: #11d593;
   --grad-green-4: #12cfcd;
   --grad-green-5: #16c2c1;
+
+  /* 合成グラデーション（チェックボックス等の 332deg 帯） */
+  --c-brand-gradient: linear-gradient(
+    332deg,
+    var(--grad-green-1),
+    var(--grad-green-2) 23.96%,
+    var(--grad-green-3) 55.46%,
+    var(--grad-green-4) 83.85%,
+    var(--grad-green-5)
+  );
+}
+
+/* ------------------------------------------------------------
+   アイコン（data-URI SVG・fill 色込み）
+   SVG-as-image では fill='currentColor' は親の color を継承せず
+   黒に解決される点に注意（--icon-search は事実上の黒アイコン）。
+   ダークモード導入時は、このセクションのトークンごと
+   fill 違いの URI に差し替える（描画パスを変えないため）。
+   ------------------------------------------------------------ */
+:root {
+  --icon-refresh: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23b7b7b7' d='M256 0C179.9 0 111.7 33.4 64.9 86.2L0 21.3V192h170.7l-60.2-60.2C145.6 90.5 197.5 64 256 64c106 0 192 85.9 192 192s-86 192-192 192c-53 0-101-21.5-135.8-56.2L75 437c46.4 46.3 110.4 75 181 75 141.4 0 256-114.6 256-256S397.4 0 256 0zm-21.3 106.7v170.7h128v-42.7h-85.3v-128h-42.7z' /%3E%3C/svg%3E");
+  --icon-search: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 27' class='search-icon'%3E%3Cpath d='M11.56,3.43a8.26,8.26,0,0,0,0,16.52,8.18,8.18,0,0,0,5-1.72l4.7,4.7a1.1,1.1,0,0,0,1.56,0,1.09,1.09,0,0,0,0-1.55l0,0-4.7-4.7a8.18,8.18,0,0,0,1.72-5A8.28,8.28,0,0,0,11.56,3.43Zm0,2.2A6.06,6.06,0,1,1,5.5,11.69,6,6,0,0,1,11.56,5.63Z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E");
+  --icon-external-teal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='%2316c2c1' viewBox='0 0 20 20'%3E%3Cpath d='M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a%0A1 1 0 102 0V4a1 1 0 00-1-1h-5z'/%3E%3Cpath d='M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z'/%3E%3C/svg%3E");
+  --icon-external-gray: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='%23b7b7b7' viewBox='0 0 20 20'%3E%3Cpath d='M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a%0A1 1 0 102 0V4a1 1 0 00-1-1h-5z'/%3E%3Cpath d='M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z'/%3E%3C/svg%3E");
+  --icon-info-brand: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 32 32' id='info'%3E%3Cg fill='%2306c755'%3E%3Cpath d='M16 0C7.164 0 0 7.164 0 16s7.164 16 16 16 16-7.164 16-16S24.836 0 16 0zm0 30C8.28 30 2 23.72 2 16S8.28 2 16 2s14 6.28 14 14-6.28 14-14 14zm0-18a2 2 0 0 0-2 2v10a2 2 0 0 0 4 0V14a2 2 0 0 0-2-2zm-2-3.968a2 2 1080 1 0 4 0 2 2 1080 1 0-4 0z'%3E%3C/path%3E%3C/g%3E%3C/svg%3E");
 }
 
 /* ------------------------------------------------------------
@@ -77,6 +102,43 @@
   --c-shadow: rgba(0, 0, 0, 0.1);   /* 半透明シャドウ */
   --c-shadow-2: #f4f4f4;            /* ソリッドな淡い影（MVP box-shadow） */
   --c-tap-highlight: rgba(0, 0, 0, 0.1); /* モバイルタップハイライト */
+
+  /* ヘッダー・フッター */
+  --c-header-backdrop: rgba(255, 255, 255, 0.85); /* 固定ヘッダーの半透明背景（blur 併用） */
+  --c-bg-bright: #fffffe;            /* ほぼ純白の面（バッジ・反転文字） */
+  --c-outline-highlight: #bae8e8;    /* 選択アウトライン（淡ティール） */
+  --c-text-dim: #303030;             /* 統合候補: --c-text-2 */
+  --c-border-strong: rgb(189, 189, 189); /* コピーボタン等のはっきりした枠 */
+  --c-overlay: rgba(0, 0, 0, 0.8);   /* ツールチップ・モーダルの黒幕 */
+  --c-surface-3: #f0f0f0;            /* 広告情報ボタン等の小さな面 */
+
+  /* ブログボタン（ヘッダー内・緑系） */
+  --c-btn-blog-text: #05a648;
+  --c-btn-blog-bg: #f1faf4;
+  --c-btn-blog-border: #bfe9cf;
+
+  /* SNS ブランド色（シェアアイコン背景） */
+  --c-sns-x: #000000;
+  --c-sns-hatena: #00a4de;
+
+  /* クールグレー系（テーマ発見 UI・recommend 系） */
+  --c-cool-surface: #f6f8fa;
+  --c-cool-surface-hover: #eef1f5;
+  --c-cool-border-soft: #eef0f3;
+  --c-cool-border: #d7dde6;
+  --c-cool-text-weak: #9aa3af;       /* プレースホルダ・補足 */
+  --c-cool-text: #5b6573;            /* 棚ラベル・メタ情報 */
+  --c-cool-text-strong: #28303c;     /* チップ文字 */
+  --c-cool-text-heading: #1f2937;    /* 行タイトル */
+  --c-cool-text-deep: #0f1620;       /* 見出し・入力文字 */
+
+  /* テーマチップ（hot・緑系） */
+  --c-chip-hot-text: #067a37;
+  --c-chip-hot-bg: #eefcf3;
+  --c-chip-hot-border: #bfead0;
+  --c-chip-hot-bg-hover: #e2f9ea;
+  --c-chip-hot-border-hover: #a6e0bd;
+  --c-brand-ring: rgba(6, 199, 85, 0.14); /* 検索フォーカスの緑リング */
 
   /* --- MVP フレームワーク残骸（使用箇所僅少。ダーク対応時に個別判断） --- */
   --c-legacy-accent: #118bee15;          /* code/samp 背景・テーブル縞 */

--- a/scripts/check-css-colors.sh
+++ b/scripts/check-css-colors.sh
@@ -34,9 +34,15 @@ MIGRATED=(
   public/style/base/mvp.css
   public/style/base/mvpmin.css
   public/style/base/unset.css
+  public/style/components/site_header.css
+  public/style/components/site_footer.css
+  public/style/components/search_form.css
+  public/style/components/ads_element.css
+  public/style/components/theme_discovery.css
   app/Views/components/head.php
   app/Views/components/oc_head.php
   app/Views/components/policy_head.php
+  app/Views/components/theme_discovery.php
 )
 
 fail=0


### PR DESCRIPTION
## 概要

ダークモード導入プロジェクトの第3弾（#334 → #335 の続き）。全ページ共通の部品CSS（ヘッダ・フッタ・検索フォーム・広告要素・テーマ発見UI）の配色をデザイントークンに移行します。**見た目は一切変わりません**。

## 変更内容

1. **共通部品4ファイルのトークン化＋構造整理**: site_header / site_footer / search_form / ads_element の全色指定を `var(--c-*)` に置換。セクションコメントで整理し、重複した `@media` ブロックの統合・空ルールやコメントアウト死骸の削除も実施
2. **テーマ発見UIの埋め込みCSSを外部化**: theme_discovery.php 内の `<style>`（約45ルール）を `components/theme_discovery.css` へ。クールグレー系のトークン群を新設
3. **名前衝突リスクのあるグローバル変数を整理**: `--background` `--headline` `--border-color` `--hover` などの汎用名変数を `--c-*` トークンへ統一（消費元の room_list / room_page / recent系テンプレートも同時更新）。未使用だった `--secondary` `--link-icon` は削除
4. **SVGアイコンの色管理を将来のダーク対応形式に**: fill色が埋め込まれた data-URI SVG を `--icon-*` トークンに集約。⚠️ 技術メモ: SVG-as-image では `fill='currentColor'` が親の color を継承しない（黒に解決される）ため、ダークモードは「URIトークンごと差し替え」方式を採用。2箇所で重複定義されていた更新アイコンも統合
5. **ブランド緑グラデーション（チェックボックスの332度帯）を `--c-brand-gradient` に集約**

## 検証

- 主要6ページ（トップ / ルーム詳細 / 入室確認 / おすすめタグ / ポリシー / 404）の全DOM computed-style before/after 比較 → **差分0行**（タグページの唯一の差分は外部化により消えた `<style>` 要素そのもの）
- フッターの外部リンクアイコン部分のスクリーンショット比較 → 同一
- `make css-check`: 移行済み12ファイルすべてクリーン。未移行残数 416→361件（CSS）/ 121→86件（テンプレート）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
