### PR TITLE
一覧ページの配色を一元管理化（見た目の変更なし・ダークモード準備 第4弾）

### DIFF
--- a/public/style/components/recommend_list.css
+++ b/public/style/components/recommend_list.css
@@ -9,7 +9,7 @@
   all: unset;
   font-weight: bold;
   font-size: 14px;
-  color: #111;
+  color: var(--c-text-1);
   align-items: center;
   display: flex;
   flex-wrap: wrap;
@@ -43,10 +43,9 @@
   word-break: break-all;
   margin: 0;
   margin-top: 6px;
-  /* text-align: center; */
   line-height: 125%;
   overflow-wrap: anywhere;
-  color: #111;
+  color: var(--c-text-1);
   font-weight: 500;
 }
 
@@ -61,12 +60,12 @@
   margin-top: 2px;
   line-height: 125%;
   overflow-wrap: anywhere;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .recommend-member {
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
   line-height: 125%;
   margin-top: 2px;
   white-space: nowrap;
@@ -83,14 +82,13 @@
 .recommend-list a {
   cursor: pointer;
   text-decoration: none;
-  color: #111;
+  color: var(--c-text-1);
   user-select: none;
   display: flex;
   flex-direction: column;
-  /* align-items: center; */
   height: 174px;
   justify-content: space-evenly;
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   border-radius: 4px;
   padding: 6px;
   text-align: center;
@@ -117,7 +115,7 @@
   display: inline-block;
   fill: currentcolor;
   flex-shrink: 0;
-  color: rgb(7, 181, 59);
+  color: var(--c-up);
   font-size: 11px;
   margin: -1px -4px;
 }
@@ -132,7 +130,7 @@
 
 .btn-wrapper .inner {
   display: flex;
-  flex-direction: row; /* align-items: center; */
+  flex-direction: row;
   margin: 0 1rem;
   width: 100%;
 }
@@ -143,7 +141,7 @@
 
 @media screen and (max-width: 511px) {
   .recommend-list li.selected > a {
-    background-color: #f5f5f5;
+    background-color: var(--c-surface);
     border: none;
   }
 }
@@ -189,7 +187,7 @@
     padding: 4px 6px;
     border-radius: 4px;
     margin: 2px -6px;
-    background-color: #f5f5f5;
+    background-color: var(--c-surface);
   }
 
   .recommend-list h4 {
@@ -218,9 +216,9 @@
     display: inline-block;
     margin: 0;
     height: 32px;
-    border: 1px solid #efefef;
+    border: 1px solid var(--c-border);
     border-radius: 9rem;
-    background-color: #fff;
+    background-color: var(--c-bg);
     font-size: 11px;
     cursor: pointer;
     padding: 0 12px;

--- a/public/style/components/room_list.css
+++ b/public/style/components/room_list.css
@@ -1,7 +1,3 @@
-:root {
-  --border-color: #efefef;
-}
-
 .ht-top-header {
   background-color: var(--c-border);
   margin: 0rem -1rem 0rem -1rem;
@@ -48,14 +44,14 @@
   margin: auto;
   line-height: 1.1;
   padding-bottom: 0.2rem;
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .main-header-title-desc {
   display: block;
   font-size: 15px;
   padding-bottom: 0.1rem;
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .add-openchat-form {
@@ -63,13 +59,13 @@
   margin: 1rem 0 1.5rem 0;
   min-width: auto;
   border-radius: 16px;
-  border: solid 1px #e8e8e8;
+  border: solid 1px var(--c-border-plain);
   padding: 12px;
 }
 
 .add-openchat-form label {
   font-size: 13px;
-  color: #616161;
+  color: var(--c-text-mid);
   font-weight: 500;
 }
 
@@ -86,17 +82,17 @@
   -webkit-appearance: none;
   appearance: none;
   border-radius: 4px;
-  border: solid 1px #e8e8e8;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  border: solid 1px var(--c-border-plain);
+  -webkit-tap-highlight-color: transparent;
 }
 
 .add-openchat-form input:focus {
   outline: 0;
-  box-shadow: 0px 0px 0px 2px rgba(77, 199, 100, 0.9);
+  box-shadow: 0px 0px 0px 2px var(--c-green-ring);
 }
 
 .false input {
-  border: 1px solid #ff6868;
+  border: 1px solid var(--c-red-soft);
 }
 
 .false input:focus {
@@ -105,7 +101,7 @@
 }
 
 .recent-oc-btn {
-  color: #777;
+  color: var(--c-text-3);
   text-decoration: underline 1px;
   font-size: 13px;
 }
@@ -117,8 +113,8 @@
   white-space: nowrap;
   margin: 0 auto;
   display: block;
-  background: rgb(77, 199, 100);
-  color: white;
+  background: var(--c-green-soft);
+  color: var(--c-text-inverse);
   border-radius: 99rem;
   padding: 0px 22px;
   height: 40px;
@@ -128,14 +124,14 @@
 }
 
 .ellipse-btn:hover {
-  background: rgb(52, 134, 67);
-  color: white;
+  background: var(--c-green-deep);
+  color: var(--c-text-inverse);
 }
 
 .ellipse-btn:disabled {
   box-shadow: 0 0 0 0;
-  color: white;
-  background: rgba(77, 199, 100, 0.5);
+  color: var(--c-text-inverse);
+  background: var(--c-green-soft-50);
 }
 
 .ellipse-btn:focus-visible {
@@ -153,7 +149,7 @@
   display: none;
   font-size: 13px;
   font-weight: bold;
-  color: #ff6868;
+  color: var(--c-red-soft);
   width: fit-content;
 }
 
@@ -186,16 +182,11 @@
   all: unset;
   font-size: 16px;
   font-weight: bold;
-  background: -webkit-linear-gradient(
-    45deg,
-    rgb(253, 18, 226) 20%,
-    rgb(164, 67, 221),
-    rgb(84, 126, 255) 90%
-  );
+  background: var(--c-vivid-gradient);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  color: #978170;
+  color: var(--c-text-taupe);
   display: inline-block;
   width: fit-content;
   line-height: 125%;
@@ -214,7 +205,7 @@
 }
 
 .openchat-list-subtitle {
-  color: #777;
+  color: var(--c-text-3);
   font-size: 12px;
   display: inline-block;
   margin: auto 0;
@@ -223,7 +214,7 @@
 
 .openchat-list-date {
   display: flex;
-  color: #b7b7b7;
+  color: var(--c-text-5);
   font-size: 13px;
   flex-wrap: wrap;
 }
@@ -263,14 +254,14 @@
 .refresh-time span {
   font-size: 14px;
   line-height: normal;
-  color: #111;
+  color: var(--c-text-1);
   font-weight: bold;
 }
 
 .openchat-list-title-area p {
   font-size: 13px;
   margin: 0.5rem 0;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .ranking-page-main .openchat-list-title-area p {
@@ -297,8 +288,8 @@
   padding: 0.5rem 0;
   flex-direction: column;
   gap: 12px;
-  /* border-bottom: 1px solid #efefef; */
-  /* border-top: 1px solid #efefef; */
+  /* border-bottom: 1px solid var(--c-border); */
+  /* border-top: 1px solid var(--c-border); */
 }
 
 .recent-comment-list .openchat-item-list {
@@ -397,7 +388,7 @@
 }
 
 .openchat-item-desc {
-  color: #777;
+  color: var(--c-text-3);
   font-size: 13px;
   line-height: 135%;
   display: -webkit-box;
@@ -441,7 +432,7 @@
 
 .openchat-item-lower {
   display: flex;
-  color: #aaa;
+  color: var(--c-text-4);
   font-size: 13px;
   line-height: 1.1rem;
   gap: 4px;
@@ -452,7 +443,7 @@
 }
 
 .openchat-item-mui-chip-outer {
-  background-color: #f5f5f5;
+  background-color: var(--c-surface);
   border-radius: 4px;
   font-size: 12px;
   display: block;
@@ -467,11 +458,11 @@
   padding-left: 7px;
   padding-right: 7px;
   white-space: nowrap;
-  color: RGB(124, 124, 124);
+  color: var(--c-text-gray-mid);
 }
 
 .openchat-itme-stats-title {
-  color: var(--color-text-secondary);
+  color: var(--c-text-3);
   font-size: 11px;
   display: inline-block;
 }
@@ -573,7 +564,7 @@
 }
 
 .recent-comment-list .openchat-item-desc {
-  color: #777;
+  color: var(--c-text-3);
   font-weight: normal;
   font-size: 13px;
   line-height: 150%;
@@ -616,11 +607,11 @@
 
 .top-ranking .openchat-item-title {
   font-size: 15px;
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .comment-user {
-  color: #777;
+  color: var(--c-text-3);
   font-size: 12px;
   display: block;
   position: relative;
@@ -636,7 +627,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  color: #111;
+  color: var(--c-text-1);
   font-weight: 500;
   font-size: 15px;
 }
@@ -648,7 +639,7 @@
 }
 
 .openchat-item-title .comment-member-count {
-  color: #111;
+  color: var(--c-text-1);
   font-weight: 500;
 }
 
@@ -671,7 +662,7 @@
   left: -6px;
   width: 2px;
   height: 2px;
-  background-color: #aaa;
+  background-color: var(--c-text-4);
 } */
 
 .comment-footer {
@@ -691,7 +682,7 @@
 .comment-time {
   font-weight: normal;
   position: relative;
-  color: #aaa;
+  color: var(--c-text-4);
   font-size: 12px;
   flex-shrink: 0;
 }
@@ -736,11 +727,11 @@
 }
 
 .recent-comment-list .registration-date {
-  color: #aaa;
+  color: var(--c-text-4);
 }
 
 .top-ranking.created-at .blue {
-  color: #aaa;
+  color: var(--c-text-4);
 }
 
 .top-ranking-readMore {
@@ -758,14 +749,9 @@
 .recent-comment-list .top-ranking-readMore {
   margin: 0;
   height: 42px;
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   border-radius: 7px;
-  background: -webkit-linear-gradient(
-    45deg,
-    rgb(253, 18, 226) 20%,
-    rgb(164, 67, 221),
-    rgb(84, 126, 255) 90%
-  );
+  background: var(--c-vivid-gradient);
   opacity: 0.7;
 }
 
@@ -774,7 +760,7 @@
 .recent-comment-list .top-ranking-readMore.white-btn {
   margin: 0;
   height: 42px;
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   border-radius: 7px;
   background: unset;
   opacity: 1;
@@ -786,7 +772,7 @@
   width: fit-content;
   margin: auto;
   line-height: 24px;
-  color: #fff;
+  color: var(--c-text-inverse);
   font-weight: 900;
 }
 
@@ -798,7 +784,7 @@
 }
 
 .white-btn .ranking-readMore {
-  color: #111;
+  color: var(--c-text-1);
   font-size: 13px;
 }
 
@@ -808,21 +794,21 @@
   margin-left: 6px;
   width: 6px;
   height: 6px;
-  border-top: 1px solid #111;
-  border-right: 1px solid #111;
+  border-top: 1px solid var(--c-text-1);
+  border-right: 1px solid var(--c-text-1);
   transform: rotate(45deg);
   margin-bottom: 1px;
 }
 
 .ranking-readMore .small {
-  color: #fff;
+  color: var(--c-text-inverse);
   font-weight: normal;
   font-size: 13px;
   margin-left: 4px;
 }
 
 .white-btn .ranking-readMore .small {
-  color: #aaa;
+  color: var(--c-text-4);
 }
 
 .page-select {
@@ -834,10 +820,9 @@
 .page-select form {
   position: relative;
   display: flex;
-  background-color: #fff;
+  background-color: var(--c-text-inverse);
   border-radius: 8px;
   border: 1px solid var(--c-border);
-  border-color: #efefef;
   box-sizing: border-box;
   margin: 0 auto;
   height: 48px;
@@ -882,8 +867,8 @@
   width: 6px;
   height: 6px;
   border: 0;
-  border-bottom: solid 2px #111;
-  border-right: solid 2px #111;
+  border-bottom: solid 2px var(--c-text-1);
+  border-right: solid 2px var(--c-text-1);
   transform: rotate(45deg);
 }
 
@@ -917,7 +902,7 @@
 }
 
 .button01.prev a {
-  color: #aaa;
+  color: var(--c-text-4);
   border: 0px;
   background-color: inherit;
   box-shadow: 0 0 0 0;
@@ -939,8 +924,8 @@
   margin-right: 4px;
   width: 5px;
   height: 5px;
-  border-top: 2px solid #aaa;
-  border-right: 2px solid #aaa;
+  border-top: 2px solid var(--c-text-4);
+  border-right: 2px solid var(--c-text-4);
   transform: rotate(225deg);
   margin-bottom: 2px;
 }
@@ -948,7 +933,7 @@
 .button01 a:focus-visible {
   transition: 0s;
   outline: 2px solid var(--c-outline-highlight);
-  background-color: rgba(227, 246, 245, 0.7);
+  background-color: var(--c-highlight-teal);
 }
 
 .button01label {
@@ -960,7 +945,7 @@
   line-height: 1.4;
   font-size: 13px;
   margin: 0 0.5rem;
-  color: #aaa;
+  color: var(--c-text-4);
   white-space: nowrap;
 }
 
@@ -977,8 +962,8 @@
 .list-btn {
   height: 48px;
   width: 100%;
-  background-color: white;
-  color: var(--color-text-secondary);
+  background-color: var(--c-text-inverse);
+  color: var(--c-text-3);
   font-size: 14px;
   cursor: pointer;
   user-select: none;
@@ -987,7 +972,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  color: #b7b7b7;
+  color: var(--c-text-5);
 }
 
 .btn-text {
@@ -1005,12 +990,12 @@
 }
 
 .list-btn:disabled {
-  background-color: white;
-  color: #111;
+  background-color: var(--c-text-inverse);
+  color: var(--c-text-1);
 }
 
 .list-btn:disabled .btn-buttom {
-  background-color: #111;
+  background-color: var(--c-text-1);
 }
 
 .disabledList {
@@ -1022,17 +1007,17 @@
 }
 
 .registration .registration-date.gray {
-  color: #777;
+  color: var(--c-text-3);
   font-size: 13px;
   /* font-weight: bold;*/
 }
 
 .blue {
-  color: #4d73ff;
+  color: var(--c-accent-blue);
 }
 
 .border-blue {
-  border: solid 2px #4d73ff;
+  border: solid 2px var(--c-accent-blue);
 }
 
 .openchat-item.hidden-changelog {
@@ -1055,7 +1040,7 @@
 
 .top-small-desc,
 .top-small-desc a {
-  color: #777;
+  color: var(--c-text-3);
   font-size: 13px;
 }
 
@@ -1125,14 +1110,14 @@
 
 .mylist .openchat-item::before {
   left: 33px;
-  border: solid 1px white;
+  border: solid 1px var(--c-bg);
   background: linear-gradient(
     -332deg,
-    #0dc95a,
-    #11d871 21.96%,
-    #11d593 53.46%,
-    #12cfcd 81.85%,
-    #16c2c1
+    var(--grad-green-1),
+    var(--grad-green-2) 21.96%,
+    var(--grad-green-3) 53.46%,
+    var(--grad-green-4) 81.85%,
+    var(--grad-green-5)
   );
   z-index: 2;
 }
@@ -1371,11 +1356,11 @@
   text-decoration: none;
   cursor: pointer;
   align-items: center;
-  background-color: #fff;
-  border: 1px solid #e8e8e8;
+  background-color: var(--c-text-inverse);
+  border: 1px solid var(--c-border-plain);
   border-radius: 36px;
   box-sizing: border-box;
-  color: #111;
+  color: var(--c-text-1);
   display: inline-flex;
   font-size: 13px;
   height: 36px;
@@ -1401,12 +1386,7 @@
   height: 38px;
   width: 48px;
   right: 0px;
-  background-image: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0),
-    rgba(255, 255, 255, 0.95) 37%,
-    rgba(255, 255, 255, 1) 99%
-  );
+  background-image: var(--c-fade-right);
 }
 
 .tag-btn.open-btn {
@@ -1418,9 +1398,9 @@
   height: 36px;
   margin-left: auto;
   box-shadow:
-    rgba(0, 0, 0, 0.1) 0px 1px 3px 0px,
-    rgba(0, 0, 0, 0.06) 0px 1px 2px 0px;
-  border: 1px solid #06c755;
+    var(--c-shadow) 0px 1px 3px 0px,
+    var(--c-shadow-soft) 0px 1px 2px 0px;
+  border: 1px solid var(--c-brand);
 }
 
 .tag-btn.open-btn::after {
@@ -1429,8 +1409,8 @@
   position: absolute;
   width: 6px;
   height: 6px;
-  border-top: 2px solid #06c755;
-  border-right: 2px solid #06c755;
+  border-top: 2px solid var(--c-brand);
+  border-right: 2px solid var(--c-brand);
   transform: rotate(135deg);
   top: -2px;
   right: 0;
@@ -1474,7 +1454,7 @@
 }
 
 .hour.tag-btn {
-  border: 1px solid #06c755;
+  border: 1px solid var(--c-brand);
 }
 
 .tag-list .css-162gv95 {
@@ -1484,13 +1464,13 @@
   display: inline-block;
   fill: currentcolor;
   flex-shrink: 0;
-  color: #06c755;
+  color: var(--c-brand);
   font-size: 11px;
   margin: -1px -4px 0px 2px;
 }
 
 .gradient-bottom {
-  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+  background-image: var(--c-fade-bottom);
   position: absolute;
   bottom: 0;
   left: 0;
@@ -1499,11 +1479,11 @@
 }
 
 .news-summary {
-  color: #111;
+  color: var(--c-text-1);
   user-select: none;
   font-size: 13px;
   font-weight: normal;
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   border-radius: 7px;
   padding-top: 12px;
   height: 42px;
@@ -1529,7 +1509,7 @@
 .list-aside details {
   margin: 0;
   font-size: 13px;
-  color: #555;
+  color: var(--c-text-mid-2);
   font-weight: normal;
 }
 
@@ -1581,10 +1561,6 @@
     margin-top: 0;
   }
 }
-
-/* .adsbygoogle.adsbygoogle-noablate {
-  margin: 0 -1rem !important;
-} */
 
 .responsive-google {
   margin: auto !important;

--- a/public/style/pages/ranking_ban.css
+++ b/public/style/pages/ranking_ban.css
@@ -3,7 +3,7 @@
 /* ---------- 旧インラインstyleからの移設 ---------- */
 
 .list-title {
-  color: #111;
+  color: var(--c-text-1);
   all: unset;
   font-size: 20px;
   font-weight: bold;
@@ -27,7 +27,7 @@ body > .google-auto-placed {
 .rb-lead {
   font-size: 15px;
   line-height: 1.8;
-  color: #3d4043;
+  color: var(--c-text-charcoal);
   margin: 0.5rem 0 0 0;
 }
 
@@ -41,11 +41,11 @@ body > .google-auto-placed {
 }
 
 .rb-dot--gone {
-  background-color: #d9333f;
+  background-color: var(--c-accent-red);
 }
 
 .rb-dot--back {
-  background-color: #06c755;
+  background-color: var(--c-brand);
 }
 
 /* ---------- プリセットチップ ---------- */
@@ -66,7 +66,7 @@ body > .google-auto-placed {
   display: block;
   font-size: 13px;
   font-weight: bold;
-  color: #5b6066;
+  color: var(--c-text-neutral);
   margin-bottom: 8px;
 }
 
@@ -90,11 +90,11 @@ body > .google-auto-placed {
   align-items: center;
   height: 36px;
   padding: 0 14px;
-  border: 1px solid #ededf0;
+  border: 1px solid var(--c-border-muted);
   border-radius: 999px;
   font-size: 13px;
-  color: #3d4043;
-  background-color: #fff;
+  color: var(--c-text-charcoal);
+  background-color: var(--c-bg);
   cursor: pointer;
   white-space: nowrap;
   transition: background-color 0.15s, border-color 0.15s;
@@ -102,18 +102,18 @@ body > .google-auto-placed {
 }
 
 .rb-preset:hover {
-  background-color: #f7faf8;
+  background-color: var(--c-green-mist);
 }
 
 .rb-preset:focus-visible {
-  outline: 2px solid #06c755;
+  outline: 2px solid var(--c-brand);
   outline-offset: 1px;
 }
 
 .rb-preset.is-active {
-  background-color: #06c75514;
-  border-color: #06c755;
-  color: #111;
+  background-color: var(--c-brand-tint);
+  border-color: var(--c-brand);
+  color: var(--c-text-1);
   font-weight: bold;
 }
 
@@ -121,9 +121,9 @@ body > .google-auto-placed {
 
 .rb-advanced {
   margin: 12px 0 0; /* mvp.css の details{margin:1.3rem 0} を上書き */
-  border: 1px solid #ededf0;
+  border: 1px solid var(--c-border-muted);
   border-radius: 12px;
-  background-color: #fff;
+  background-color: var(--c-bg);
 }
 
 .rb-advanced > summary {
@@ -134,7 +134,7 @@ body > .google-auto-placed {
   padding: 12px 16px;
   font-size: 13.5px;
   font-weight: bold;
-  color: #5b6066;
+  color: var(--c-text-neutral);
   cursor: pointer;
   -webkit-user-select: none;
   user-select: none;
@@ -151,8 +151,8 @@ body > .google-auto-placed {
   width: 7px;
   height: 7px;
   margin-top: -3px;
-  border-right: 2px solid #8a9097;
-  border-bottom: 2px solid #8a9097;
+  border-right: 2px solid var(--c-text-steel);
+  border-bottom: 2px solid var(--c-text-steel);
   transform: rotate(45deg);
   transition: transform 0.15s;
 }
@@ -165,17 +165,17 @@ body > .google-auto-placed {
 .rb-advanced-sub {
   font-weight: normal;
   font-size: 12px;
-  color: #8a9097;
+  color: var(--c-text-steel);
 }
 
 /* ---------- フィルタパネル ---------- */
 
 .rb-panel {
-  border: 1px solid #ededf0;
+  border: 1px solid var(--c-border-muted);
   border-radius: 12px;
   padding: 16px;
   margin-top: 12px;
-  background-color: #fff;
+  background-color: var(--c-bg);
 }
 
 /* 詳細設定の中ではパネルの枠を外す（二重枠回避） */
@@ -197,13 +197,13 @@ body > .google-auto-placed {
 .rb-field-label {
   font-size: 13px;
   font-weight: bold;
-  color: #111;
+  color: var(--c-text-1);
   margin-bottom: 6px;
 }
 
 .rb-field-hint {
   font-size: 12px;
-  color: #8a9097;
+  color: var(--c-text-steel);
   margin: 6px 0 0 0;
   line-height: 1.6;
 }
@@ -236,10 +236,10 @@ body > .google-auto-placed {
   align-items: center;
   justify-content: center;
   min-height: 44px;
-  border: 1px solid #ededf0;
+  border: 1px solid var(--c-border-muted);
   border-radius: 8px;
   cursor: pointer;
-  background-color: #fff;
+  background-color: var(--c-bg);
   transition: background-color 0.15s, border-color 0.15s;
   padding: 2px 4px;
   box-sizing: border-box;
@@ -256,28 +256,28 @@ body > .google-auto-placed {
 
 .rb-seg-text {
   font-size: 13px;
-  color: #3d4043;
+  color: var(--c-text-charcoal);
   text-align: center;
   line-height: 1.3;
 }
 
 .rb-seg-item:hover {
-  background-color: #f7faf8;
+  background-color: var(--c-green-mist);
 }
 
 .rb-seg-item.is-selected {
-  background-color: #06c75514;
-  border: 1.5px solid #06c755;
+  background-color: var(--c-brand-tint);
+  border: 1.5px solid var(--c-brand);
   padding: 1.5px 3.5px;
 }
 
 .rb-seg-item.is-selected .rb-seg-text {
   font-weight: bold;
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .rb-seg-item:has(input:focus-visible) {
-  outline: 2px solid #06c755;
+  outline: 2px solid var(--c-brand);
   outline-offset: 1px;
 }
 
@@ -296,24 +296,24 @@ body > .google-auto-placed {
   height: 44px;
   margin: 0;
   padding: 0 10px;
-  border: 1px solid #ededf0;
+  border: 1px solid var(--c-border-muted);
   border-radius: 8px;
   font-size: 15px;
-  color: #111;
-  background-color: #fff;
+  color: var(--c-text-1);
+  background-color: var(--c-bg);
   font-family: var(--font-family);
   -webkit-appearance: none;
   appearance: none;
 }
 
 .rb-date-input:focus {
-  border-color: #06c755;
+  border-color: var(--c-brand);
   outline: none;
 }
 
 .rb-dates-sep {
   flex: none;
-  color: #8a9097;
+  color: var(--c-text-steel);
 }
 
 /* キーワード検索 */
@@ -329,11 +329,11 @@ body > .google-auto-placed {
   width: 100%;
   height: 44px;
   padding: 0 38px 0 12px;
-  border: 1px solid #ededf0;
+  border: 1px solid var(--c-border-muted);
   border-radius: 8px;
   font-size: 16px; /* iOSズーム回避 */
-  color: #111;
-  background-color: #fff;
+  color: var(--c-text-1);
+  background-color: var(--c-bg);
   font-family: var(--font-family);
 }
 
@@ -342,11 +342,11 @@ body > .google-auto-placed {
 }
 
 .rb-search input[type='search']:focus {
-  border-color: #06c755;
+  border-color: var(--c-brand);
 }
 
 .rb-search input[type='search']::placeholder {
-  color: #8a9097;
+  color: var(--c-text-steel);
   font-size: 13px;
 }
 
@@ -363,12 +363,12 @@ body > .google-auto-placed {
   justify-content: center;
   border-radius: 50%;
   font-size: 14px;
-  color: #8a9097;
+  color: var(--c-text-steel);
   cursor: pointer;
 }
 
 .rb-search-clear:hover {
-  background-color: #f4f5f6;
+  background-color: var(--c-surface-gray);
 }
 
 .rb-search-clear.is-hidden {
@@ -380,17 +380,17 @@ body > .google-auto-placed {
 .rb-summary {
   margin-top: 14px;
   padding: 10px 12px;
-  border-left: 3px solid #06c755;
-  background-color: #f7faf8;
+  border-left: 3px solid var(--c-brand);
+  background-color: var(--c-green-mist);
   border-radius: 0 8px 8px 0;
   font-size: 14px;
-  color: #3d4043;
+  color: var(--c-text-charcoal);
   line-height: 1.7;
 }
 
 .rb-summary-count {
   font-weight: bold;
-  color: #111;
+  color: var(--c-text-1);
   white-space: nowrap;
 }
 
@@ -402,7 +402,7 @@ body > .google-auto-placed {
 
 .rb-loading-text {
   font-size: 13px;
-  color: #8a9097;
+  color: var(--c-text-steel);
   margin: 8px 0 0;
 }
 
@@ -412,7 +412,7 @@ body > .google-auto-placed {
   height: 3px;
   overflow: hidden;
   border-radius: 2px;
-  background-color: #ededf0;
+  background-color: var(--c-border-muted);
 }
 
 .rb-progress-bar {
@@ -421,7 +421,7 @@ body > .google-auto-placed {
   left: 0;
   height: 100%;
   width: 40%;
-  background-color: #06c755;
+  background-color: var(--c-brand);
   border-radius: 2px;
   animation: rb-progress-slide 1.1s ease-in-out infinite;
 }
@@ -451,7 +451,7 @@ body > .google-auto-placed {
   display: flex;
   gap: 12px;
   padding: 12px 0;
-  border-bottom: 1px solid #ededf0;
+  border-bottom: 1px solid var(--c-border-muted);
 }
 
 .rb-skel-img {
@@ -480,7 +480,7 @@ body > .google-auto-placed {
 
 .rb-skel-img,
 .rb-skel-line {
-  background: linear-gradient(90deg, #f4f5f6 25%, #ededf0 37%, #f4f5f6 63%);
+  background: linear-gradient(90deg, var(--c-surface-gray) 25%, var(--c-border-muted) 37%, var(--c-surface-gray) 63%);
   background-size: 400% 100%;
   animation: rb-shimmer 1.4s ease infinite;
 }
@@ -500,7 +500,7 @@ body > .google-auto-placed {
   text-align: center;
   padding: 2rem 0;
   font-size: 14px;
-  color: #5b6066;
+  color: var(--c-text-neutral);
 }
 
 .rb-retry {
@@ -512,9 +512,9 @@ body > .google-auto-placed {
   height: 40px;
   padding: 0 20px;
   margin-top: 8px;
-  border: 1px solid #06c755;
+  border: 1px solid var(--c-brand);
   border-radius: 999px;
-  color: #06c755;
+  color: var(--c-brand);
   font-size: 14px;
   font-weight: bold;
   cursor: pointer;
@@ -522,7 +522,7 @@ body > .google-auto-placed {
 }
 
 .rb-retry:hover {
-  background-color: #06c75514;
+  background-color: var(--c-brand-tint);
 }
 
 /* ---------- 結果フラグメント ---------- */
@@ -531,13 +531,13 @@ body > .google-auto-placed {
   display: inline-block;
   font-size: 13px;
   white-space: pre-wrap;
-  color: #111;
+  color: var(--c-text-1);
   margin-top: 4px;
 }
 
 .rb-empty {
   text-align: center;
-  color: #5b6066;
+  color: var(--c-text-neutral);
   padding: 1.5rem 0;
 }
 
@@ -569,13 +569,13 @@ body > .google-auto-placed {
 }
 
 .rb-badge--gone {
-  color: #d9333f;
-  background-color: #fdf1f2;
+  color: var(--c-accent-red);
+  background-color: var(--c-red-tint);
 }
 
 .rb-badge--back {
-  color: #06c755;
-  background-color: #e9faf0;
+  color: var(--c-brand);
+  background-color: var(--c-green-tint);
 }
 
 .rb-meta {
@@ -584,16 +584,16 @@ body > .google-auto-placed {
   flex-wrap: wrap;
   gap: 2px 4px;
   font-size: 13px;
-  color: #5b6066;
+  color: var(--c-text-neutral);
   margin-top: 4px;
 }
 
 .rb-meta-diff {
-  color: #8a9097;
+  color: var(--c-text-steel);
 }
 
 .rb-meta-sep {
-  color: #8a9097;
+  color: var(--c-text-steel);
 }
 
 .rb-meta .openchat-item-mui-chip-inner {
@@ -611,12 +611,12 @@ body > .google-auto-placed {
 
 .rb-change-label {
   font-weight: bold;
-  color: #5b6066;
+  color: var(--c-text-neutral);
   white-space: nowrap;
 }
 
 .rb-change-label--caused {
-  color: #d9333f;
+  color: var(--c-accent-red);
 }
 
 .rb-chips {
@@ -631,36 +631,36 @@ body > .google-auto-placed {
   padding: 1px 7px;
   border-radius: 4px;
   font-size: 12px;
-  color: #5b6066;
-  background-color: #f4f5f6;
+  color: var(--c-text-neutral);
+  background-color: var(--c-surface-gray);
   white-space: nowrap;
 }
 
 .rb-change-none {
   font-size: 13px;
-  color: #8a9097;
+  color: var(--c-text-steel);
 }
 
 .rb-timeline {
   font-size: 12px;
-  color: #8a9097;
+  color: var(--c-text-steel);
   margin-top: 4px;
 }
 
 /* ---------- ページャ（ピル型に整える） ---------- */
 
 .rb-pager .rb-pager-btn a {
-  border: 1px solid #ededf0;
+  border: 1px solid var(--c-border-muted);
   border-radius: 999px;
   height: 44px;
   transition: background-color 0.15s;
 }
 
 .rb-pager .rb-pager-btn a:hover {
-  background-color: #f7faf8;
+  background-color: var(--c-green-mist);
 }
 
 .rb-pager .rb-pager-btn.prev a {
-  border: 1px solid #ededf0;
-  background-color: #fff;
+  border: 1px solid var(--c-border-muted);
+  background-color: var(--c-bg);
 }

--- a/public/style/tokens.css
+++ b/public/style/tokens.css
@@ -132,6 +132,47 @@
   --c-cool-text-heading: #1f2937;    /* 行タイトル */
   --c-cool-text-deep: #0f1620;       /* 見出し・入力文字 */
 
+  /* 一覧ページ系 */
+  --c-border-plain: #e8e8e8;          /* フォーム・タグボタンの控えめな枠 */
+  --c-text-mid: #616161;              /* 統合候補: --c-text-3 */
+  --c-text-mid-2: #555;               /* 統合候補: --c-text-2 */
+  --c-text-taupe: #978170;            /* グラデ文字の非対応ブラウザ用フォールバック */
+  --c-text-gray-mid: rgb(124, 124, 124); /* MUIチップ文字 */
+  --c-red-soft: #ff6868;              /* 入力エラー */
+  --c-green-soft: rgb(77, 199, 100);  /* 登録ボタン緑 */
+  --c-green-soft-50: rgba(77, 199, 100, 0.5);
+  --c-green-ring: rgba(77, 199, 100, 0.9); /* 入力フォーカスリング */
+  --c-green-deep: rgb(52, 134, 67);   /* 登録ボタン hover */
+  --c-highlight-teal: rgba(227, 246, 245, 0.7); /* focus-visible 背景 */
+  --c-shadow-soft: rgba(0, 0, 0, 0.06);
+
+  /* 装飾グラデーション（一覧の見出し文字・もっと見るボタン） */
+  --c-vivid-gradient: -webkit-linear-gradient(
+    45deg,
+    rgb(253, 18, 226) 20%,
+    rgb(164, 67, 221),
+    rgb(84, 126, 255) 90%
+  );
+
+  /* 白へのフェード（リスト端の装飾。ダーク時は背景色側に追従させる） */
+  --c-fade-right: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 0.95) 37%,
+    rgba(255, 255, 255, 1) 99%
+  );
+  --c-fade-bottom: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+
+  /* 公開分析（labs/publication-analytics）系 */
+  --c-text-charcoal: #3d4043;        /* リード文・チップ文字 */
+  --c-text-neutral: #5b6066;         /* ラベル・補足（統合候補: --c-cool-text） */
+  --c-border-muted: #ededf0;         /* 控えめな枠（値は --c-surface-2 と同一、役割で分離） */
+  --c-brand-tint: #06c75514;         /* ブランド緑の薄い面（選択状態） */
+  --c-green-mist: #f7faf8;           /* 緑がかったホバー面・サマリー背景 */
+  --c-green-tint: #e9faf0;           /* 復帰バッジの淡緑面 */
+  --c-red-tint: #fdf1f2;             /* 消滅バッジの淡赤面 */
+  --c-surface-gray: #f4f5f6;         /* グレー系の小さな面・スケルトン */
+
   /* テーマチップ（hot・緑系） */
   --c-chip-hot-text: #067a37;
   --c-chip-hot-bg: #eefcf3;

--- a/scripts/check-css-colors.sh
+++ b/scripts/check-css-colors.sh
@@ -39,6 +39,9 @@ MIGRATED=(
   public/style/components/search_form.css
   public/style/components/ads_element.css
   public/style/components/theme_discovery.css
+  public/style/components/room_list.css
+  public/style/components/recommend_list.css
+  public/style/pages/ranking_ban.css
   app/Views/components/head.php
   app/Views/components/oc_head.php
   app/Views/components/policy_head.php


### PR DESCRIPTION
## 概要

ダークモード導入プロジェクトの第4弾（#334→#335→#336 の続き）。一覧表示まわりのCSS3ファイル（最大の room_list.css 1614行を含む）の配色をデザイントークンに移行します。**見た目は一切変わりません**。

## 変更内容

1. **room_list.css（サイト最大のCSS）の全色をトークン化**
   - 登録フォームの緑系ファミリ（ボタン・フォーカスリング・hover）、一覧見出しのビビッドグラデ文字、リスト端の白フェード装飾×2、ピン留めアイコンの逆回転ブランドグラデをそれぞれトークン化
   - 使われなくなっていた `:root` 内の `--border-color` 定義、同値の重複宣言、コメントアウトの死骸を削除
2. **ranking_ban.css（公開分析ページ）**: チャコール/グレー系テキスト・消滅/復帰バッジの淡色面・ブランド緑の薄面（#06c75514）等を新トークンで置換
3. **recommend_list.css**: 既存トークンで置換
4. mvpフレームワークのレガシー変数参照を `--c-*` 直接参照へ切替

## 検証

- トップ / ルーム詳細 / 公開分析 / 404 の全DOM computed-style before/after 比較 → **全ページ差分0行**
- `make css-check`: 移行済み15ファイルすべてクリーン。未移行残数 361→**206件**（CSS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
