### PR TITLE
ルーム詳細ページの配色を一元管理化（見た目の変更なし・ダークモード準備 第5弾）

### DIFF
--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -114,21 +114,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
 
       <hr class="hr-top" style="margin-bottom: 8px;">
 
-      <style>
-        /* /oc のカテゴリ・タグを「押せる」チップ化（回遊強化）。タグ=緑→/recommend、カテゴリ=中立→/ranking。 */
-        .oc-nav-chip{display:inline-flex;align-items:center;width:fit-content;max-width:100%;padding:5px 14px;border-radius:99px;font-weight:700;font-size:13px;line-height:1.3;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-decoration:none;border:1px solid transparent;transition:background .12s,border-color .12s,transform .08s}
-        .oc-nav-chip:active{transform:scale(.97)}
-        .oc-nav-chip--category{background:#f1f3f5;color:#28303c;border-color:#e4e8ee}
-        .oc-nav-chip--category:hover{background:#e7eaee}
-        .oc-nav-chip--tag{background:#eefcf3;color:#067a37;border-color:#bfead0}
-        .oc-nav-chip--tag:hover{background:#e2f9ea;border-color:#a6e0bd}
-        /* チップ前置きラベル(カテゴリー/タグ)。チップを主役にし、ラベルは小さく控えめなグレーで補助。
-           「ラベル+チップ」を1ユニット(.oc-nav-pair)としてグルーピングし、左揃え・横並び→入らなければ
-           ユニット単位で改行(各チップが自分のラベルを連れて折り返すので列ズレが出ない)。 */
-        .oc-nav-chips{display:flex;flex-wrap:wrap;align-items:center;column-gap:16px;row-gap:10px;width:100%}
-        .oc-nav-pair{display:inline-flex;align-items:center;gap:8px;min-width:0}
-        .oc-nav-pair__label{font-size:11.5px;font-weight:600;color:#9aa3af;white-space:nowrap;flex-shrink:0;letter-spacing:.02em}
-      </style>
+      <?php /* ナビチップのスタイルは style/pages/room_page.css に移設済み */ ?>
 
       <nav style="margin: 0 1rem; padding: 8px 0 10px 0; border: unset;" class="oc-desc-nav">
         <aside class="oc-desc-nav-category" style="display: flex; align-items:center; min-width: calc(50% - 1rem);">
@@ -150,16 +136,16 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
 
         <div class="oc-desc-nav-actions">
           <?php if (isset($_adminDto)) : ?>
-            <a href="<?php echo url('oc', $oc['id']) ?>" style="display: flex; align-items: center; justify-content: center; padding: 0 14px; background: linear-gradient(135deg, #7eb8ff, #3a7bd5); border-radius: 99px; color: white; text-decoration: none; font-size: 18px;">✕</a>
+            <a href="<?php echo url('oc', $oc['id']) ?>" style="display: flex; align-items: center; justify-content: center; padding: 0 14px; background: var(--c-grad-blue-btn); border-radius: 99px; color: var(--c-text-inverse); text-decoration: none; font-size: 18px;">✕</a>
           <?php else : ?>
-            <a id="admin-gear-btn" href="<?php echo url('oc', $oc['id'], 'admin') ?>" style="display: none; align-items: center; justify-content: center; padding: 0 14px; background: linear-gradient(135deg, #ffa751, #e85d04); border-radius: 99px; color: white; text-decoration: none; font-size: 18px;">⚙</a>
+            <a id="admin-gear-btn" href="<?php echo url('oc', $oc['id'], 'admin') ?>" style="display: none; align-items: center; justify-content: center; padding: 0 14px; background: var(--c-grad-orange-btn); border-radius: 99px; color: var(--c-text-inverse); text-decoration: none; font-size: 18px;">⚙</a>
           <?php endif ?>
           <section class="open-btn sp-btn" style="flex: 1; margin: 0; padding: 0;">
             <?php if ($oc['url']) : ?>
               <a href="<?php echo url('oc', $oc['id'], 'jump') ?>" class="openchat_link" style="font-size: 16px;">
                 <div style="display: flex; align-items: center; justify-content: center;">
                   <?php if ($oc['join_method_type'] !== 0) : ?>
-                    <svg style="height: 12px; fill: white; margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
+                    <svg style="height: 12px; fill: var(--c-text-inverse); margin-right: 3px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 489.4 489.4" xml:space="preserve">
                       <path d="M99 147v51.1h-3.4c-21.4 0-38.8 17.4-38.8 38.8v213.7c0 21.4 17.4 38.8 38.8 38.8h298.2c21.4 0 38.8-17.4 38.8-38.8V236.8c0-21.4-17.4-38.8-38.8-38.8h-1v-51.1C392.8 65.9 326.9 0 245.9 0 164.9.1 99 66 99 147m168.7 206.2c-3 2.2-3.8 4.3-3.8 7.8.1 15.7.1 31.3.1 47 .3 6.5-3 12.9-8.8 15.8-13.7 7-27.4-2.8-27.4-15.8v-.1c0-15.7 0-31.4.1-47.1 0-3.2-.7-5.3-3.5-7.4-14.2-10.5-18.9-28.4-11.8-44.1 6.9-15.3 23.8-24.3 39.7-21.1 17.7 3.6 30 17.8 30.2 35.5 0 12.3-4.9 22.3-14.8 29.5M163.3 147c0-45.6 37.1-82.6 82.6-82.6 45.6 0 82.6 37.1 82.6 82.6v51.1H163.3z" />
                     </svg>
                   <?php endif ?>

--- a/public/style/pages/graph_page.css
+++ b/public/style/pages/graph_page.css
@@ -41,14 +41,14 @@
 }
 
 .MuiToggleButton-root.MuiToggleButton-standard {
-  color: #b7b7b7;
-  border: 1px solid #efefef;
+  color: var(--c-text-5);
+  border: 1px solid var(--c-border);
 }
 
 .MuiToggleButton-root.Mui-selected.MuiToggleButton-standard,
 .MuiToggleButton-root.Mui-selected.MuiToggleButton-standard:hover {
-  background-color: #f5f5f5;
-  border: 1px solid #efefef;
+  background-color: var(--c-surface);
+  border: 1px solid var(--c-border);
 }
 
 .MuiStack-root .css-14edfjq {
@@ -57,8 +57,8 @@
 
 .MuiStack-root .css-14edfjq .MuiToggleButton-root.Mui-selected.MuiToggleButton-standard,
 .MuiStack-root .css-14edfjq .MuiToggleButton-root.Mui-selected.MuiToggleButton-standard:hover {
-  color: #b7b7b7;
-  background-color: #fff;
+  color: var(--c-text-5);
+  background-color: var(--c-text-inverse);
 }
 
 .fade-in {
@@ -85,13 +85,13 @@
   }
 
   .MuiChip-root.openchat-item-header-chip.graph:hover {
-    color: #111;
-    background-color: #f5f5f5;
+    color: var(--c-text-1);
+    background-color: var(--c-surface);
   }
 
   .MuiChip-root.openchat-item-header-chip.graph.selected:hover {
-    color: #fff;
-    background-color: #111;
+    color: var(--c-text-inverse);
+    background-color: var(--c-text-1);
   }
 }
 

--- a/public/style/pages/live_ana.css
+++ b/public/style/pages/live_ana.css
@@ -12,7 +12,7 @@
   height: 48px;
   width: 78px;
   background-color: inherit;
-  color: var(--color-text-secondary);
+  color: var(--c-text-3);
   font-size: 14px;
   display: inline-block;
   text-align: center;
@@ -22,8 +22,8 @@
 }
 
 .chart-btn:disabled {
-  box-shadow: inset 0px -6px 0px -3px rgb(3, 199, 85);
-  color: black;
+  box-shadow: inset 0px -6px 0px -3px var(--c-green-tab);
+  color: var(--c-text-black);
   background-color: inherit;
 }
 
@@ -75,7 +75,7 @@ main {
 
 .openchat-header h1 {
   text-align: center;
-  color: #118bee;
+  color: var(--c-labs-blue);
 }
 
 #file-input {
@@ -118,9 +118,6 @@ table th {
   white-space: break-spaces;
 }
 
-.live-table tr td:nth-child(4) span {
-}
-
 .live-table tr td:nth-child(4) span span {
   margin-left: 0.125rem;
   font-weight: bold;
@@ -156,7 +153,7 @@ table th {
 }
 
 .chart-btn:disabled {
-  box-shadow: inset 0px -6px 0px -3px #118bee;
+  box-shadow: inset 0px -6px 0px -3px var(--c-labs-blue);
 }
 
 .page-desc {
@@ -173,7 +170,7 @@ form {
 }
 
 .form-errorMessage {
-  color: #ff6868;
+  color: var(--c-red-soft);
   font-weight: bold;
 }
 
@@ -200,7 +197,7 @@ form {
   }
 
   .chart-btn:hover:not(:disabled) {
-    background-color: #f1f5f9;
+    background-color: var(--c-surface-slate);
   }
 }
 

--- a/public/style/pages/room_page.css
+++ b/public/style/pages/room_page.css
@@ -1,7 +1,3 @@
-:root {
-  --border-color: #efefef;
-}
-
 html {
   overflow-y: scroll;
   /* 常に垂直スクロールバーを表示 */
@@ -35,13 +31,13 @@ html {
 .oc-narrative {
   padding: 12px 1rem 14px 1rem;
   font-family: var(--font-family);
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .oc-narrative__title {
   font-size: 15px;
   font-weight: 700;
-  color: #111;
+  color: var(--c-text-1);
   margin: 0 0 8px 0;
   line-height: 1.4;
   display: flex;
@@ -60,9 +56,9 @@ html {
   padding: 8px 10px;
   font-size: 13px;
   line-height: 1.6;
-  color: #111;
-  background-color: #fafafa;
-  border-left: 3px solid #11d871;
+  color: var(--c-text-1);
+  background-color: var(--c-bg-sub);
+  border-left: 3px solid var(--c-brand-2);
   border-radius: 0 6px 6px 0;
   font-weight: 500;
   word-break: break-word;
@@ -73,7 +69,7 @@ html {
   padding: 0 2px;
   font-size: 13px;
   line-height: 1.75;
-  color: #333;
+  color: var(--c-text-2);
   word-break: break-word;
 }
 
@@ -137,7 +133,7 @@ html {
 .openchat .graph-title {
   font-weight: bold;
   font-size: 16px;
-  color: #111;
+  color: var(--c-text-1);
   margin: 0;
 }
 
@@ -151,7 +147,7 @@ html {
   justify-content: space-between;
   gap: 0;
   padding: 1rem 0;
-  border-top: 1px solid #efefef;
+  border-top: 1px solid var(--c-border);
 }
 
 /* スマホ幅: カテゴリ/タグ ブロックとボタンの間に細い区切り線を入れ、
@@ -162,7 +158,7 @@ html {
   width: 100%;
   margin-top: 14px;
   padding-top: 16px;
-  border-top: 1px solid #efefef;
+  border-top: 1px solid var(--c-border);
 }
 
 @media screen and (min-width: 512px) {
@@ -173,7 +169,7 @@ html {
     justify-content: space-evenly;
     gap: 1rem;
     padding: 1rem 0;
-    border-top: 1px solid #efefef;
+    border-top: 1px solid var(--c-border);
   }
 
   /* PC: 区切り線/上余白は解除。width:100%(基底)を維持して aside(min-width:50%) と分け合い、
@@ -198,14 +194,6 @@ html {
     max-width: 220px;
   }
 }
-
-/* .oc-desc-nav.no-ranking {
-  margin-top: -5rem;
-  position: absolute;
-  z-index: 100;
-  width: calc(100% - 2rem);
-  max-width: calc(var(--width) - 2rem);
-} */
 
 .openchat-header a {
   cursor: pointer;
@@ -250,7 +238,7 @@ html {
   line-height: 125%;
   font-size: 17.5px;
   font-weight: 700;
-  color: #111;
+  color: var(--c-text-1);
   display: block;
   white-space: break-spaces;
   word-break: break-all;
@@ -273,16 +261,16 @@ html {
   width: fit-content;
   background: -webkit-linear-gradient(
     98deg,
-    #0dc95a,
-    #11d871 23.96%,
-    #11d593 55.46%,
-    #12cfcd 83.85%,
-    #16c2c1
+    var(--grad-green-1),
+    var(--grad-green-2) 23.96%,
+    var(--grad-green-3) 55.46%,
+    var(--grad-green-4) 83.85%,
+    var(--grad-green-5)
   );
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-  color: #978170;
+  color: var(--c-text-taupe);
 }
 
 #read_more_btn {
@@ -291,12 +279,12 @@ html {
 
 /* メンバー数 */
 .talkroom_number_of_members {
-  color: #aaa;
+  color: var(--c-text-4);
 }
 
 .number_of_members {
   display: block;
-  color: #777;
+  color: var(--c-text-3);
   font-weight: bold;
   font-size: 13px;
 }
@@ -315,7 +303,7 @@ html {
   margin-top: 3px;
   margin-bottom: 1px;
   position: relative;
-  background-color: white;
+  background-color: var(--c-bg);
 }
 
 .talkroom_description_box .more {
@@ -329,23 +317,23 @@ html {
   right: 0;
   display: flex;
   visibility: hidden;
-  color: #aaa;
+  color: var(--c-text-4);
 }
 
 .more-text {
-  background-color: white;
+  background-color: var(--c-bg);
 }
 
 .talkroom_description_box .more-separater {
   width: 4rem;
-  background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+  background-image: var(--c-fade-right-2);
 }
 
 /* オープンチャットの説明 */
 .talkroom_description {
   margin: 0;
   line-height: 130%;
-  color: #111;
+  color: var(--c-text-1);
   text-align: center;
 }
 
@@ -371,7 +359,7 @@ html {
   font-weight: bold;
   cursor: pointer;
   background: inherit;
-  color: #111;
+  color: var(--c-text-1);
   border: 0;
 }
 
@@ -402,7 +390,7 @@ html {
 .openchat-list-date {
   display: flex;
   flex-direction: row;
-  color: #777;
+  color: var(--c-text-3);
   font-size: 13px;
   align-items: flex-start;
   gap: 4px;
@@ -439,14 +427,14 @@ html {
   flex-direction: row;
   flex-wrap: wrap;
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .number-box .openchat-itme-stats-title {
   font-size: 13px;
   word-break: keep-all;
   text-wrap: nowrap;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .number-box.created-at {
@@ -457,14 +445,14 @@ html {
 }
 
 .number-box.created-at .openchat-itme-stats-title {
-  color: #777;
+  color: var(--c-text-3);
   font-size: 12px;
   margin: 0;
 }
 
 .number-box.created-at.registed .openchat-itme-stats-title {
   font-size: 12px;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .number-box.bold {
@@ -490,12 +478,9 @@ html {
   height: fit-content;
   border-radius: 7px;
   word-break: keep-all;
-  color: #111;
+  color: var(--c-text-1);
   line-height: normal;
   font-weight: bold;
-}
-
-.open-btn {
 }
 
 .open-btn.pc-btn {
@@ -505,15 +490,15 @@ html {
 .openchat_link {
   background: linear-gradient(
     -156deg,
-    #0dc95a,
-    #11d871 23.96%,
-    #11d593 55.46%,
-    #12cfcd 83.85%,
-    #16c2c1
+    var(--grad-green-1),
+    var(--grad-green-2) 23.96%,
+    var(--grad-green-3) 55.46%,
+    var(--grad-green-4) 83.85%,
+    var(--grad-green-5)
   );
   border-radius: 99px;           /* 角の丸さをタグチップ(pill)と揃える */
   box-sizing: border-box;
-  color: #fff;
+  color: var(--c-text-inverse);
   font-weight: 700;
   /* height: 24px; */
   display: flex;
@@ -545,7 +530,7 @@ html {
   display: inline-block;
   fill: currentcolor;
   flex-shrink: 0;
-  color: rgb(7, 181, 59);
+  color: var(--c-up);
   font-size: 11px;
   margin: 0px 0px 1px 0px;
 }
@@ -566,7 +551,7 @@ html {
 
 .title-bar-oc-name {
   font-size: 11px;
-  color: #777;
+  color: var(--c-text-3);
   font-weight: normal;
   line-height: 1.3;
   display: -webkit-box;
@@ -579,7 +564,7 @@ html {
 
 .title-bar-oc-member {
   font-size: 11px;
-  color: #777;
+  color: var(--c-text-3);
   font-weight: normal;
   line-height: 1.3;
   text-wrap: nowrap;
@@ -648,17 +633,17 @@ html {
 
   .number-box.created-at {
     margin-left: auto;
-    color: #777;
+    color: var(--c-text-3);
   }
 
   .number-box.created-at .openchat-itme-stats-title {
     font-size: 13px;
-    color: #777;
+    color: var(--c-text-3);
   }
 
   .number-box.created-at.registed .openchat-itme-stats-title {
     font-size: 13px;
-    color: #777;
+    color: var(--c-text-3);
   }
 
   .number-box .openchat-itme-stats-title {
@@ -692,7 +677,7 @@ html {
   }
 
   .talkroom_description_box.close:not(.hidden):hover {
-    background-color: rgb(250, 250, 250);
+    background-color: var(--c-bg-sub);
   }
 
   .link-mark .line-link-icon777 {
@@ -702,7 +687,7 @@ html {
 
   .number-box.bold {
     font-weight: normal;
-    color: #777;
+    color: var(--c-text-3);
   }
 
   .openchat-header,
@@ -785,11 +770,11 @@ html {
 }
 
 #comment-root .MuiPaper-outlined.MuiPaper-rounded {
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
 }
 
 #comment-root .comment-term-text-color {
-  color: #b7b7b7;
+  color: var(--c-text-5);
 }
 
 .list-aside {
@@ -802,7 +787,7 @@ html {
   margin: 0;
   font-weight: normal;
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
   font-family: var(--font-family);
 }
 
@@ -821,7 +806,7 @@ html {
   margin-top: 6px;
   padding-left: 0.5rem;
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
   line-height: 1.8;
 }
 
@@ -840,7 +825,7 @@ html {
 
 .MuiTypography-root.MuiTypography-h3 {
   font-size: 16px;
-  color: #111;
+  color: var(--c-text-1);
   font-family: var(--font-family);
 }
 
@@ -871,4 +856,81 @@ html {
     text-align: left;
     line-height: 1.5;
   }
+}
+
+/* ---------- /oc ナビチップ（oc_content.php の埋め込み<style>から移設）
+     カテゴリ・タグを「押せる」チップ化（回遊強化）。タグ=緑→/recommend、カテゴリ=中立→/ranking。 ---------- */
+
+.oc-nav-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  padding: 5px 14px;
+  border-radius: 99px;
+  font-weight: 700;
+  font-size: 13px;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    transform 0.08s;
+}
+
+.oc-nav-chip:active {
+  transform: scale(0.97);
+}
+
+.oc-nav-chip--category {
+  background: var(--c-chip-cat-bg);
+  color: var(--c-cool-text-strong);
+  border-color: var(--c-border-2);
+}
+
+.oc-nav-chip--category:hover {
+  background: var(--c-chip-cat-bg-hover);
+}
+
+.oc-nav-chip--tag {
+  background: var(--c-chip-hot-bg);
+  color: var(--c-chip-hot-text);
+  border-color: var(--c-chip-hot-border);
+}
+
+.oc-nav-chip--tag:hover {
+  background: var(--c-chip-hot-bg-hover);
+  border-color: var(--c-chip-hot-border-hover);
+}
+
+/* チップ前置きラベル(カテゴリー/タグ)。チップを主役にし、ラベルは小さく控えめなグレーで補助。
+   「ラベル+チップ」を1ユニット(.oc-nav-pair)としてグルーピングし、左揃え・横並び→入らなければ
+   ユニット単位で改行(各チップが自分のラベルを連れて折り返すので列ズレが出ない)。 */
+.oc-nav-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 16px;
+  row-gap: 10px;
+  width: 100%;
+}
+
+.oc-nav-pair {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.oc-nav-pair__label {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--c-cool-text-weak);
+  white-space: nowrap;
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
 }

--- a/public/style/tokens.css
+++ b/public/style/tokens.css
@@ -173,6 +173,21 @@
   --c-red-tint: #fdf1f2;             /* 消滅バッジの淡赤面 */
   --c-surface-gray: #f4f5f6;         /* グレー系の小さな面・スケルトン */
 
+  /* ルーム詳細・labs 系 */
+  --c-fade-right-2: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1)); /* 説明文の続きを隠す */
+  --c-green-tab: rgb(3, 199, 85);    /* labs タブ下線（統合候補: --c-brand） */
+  --c-text-black: #000;              /* 統合候補: --c-text-1 */
+  --c-labs-blue: #118bee;            /* labs 見出し・タブ下線の青 */
+  --c-surface-slate: #f1f5f9;        /* labs ボタン hover 面 */
+
+  /* /oc ナビチップ（カテゴリ=中立） */
+  --c-chip-cat-bg: #f1f3f5;
+  --c-chip-cat-bg-hover: #e7eaee;
+
+  /* 管理者用ミニボタンのグラデーション（/oc 内・一般には非表示） */
+  --c-grad-blue-btn: linear-gradient(135deg, #7eb8ff, #3a7bd5);
+  --c-grad-orange-btn: linear-gradient(135deg, #ffa751, #e85d04);
+
   /* テーマチップ（hot・緑系） */
   --c-chip-hot-text: #067a37;
   --c-chip-hot-bg: #eefcf3;

--- a/scripts/check-css-colors.sh
+++ b/scripts/check-css-colors.sh
@@ -42,6 +42,9 @@ MIGRATED=(
   public/style/components/room_list.css
   public/style/components/recommend_list.css
   public/style/pages/ranking_ban.css
+  public/style/pages/room_page.css
+  public/style/pages/graph_page.css
+  public/style/pages/live_ana.css
   app/Views/components/head.php
   app/Views/components/oc_head.php
   app/Views/components/policy_head.php


### PR DESCRIPTION
## 概要

ダークモード導入プロジェクトの第5弾（#334→#335→#336→#337 の続き）。ルーム詳細ページ（/oc）とlabs系のCSSをデザイントークンに移行し、/oc に埋め込まれていた `<style>` を外部CSSへ移設します。**見た目は一切変わりません**。

## 変更内容

1. **room_page.css / graph_page.css / live_ana.css の全色をトークン化**: リンクタイトルの98度グラデ・「LINEで開く」ボタンの-156度グラデをブランド緑プリミティブの参照に統一。未使用変数・コメントアウト死骸・空ルールも削除
2. **oc_content.php の埋め込み `<style>` を room_page.css へ移設**: /oc のカテゴリ・タグチップ約10ルール。タグチップがテーマ発見UI（#336）と同一の配色トークンを共有できることが判明し、重複定義を解消
3. **管理者用ミニボタン**（一般ユーザー非表示）のインライングラデーション・white指定もトークン化

## 検証

- /oc・入室確認・/labs/live の全DOM computed-style before/after 比較 → **全ページ差分0行**
- `make css-check`: 移行済み18ファイルすべてクリーン。未移行残数 CSS 206→**152件** / テンプレート 86→**74件**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
