### PR TITLE
コンテンツページとテンプレート全体の配色を一元管理化（見た目の変更なし・ダークモード準備 第6弾）

### DIFF
--- a/app/Views/blog_index_content.php
+++ b/app/Views/blog_index_content.php
@@ -14,7 +14,7 @@
             <p class="blog-lead">LINEオープンチャットの<b>運営のコツ</b>・<b>検索やランキングの仕組み</b>・<b>トレンド</b>を、オプチャグラフ独自のデータをもとに解説します。</p>
 
             <?php if (empty($articles)): ?>
-                <p style="color:#8a9097;">記事は準備中です。</p>
+                <p style="color:var(--c-text-steel);">記事は準備中です。</p>
             <?php else: ?>
                 <ul class="blog-cards">
                     <?php foreach ($articles as $a): ?>

--- a/app/Views/components/comment_desc.php
+++ b/app/Views/components/comment_desc.php
@@ -25,7 +25,7 @@
                 </p>
             </li>
         </ol>
-        <p class="summary-p" style="font-size: 11px; color: #b7b7b7">
+        <p class="summary-p" style="font-size: 11px; color: var(--c-text-5)">
             コメントは検索エンジン（Googleなど）に随時読み込まれています。ユーザーの体験に基づくコメントの掲載は、検索エンジンによって高く評価されます。このオプチャ自体が高く評価されることにより、様々なキーワードの検索結果に上位掲載される機会が増えます。これにより、外部から新しい訪問者を呼び込むことができます。
         </p>
     </details>

--- a/app/Views/components/home_blog_shelf.php
+++ b/app/Views/components/home_blog_shelf.php
@@ -37,14 +37,14 @@ if (!$_posts) return;
     .home-blog-shelf .hbs-title { all: unset; display: flex; align-items: center; gap: 5px; }
     .home-blog-shelf .hbs-title span:last-child { font-size: 15px; }
     /* タップ領域は padding で広げ、負マージンで見た目の位置は変えない */
-    .home-blog-shelf .hbs-more { font-size: 13.5px; font-weight: bold; color: #06c755; text-decoration: none; white-space: nowrap; padding: .6rem 0 .6rem .6rem; margin: -.6rem 0; }
+    .home-blog-shelf .hbs-more { font-size: 13.5px; font-weight: bold; color: var(--c-brand); text-decoration: none; white-space: nowrap; padding: .6rem 0 .6rem .6rem; margin: -.6rem 0; }
     .home-blog-shelf .hbs-list { all: unset; display: grid; gap: 8px; }
     .home-blog-shelf .hbs-list li { all: unset; }
-    .home-blog-shelf .hbs-card { display: block; padding: .8rem .95rem; border: 1px solid #ededf0; border-radius: 12px; text-decoration: none; transition: border-color .15s, box-shadow .15s; }
-    .home-blog-shelf .hbs-card:hover { border-color: #06c755; box-shadow: 0 3px 12px rgba(6, 199, 85, .09); }
-    .home-blog-shelf .hbs-card-t { font-size: 14.5px; font-weight: bold; color: #111; line-height: 1.5; }
+    .home-blog-shelf .hbs-card { display: block; padding: .8rem .95rem; border: 1px solid var(--c-border-muted); border-radius: 12px; text-decoration: none; transition: border-color .15s, box-shadow .15s; }
+    .home-blog-shelf .hbs-card:hover { border-color: var(--c-brand); box-shadow: 0 3px 12px var(--c-brand-shadow-soft); }
+    .home-blog-shelf .hbs-card-t { font-size: 14.5px; font-weight: bold; color: var(--c-text-1); line-height: 1.5; }
     .home-blog-shelf .hbs-card-m { margin-top: 5px; display: flex; align-items: center; gap: 7px; }
-    .home-blog-shelf .hbs-cat { border: 1px solid #06c755; color: #05a648; border-radius: 999px; padding: 1px 9px; font-weight: bold; font-size: 11px; }
-    .home-blog-shelf .hbs-date { font-size: 11.5px; color: #9aa0a6; }
+    .home-blog-shelf .hbs-cat { border: 1px solid var(--c-brand); color: var(--c-btn-blog-text); border-radius: 999px; padding: 1px 9px; font-weight: bold; font-size: 11px; }
+    .home-blog-shelf .hbs-date { font-size: 11.5px; color: var(--c-rg-muted); }
     @media (min-width: 600px) { .home-blog-shelf .hbs-list { grid-template-columns: 1fr 1fr; } }
 </style>

--- a/app/Views/components/labs_joincount_form.php
+++ b/app/Views/components/labs_joincount_form.php
@@ -7,12 +7,12 @@
         font-size: 13px;
         width: 100%;
         box-shadow: none;
-        border: 1px solid #e6e6e6;
+        border: 1px solid var(--c-border-plain-2);
     }
 
     #file-input {
         width: 100%;
-        border: 1px solid #e6e6e6;
+        border: 1px solid var(--c-border-plain-2);
     }
 
     .form-section form p {
@@ -25,7 +25,7 @@
     }
 
     .form-section .form-errorMessage {
-        color: #ff6868;
+        color: var(--c-red-soft);
         font-weight: bold;
     }
 </style>

--- a/app/Views/components/myList.php
+++ b/app/Views/components/myList.php
@@ -1,7 +1,7 @@
 <article class="mylist pad-side">
     <div class="refresh-time openchat-list-date">
-        <span style="font-weight: bold; color:#111; font-size:13px; margin: 0; line-height: unset;">ピン留め (24時間の人数増加)</span>
-        <span style="font-weight: normal; color:#aaa; font-size:13px; margin: 0; line-height: unset;"><?php echo $hourlyUpdatedAt->format('G:i') ?></span>
+        <span style="font-weight: bold; color:var(--c-text-1); font-size:13px; margin: 0; line-height: unset;">ピン留め (24時間の人数増加)</span>
+        <span style="font-weight: normal; color:var(--c-text-4); font-size:13px; margin: 0; line-height: unset;"><?php echo $hourlyUpdatedAt->format('G:i') ?></span>
     </div>
     <div style="margin: -4px 0 -4px 0;">
         <?php viewComponent('open_chat_list_ranking', ['openChatList' => $myList, 'isHourly' => true, 'noReverse' => true]) ?>

--- a/app/Views/components/open_chat_list_ranking_ban.php
+++ b/app/Views/components/open_chat_list_ranking_ban.php
@@ -13,7 +13,7 @@
         <h3 class="unset">
           <a class="openchat-item-title unset" href="<?php echo url('/oc/' . $oc['id'] . "?bar=ranking&limit={$timeFrame}") ?>"><?php if (($oc['emblem'] ?? 0) === 1) : ?><span class="super-icon sp"></span><?php elseif (($oc['emblem'] ?? 0) === 2) : ?><span class="super-icon official"></span><?php endif ?><?php if (($oc['join_method_type'] ?? 0) === 2) : ?><span class="lock-icon"></span><?php endif ?><span><?php echo $oc['name'] ?></span></a>
         </h3>
-        <p class="openchat-item-desc unset" style="color: #777;"><?php echo $oc['description'] ?></p>
+        <p class="openchat-item-desc unset" style="color: var(--c-text-3);"><?php echo $oc['description'] ?></p>
         <footer class="openchat-item-lower-outer rb-card-footer" style="gap: 0;">
 
           <?php // 1. ステータスバッジ（最優先情報） ?>

--- a/app/Views/components/open_chat_list_ranking_comment2.php
+++ b/app/Views/components/open_chat_list_ranking_comment2.php
@@ -54,7 +54,7 @@ use App\Views\Ads\GoogleAdsense as GAd;
             </div>
           <?php endif ?>
         <?php else : ?>
-          <div class="comment-user" style="font-size: 12px; margin-top: 4px; color: #777;">
+          <div class="comment-user" style="font-size: 12px; margin-top: 4px; color: var(--c-text-3);">
             <span>削除されたコメント</span>
           </div>
         <?php endif ?>
@@ -95,7 +95,7 @@ use App\Views\Ads\GoogleAdsense as GAd;
               <div style="font-size: 12px;" class="comment-name">
                 <span aria-hidden="true"></span><?php if (($oc['emblem'] ?? 0) === 1) : ?><span class="super-icon sp"></span><?php elseif (($oc['emblem'] ?? 0) === 2) : ?><span class="super-icon official"></span><?php endif ?><span><?php echo $oc['name'] ?></span>
               </div>
-              <div class="comment-member-count" style="font-size: 12px; margin-right: 4px; color: #777;">
+              <div class="comment-member-count" style="font-size: 12px; margin-right: 4px; color: var(--c-text-3);">
                 <span>削除されたコメント</span>
               </div>
               <div class="comment-time" style="font-size: 12px; margin-left: 4px;">

--- a/app/Views/components/open_chat_list_recommend.php
+++ b/app/Views/components/open_chat_list_recommend.php
@@ -51,7 +51,7 @@
           <?php // 24時間の人数増加は独立行に（メンバー行に入れると溢れるため）。伸び部屋のみ表示。 ?>
           <?php $diff24h = (int)($oc['diff_member_24h'] ?? 0); ?>
           <?php if ($diff24h > 0 && !$hideIncrease) : ?>
-            <div class="positive" style="font-size: 13px; margin-top: 1px;"><span aria-hidden="true" style="font-size: 11px; user-select: none;">🚀</span> <span class="openchat-item-stats"><?php echo sprintfT('%s人増加', formatMember($diff24h)) ?></span><span style="font-size: 11px; color: #9aa3af; font-weight: normal; margin-left: 4px;">（<?php echo t('24時間') ?>）</span></div>
+            <div class="positive" style="font-size: 13px; margin-top: 1px;"><span aria-hidden="true" style="font-size: 11px; user-select: none;">🚀</span> <span class="openchat-item-stats"><?php echo sprintfT('%s人増加', formatMember($diff24h)) ?></span><span style="font-size: 11px; color: var(--c-cool-text-weak); font-weight: normal; margin-left: 4px;">（<?php echo t('24時間') ?>）</span></div>
           <?php endif ?>
         </footer>
       </div>

--- a/app/Views/components/recommend_growth_chart.php
+++ b/app/Views/components/recommend_growth_chart.php
@@ -67,7 +67,7 @@ if ($useRank) {
   elseif ($b <= 50)  $tierWord = t('全体でも上位クラスの大規模な');
   elseif ($b <= 300) $tierWord = t('全体ランキング上位の活発な');
   else               $tierWord = t('全体ランキングに入る活発な');
-  $color = '#06c755';
+  $color = 'var(--c-brand)';
 
   // 多言語対応: 語順が言語で異なるため位置指定子(%1$s..)のテンプレートにして翻訳側で並べ替え可能にする。
   $trend = $improve > 0
@@ -83,7 +83,7 @@ if ($useRank) {
   // フォールバック: 合計メンバー数。色は安心できる緑/灰(赤は使わない)。
   $label = t('メンバー数（掲載部屋の合計）');
   $improve = $memberInc;
-  $color = $improve >= 0 ? '#06c755' : '#8a9097';
+  $color = $improve >= 0 ? 'var(--c-brand)' : 'var(--c-text-steel)';
   $chartPoints = ($member !== null && !empty($member['points'])) ? $member['points'] : [];
   $chart = ThemeGrowthChartSvg::build($chartPoints);
 
@@ -148,12 +148,12 @@ $ocIcon   = fileUrl('assets/openchat_icon.png', urlRoot: '');
         <svg class="recommend-growth__svg" viewBox="0 0 <?php echo $chart['width'] ?> <?php echo $chart['height'] ?>" width="100%" height="<?php echo $chart['height'] ?>" preserveAspectRatio="none" role="img" aria-hidden="true" focusable="false">
           <defs>
             <linearGradient id="<?php echo $gid ?>" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stop-color="<?php echo $color ?>" stop-opacity="0.28" />
-              <stop offset="100%" stop-color="<?php echo $color ?>" stop-opacity="0.02" />
+              <stop offset="0%" style="stop-color: <?php echo $color ?>;" stop-opacity="0.28" />
+              <stop offset="100%" style="stop-color: <?php echo $color ?>;" stop-opacity="0.02" />
             </linearGradient>
           </defs>
           <path d="<?php echo $chart['areaPath'] ?>" fill="url(#<?php echo $gid ?>)" />
-          <path d="<?php echo $chart['linePath'] ?>" fill="none" stroke="<?php echo $color ?>" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+          <path d="<?php echo $chart['linePath'] ?>" fill="none" style="stroke: <?php echo $color ?>;" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" vector-effect="non-scaling-stroke" />
         </svg>
         <span class="recommend-growth__dot" aria-hidden="true" style="left: <?php echo round($chart['lastX'] / $chart['width'] * 100, 2) ?>%; top: <?php echo round($chart['lastY'] / $chart['height'] * 100, 2) ?>%;"></span>
       </div>

--- a/app/Views/components/recommend_list.php
+++ b/app/Views/components/recommend_list.php
@@ -27,7 +27,7 @@ use App\Services\Recommend\Enum\RecommendListType;
                             <div style="text-wrap: wrap;">「<?php echo $recommend->listName ?>」の</div>
                             <div>おすすめ</div>
                         </h3>
-                        <small style="font-size: 14px; font-weight:bold; color:#4d73ff; margin: auto 0; margin-left: 4px; text-wrap: nowrap; word-break: keep-all;" aria-hidden="true">すべて見る</small>
+                        <small style="font-size: 14px; font-weight:bold; color:var(--c-accent-blue); margin: auto 0; margin-left: 4px; text-wrap: nowrap; word-break: keep-all;" aria-hidden="true">すべて見る</small>
                     </a>
                 <?php endif ?>
             </div>

--- a/app/Views/components/recommend_list2.php
+++ b/app/Views/components/recommend_list2.php
@@ -25,7 +25,7 @@ if ($recommend->type === RecommendListType::Category) {
     <header class="openchat-list-title-area unset">
         <div class="openchat-list-date unset ranking-url">
             <h2 class="unset">
-                <span style="line-height: 1.5; font-size: 16px; color: #111; font-weight: bold;"><?php echo $title ?></span>
+                <span style="line-height: 1.5; font-size: 16px; color: var(--c-text-1); font-weight: bold;"><?php echo $title ?></span>
             </h2>
         </div>
     </header>

--- a/app/Views/components/similar_size_rooms.php
+++ b/app/Views/components/similar_size_rooms.php
@@ -42,7 +42,7 @@ $isRanked = $mode === 'tag_top';
 ?>
 <article class="top-ranking<?php echo $isRanked ? '' : ' not-rank' ?>" style="margin-top: 24px;" aria-labelledby="similar-size-rooms-title">
     <header style="display: block; margin: 0 0 12px 0;">
-        <h2 id="similar-size-rooms-title" style="display: block; margin: 0; padding: 0; font-size: 15px; font-weight: bold; color: #111; line-height: 1.4;">
+        <h2 id="similar-size-rooms-title" style="display: block; margin: 0; padding: 0; font-size: 15px; font-weight: bold; color: var(--c-text-1); line-height: 1.4;">
             <?php if ($mode === 'tag_top' && $scope !== ''): ?>
                 <?php echo sprintfT('「%s」でいま人数が伸びているルーム', htmlspecialchars($scope, ENT_QUOTES, 'UTF-8')) ?>
             <?php elseif ($scope !== ''): ?>

--- a/app/Views/components/site_header.php
+++ b/app/Views/components/site_header.php
@@ -6,9 +6,9 @@
         <a class="<?php echo t('header_site_title') ?> unset" href="<?php echo url() ?>">
             <img src="<?php echo fileUrl(\App\Config\AppConfig::SITE_ICON_FILE_PATH, urlRoot: '') ?>" alt="">
             <?php if (strpos(path(), '/oc') === false || isset($titleP)) : ?>
-                <h1><?php echo t('サイトタイトル'); if (\App\Config\AppConfig::$isStaging) echo '<span style="font-size: 0.7em; color: #888;">' . t(' (開発環境)') . '</span>'; ?></h1>
+                <h1><?php echo t('サイトタイトル'); if (\App\Config\AppConfig::$isStaging) echo '<span style="font-size: 0.7em; color: var(--c-text-mid-3);">' . t(' (開発環境)') . '</span>'; ?></h1>
             <?php else : ?>
-                <p><?php echo t('サイトタイトル'); if (\App\Config\AppConfig::$isStaging) echo '<span style="font-size: 0.7em; color: #888;">' . t(' (開発環境)') . '</span>'; ?></p>
+                <p><?php echo t('サイトタイトル'); if (\App\Config\AppConfig::$isStaging) echo '<span style="font-size: 0.7em; color: var(--c-text-mid-3);">' . t(' (開発環境)') . '</span>'; ?></p>
             <?php endif ?>
         </a>
         <?php // 右側アクション群（ブログ=日本語のみ／カテゴリ）。検索ボタン(右端absolute)の50px分を確保、トップでは詰める ?>

--- a/app/Views/components/top_ranking_comment_list_hour.php
+++ b/app/Views/components/top_ranking_comment_list_hour.php
@@ -17,7 +17,7 @@ $_hourlyRange = $hourlyStart . '〜<time datetime="' . $hourlyTime . '">' . $hou
             <h2 class="unset">
                 <span class="openchat-list-title"><?php echo t('1時間の人数増加ランキング') ?></span>
             </h2>
-            <span style="font-weight: normal; color:#aaa; font-size:13px; margin: 0">
+            <span style="font-weight: normal; color:var(--c-text-4); font-size:13px; margin: 0">
                 <?php echo $_hourlyRange ?>
             </span>
         </div>

--- a/app/Views/components/top_ranking_comment_list_hour24.php
+++ b/app/Views/components/top_ranking_comment_list_hour24.php
@@ -4,7 +4,7 @@
             <h2 class="unset">
                 <span class="openchat-list-title"><?php echo t('24時間の人数増加ランキング') ?></span>
             </h2>
-            <span style="font-weight: normal; color:#aaa; font-size:13px; margin: 0"><?php echo t('1時間ごとに更新') ?></span>
+            <span style="font-weight: normal; color:var(--c-text-4); font-size:13px; margin: 0"><?php echo t('1時間ごとに更新') ?></span>
         </div>
     </header>
     <?php viewComponent('open_chat_list_ranking', ['openChatList' => array_slice($dto->dailyList, 0, \App\Config\AppConfig::$listLimitTopRanking), 'isHourly' => true, 'noReverse' => true, 'showReverseListMedal' => true]) ?>

--- a/app/Views/components/top_ranking_comment_list_week.php
+++ b/app/Views/components/top_ranking_comment_list_week.php
@@ -4,7 +4,7 @@
             <h2 class="unset">
                 <span class="openchat-list-title"><?php echo t('1週間の人数増加ランキング') ?></span>
             </h2>
-            <span style="font-weight: normal; color:#aaa; font-size:13px; margin: 0"><?php echo t('1日ごとに更新') ?></span>
+            <span style="font-weight: normal; color:var(--c-text-4); font-size:13px; margin: 0"><?php echo t('1日ごとに更新') ?></span>
         </div>
     </header>
     <?php viewComponent('open_chat_list_ranking', ['openChatList' => array_slice($dto->weeklyList, 0, \App\Config\AppConfig::$listLimitTopRanking), 'noReverse' => true, 'showReverseListMedal' => true]) ?>

--- a/app/Views/components/topic_tag.php
+++ b/app/Views/components/topic_tag.php
@@ -40,7 +40,7 @@ function greenTag($word)
                     <span class="openchat-list-title"><?php echo t('いま人数急増中のテーマ') ?></span>
                     <span aria-hidden="true" style="font-size: 9px; user-select: none; margin-bottom: px;margin-left: -3px;">🚀</span>
                 </h2>
-                <span style="font-weight: normal; color:#aaa; font-size:13px; margin: 0"><?php echo $topPageDto->hourlyUpdatedAt->format('G:i') ?></span>
+                <span style="font-weight: normal; color:var(--c-text-4); font-size:13px; margin: 0"><?php echo $topPageDto->hourlyUpdatedAt->format('G:i') ?></span>
             </div>
         </header>
 

--- a/app/Views/errors/oc_error.php
+++ b/app/Views/errors/oc_error.php
@@ -74,9 +74,9 @@
             <?php viewComponent('site_header') ?>
         </div>
         <header style="padding: 1rem 1rem 0 1rem; text-align: center">
-            <p style="color: #111; font-size: 11px; text-align: left;">「<?php echo $recommend[2] ?? '' ?>」 ID:<?php echo $open_chat_id ?></p>
-            <p style="font-weight: bold; color: #777">このオープンチャットはオプチャグラフから削除されました😇</p>
-            <p style="color: #aaa; font-size: 13px">LINE内でルームが削除された可能性があります</p>
+            <p style="color: var(--c-text-1); font-size: 11px; text-align: left;">「<?php echo $recommend[2] ?? '' ?>」 ID:<?php echo $open_chat_id ?></p>
+            <p style="font-weight: bold; color: var(--c-text-3)">このオープンチャットはオプチャグラフから削除されました😇</p>
+            <p style="color: var(--c-text-4); font-size: 13px">LINE内でルームが削除された可能性があります</p>
         </header>
         <?php if (isset($recommend[0]) && $recommend[0]) : ?>
             <aside class="recommend-list-aside">

--- a/app/Views/labs_content.php
+++ b/app/Views/labs_content.php
@@ -12,7 +12,7 @@ viewComponent('policy_head', compact('_css', '_meta')) ?>
         <main style="overflow: hidden;">
             <article class="terms">
                 <h1 style="letter-spacing: 0px;">
-                    <svg style="color: #111; fill: currentColor; display: inline-block; margin-right: 4px; margin-bottom: -4px; margin-left: -12px;" focusable="false" height="24px" viewBox="0 -960 960 960" width="24px">
+                    <svg style="color: var(--c-text-1); fill: currentColor; display: inline-block; margin-right: 4px; margin-bottom: -4px; margin-left: -12px;" focusable="false" height="24px" viewBox="0 -960 960 960" width="24px">
                         <path d="M209-120q-42 0-70.5-28.5T110-217q0-14 3-25.5t9-21.5l228-341q10-14 15-31t5-34v-110h-20q-13 0-21.5-8.5T320-810q0-13 8.5-21.5T350-840h260q13 0 21.5 8.5T640-810q0 13-8.5 21.5T610-780h-20v110q0 17 5 34t15 31l227 341q6 9 9.5 20.5T850-217q0 41-28 69t-69 28H209Zm221-660v110q0 26-7.5 50.5T401-573L276-385q-6 8-8.5 16t-2.5 16q0 23 17 39.5t42 16.5q28 0 56-12t80-47q69-45 103.5-62.5T633-443q4-1 5.5-4.5t-.5-7.5l-78-117q-15-21-22.5-46t-7.5-52v-110H430Z"></path>
                     </svg><span style="line-height: 2;">分析Labs</span>
                 </h1>

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -31,7 +31,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
         <div class="openchat-header-right">
           <div>
             <h1 class="talkroom_link_h1 unset"><?php if ($oc['emblem'] === 1) : ?><span class="super-icon sp"></span><?php elseif ($oc['emblem'] === 2) : ?><span class="super-icon official"></span><?php endif ?><?php echo $oc['name'] ?></h1>
-            <a class="link-mark" style="text-decoration: none; width: fit-content;" title="<?php echo $oc['name'] ?>" rel="external" target="_blank" href="<?php echo AppConfig::LINE_OPEN_URL[MimimalCmsConfig::$urlRoot] . $oc['emid'] . AppConfig::LINE_OPEN_URL_SUFFIX ?>"><span class="link-title" style="background: unset; color: #b7b7b7; -webkit-text-fill-color: unset; font-weight: normal; line-height: 125%; margin-bottom: -1px;"><!-- <span aria-hidden="true" style="font-size: 10px; margin-right:2px;">🔗</span> --><?php echo t('LINEオープンチャット') ?></span></a>
+            <a class="link-mark" style="text-decoration: none; width: fit-content;" title="<?php echo $oc['name'] ?>" rel="external" target="_blank" href="<?php echo AppConfig::LINE_OPEN_URL[MimimalCmsConfig::$urlRoot] . $oc['emid'] . AppConfig::LINE_OPEN_URL_SUFFIX ?>"><span class="link-title" style="background: unset; color: var(--c-text-5); -webkit-text-fill-color: unset; font-weight: normal; line-height: 125%; margin-bottom: -1px;"><!-- <span aria-hidden="true" style="font-size: 10px; margin-right:2px;">🔗</span> --><?php echo t('LINEオープンチャット') ?></span></a>
           </div>
 
           <div class="talkroom_description_box close" id="talkroom_description_box">
@@ -41,7 +41,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
             <button id="talkroom-description-close-btn" class="close-btn" title="<?php echo t('一部を表示') ?>"><?php echo t('一部を表示') ?></button>
             <div class="more" id="read_more_btn">
               <div class="more-separater">&nbsp;</div>
-              <button class="unset more-text" style="font-weight: bold; color: #111;" title="<?php echo t('すべて見る') ?>">…<?php echo t('すべて見る') ?></button>
+              <button class="unset more-text" style="font-weight: bold; color: var(--c-text-1);" title="<?php echo t('すべて見る') ?>">…<?php echo t('すべて見る') ?></button>
             </div>
           </div>
 

--- a/app/Views/policy_content.php
+++ b/app/Views/policy_content.php
@@ -150,11 +150,11 @@ viewComponent('policy_head', compact('_css', '_meta')) ?>
                 </p>
 
                 <h2 style="margin-bottom: 2rem;">オプチャグラフに関する情報共有・コメント</h2>
-                <a id="admin-gear-btn" href="<?php echo url('oc/0/admin') ?>#comments" style="display: none; align-items: center; justify-content: center; width: 36px; height: 36px; margin-top: -1.5rem; margin-bottom: 1rem; background: linear-gradient(135deg, #ffa751, #e85d04); border-radius: 8px; color: white; text-decoration: none; font-size: 18px;">⚙</a>
+                <a id="admin-gear-btn" href="<?php echo url('oc/0/admin') ?>#comments" style="display: none; align-items: center; justify-content: center; width: 36px; height: 36px; margin-top: -1.5rem; margin-bottom: 1rem; background: var(--c-grad-orange-btn); border-radius: 8px; color: var(--c-text-inverse); text-decoration: none; font-size: 18px;">⚙</a>
                 <script>if(document.cookie.split('; ').find(r=>r.startsWith('admin-enable='))){document.getElementById('admin-gear-btn').style.display='flex'}</script>
 
                 <?php if (isset($_adminDto)): ?>
-                    <div style="padding: 1rem; margin: 0 0 1rem; border: 1px solid #ccc;">
+                    <div style="padding: 1rem; margin: 0 0 1rem; border: 1px solid var(--c-border-mid);">
                         <form action="/admin-api/deletecomment" method="POST" style="margin: 1rem 0;">
                             <label for="comments-delete">コメントのフラグを変更</label>
                             <select name="commentId" id="comments-delete" style="width: 5rem; font-size:1rem">

--- a/app/Views/recent_comment.php
+++ b/app/Views/recent_comment.php
@@ -16,7 +16,7 @@ viewComponent('head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']) ?
     <?php endif ?>
     <style>
         .list-title {
-            color: #111;
+            color: var(--c-text-1);
             all: unset;
             font-size: 20px;
             font-weight: bold;
@@ -40,11 +40,11 @@ viewComponent('head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']) ?
 
         .p-small {
             font-size: 13px;
-            color: #777;
+            color: var(--c-text-3);
         }
 
         .search-pager {
-            background: rgb(250, 250, 250);
+            background: var(--c-bg-sub);
             width: 100%;
             justify-content: space-evenly;
             padding: 4px 2rem;
@@ -53,8 +53,8 @@ viewComponent('head', compact('_css', '_meta') + ['dataOverlays' => 'bottom']) ?
         article .search-pager {
             margin: 0 -1rem;
             width: calc(100% + 2rem);
-            border-bottom: 1px solid #efefef;
-            border-top: 1px solid #efefef;
+            border-bottom: 1px solid var(--c-border);
+            border-top: 1px solid var(--c-border);
         }
 
         .head-pager .search-pager {

--- a/app/Views/recent_content.php
+++ b/app/Views/recent_content.php
@@ -10,7 +10,7 @@
         }
 
         .list-title {
-            color: #111;
+            color: var(--c-text-1);
             all: unset;
             font-size: 20px;
             font-weight: bold;
@@ -23,7 +23,7 @@
 
         .p-small {
             font-size: 13px;
-            color: #777;
+            color: var(--c-text-3);
 
         }
     </style>
@@ -40,7 +40,7 @@
                         <small class="p-small">このページではオプチャグラフに登録されたオープンチャットを登録日時順で表示します。</small>
                     </p>
                     <p>
-                        <small class="p-small"><a style="color:#777" rel="external nofollow noopener" href="https://openchat.line.me/jp/explore" target="_blank">ランキング（LINE公式サイト）<span class="line-link-icon777"></span></a>にランクインしたオープンチャットは、オプチャグラフに随時登録されます。</small>
+                        <small class="p-small"><a style="color:var(--c-text-3)" rel="external nofollow noopener" href="https://openchat.line.me/jp/explore" target="_blank">ランキング（LINE公式サイト）<span class="line-link-icon777"></span></a>にランクインしたオープンチャットは、オプチャグラフに随時登録されます。</small>
                     </p>
                     <p>
                         <small class="p-small">LINE公式のランキングは1時間毎に更新されるため、オプチャグラフはその時間帯に合わせて公式サイトからデータを取得しています。</small>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -83,7 +83,7 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
                   <?php // 同一H2の反復(量産シグナル)を避け、継続チャンクは見出しではなく軽い順位区切りにする ?>
                   <div class="recommend-ranking-continue"><?php echo sprintfT('%s位', $currentCount + 1) ?>〜</div>
                 <?php else : ?>
-                  <h2 style="all: unset; font-size: 15px; font-weight: bold; color: #111; display: flex; flex-direction:row; flex-wrap:wrap; line-height: 1.3;">
+                  <h2 style="all: unset; font-size: 15px; font-weight: bold; color: var(--c-text-1); display: flex; flex-direction:row; flex-wrap:wrap; line-height: 1.3;">
                     <div><?php echo sprintfT("「%s」でいま人数が伸びているルーム", $extractTag) ?>&nbsp;</div>
                     <div>(<?php echo $hourlyUpdatedAt->format('G:i') ?>)</div>
                   </h2>

--- a/app/Views/register_form_content.php
+++ b/app/Views/register_form_content.php
@@ -5,7 +5,7 @@
 <body class="body">
     <style>
         .list-title {
-            color: #111;
+            color: var(--c-text-1);
             all: unset;
             font-size: 20px;
             font-weight: bold;

--- a/app/Views/tags_content.php
+++ b/app/Views/tags_content.php
@@ -3,7 +3,7 @@
 function memberCount(int $count)
 {
 ?>
-    <span style="color:<?php echo $count === 0 ? '#aaa' : ($count > 0 ? '#4d73ff' : '#ff5d6d') ?>">
+    <span style="color:<?php echo $count === 0 ? 'var(--c-text-4)' : ($count > 0 ? 'var(--c-accent-blue)' : 'var(--c-down)') ?>">
         <?php if ($count === 0) : ?>
             ±0
         <?php else : ?>
@@ -33,8 +33,8 @@ function memberCount(int $count)
                 設定済: <?php echo count($adsTagMap) ?>件
             </p>
         <?php else : ?>
-            <p style="font-size: 13px; color: #777">各タグを、近そうなカテゴリに分類して表示しています。タグ内のルームは様々なカテゴリに属しています。</p>
-            <p style="font-size: 13px; color: #777">タグを探すときは、ブラウザの機能でページ内のテキストを検索してください。</p>
+            <p style="font-size: 13px; color: var(--c-text-3)">各タグを、近そうなカテゴリに分類して表示しています。タグ内のルームは様々なカテゴリに属しています。</p>
+            <p style="font-size: 13px; color: var(--c-text-3)">タグを探すときは、ブラウザの機能でページ内のテキストを検索してください。</p>
             <aside class="list-aside ranking-desc" style="margin: 1rem 0;">
                 <details class="icon-desc">
                     <summary style="font-size: 14px;">タグ内の人数集計について</summary>
@@ -59,14 +59,14 @@ function memberCount(int $count)
                         <h2 class="unset">
                             <span class="openchat-list-title">カテゴリー</span>
                         </h2>
-                        <span style="font-weight: normal; color:#aaa; font-size:13px; margin: 0">各カテゴリまで移動</span>
+                        <span style="font-weight: normal; color:var(--c-text-4); font-size:13px; margin: 0">各カテゴリまで移動</span>
                     </div>
                 </header>
                 <div style="margin: 1rem; margin-bottom: 0; margin-top: .5rem;">
                     <?php foreach ($categories as $key => $category) : ?>
                         <a style="font-size:15px; text-wrap:nowrap; margin-bottom:20px; margin-right: 1px; display:inline-flex; gap:2px; text-decoration:none;" href="#<?php echo $key ?>">
-                            <span style="color:#111; text-decoration:underline; font-weight: bold;"><?php echo $key ? $category : 'その他' ?></span>
-                            <span style="color:#777; font-size:10px; margin: 0; line-height: 1.5; font-weight: bold;"><?php echo count($tagsGroup[$key]) ?>タグ</span>
+                            <span style="color:var(--c-text-1); text-decoration:underline; font-weight: bold;"><?php echo $key ? $category : 'その他' ?></span>
+                            <span style="color:var(--c-text-3); font-size:10px; margin: 0; line-height: 1.5; font-weight: bold;"><?php echo count($tagsGroup[$key]) ?>タグ</span>
                         </a>
                     <?php endforeach ?>
                 </div>
@@ -84,7 +84,7 @@ function memberCount(int $count)
                             <h2 class="unset">
                                 <span class="openchat-list-title"><?php echo $key ? $category : 'その他' ?></span>
                             </h2>
-                            <span style="font-weight: normal; color:#aaa; font-size:13px; margin: 0"><?php echo count($tagsGroup[$key]) ?>個のタグ</span>
+                            <span style="font-weight: normal; color:var(--c-text-4); font-size:13px; margin: 0"><?php echo count($tagsGroup[$key]) ?>個のタグ</span>
                         </div>
                     </header>
                     <ul class="tag-list open">
@@ -97,9 +97,9 @@ function memberCount(int $count)
                                         <small style="font-weight: normal; display:block; line-height: 1.5;"><?php echo number_format($tag['record_count']) ?>件・平均 <?php echo number_format(round($tag['total_member'] / $tag['record_count'])) ?>人</small>
                                     </div>
                                     <div>
-                                        <small style="color:#aaa; display:block; margin-left:4px;line-height: 1.3;">1H</small>
-                                        <small style="color:#aaa; display:block; margin-left:4px;line-height: 1.3;">24H</small>
-                                        <small style="color:#aaa; display:block; margin-left:4px;line-height: 1.3;">1W</small>
+                                        <small style="color:var(--c-text-4); display:block; margin-left:4px;line-height: 1.3;">1H</small>
+                                        <small style="color:var(--c-text-4); display:block; margin-left:4px;line-height: 1.3;">24H</small>
+                                        <small style="color:var(--c-text-4); display:block; margin-left:4px;line-height: 1.3;">1W</small>
                                     </div>
                                     <div>
                                         <small style="display:block; margin-left:4px;line-height: 1.3;"><?php memberCount($tag['hour'] ?? 0) ?></small>
@@ -130,7 +130,7 @@ function memberCount(int $count)
                         <?php endforeach ?>
                     </ul>
                 </div>
-                <a style="font-size:15px; text-wrap:nowrap; margin-left:auto; display:inline-flex; color: #111" href="#top">ページの先頭に戻る</a>
+                <a style="font-size:15px; text-wrap:nowrap; margin-left:auto; display:inline-flex; color: var(--c-text-1)" href="#top">ページの先頭に戻る</a>
             </article>
         <?php endforeach ?>
     </main>

--- a/app/Views/term_content.php
+++ b/app/Views/term_content.php
@@ -30,7 +30,7 @@ use App\Config\AppConfig;
 <body>
     <style>
         hr {
-            border-bottom: 1px #efefef solid;
+            border-bottom: 1px var(--c-border) solid;
             margin: 2rem 0;
         }
 

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -22,10 +22,10 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
         <div style="padding: 0 1rem; margin-bottom: 1rem;">
             <div style="margin: 1rem 0;">
-                <small style="display: block; color: #000; font-size: 11px; font-weight: bold; line-height: 1;">LINE</small>
+                <small style="display: block; color: var(--c-text-black); font-size: 11px; font-weight: bold; line-height: 1;">LINE</small>
                 <h1 style="margin: 0; padding: 0; font-size: 28px; font-weight: bold; line-height: 1;">OPENCHAT Graph <?php echo MimimalCmsConfig::$urlRoot ? strtoupper(str_replace('/', '', MimimalCmsConfig::$urlRoot)) : '' ?>📈</h1>
             </div>
-            <small style="display: block; color: #000; font-size: 10px; margin: .5rem 0 1rem 0;">
+            <small style="display: block; color: var(--c-text-black); font-size: 10px; margin: .5rem 0 1rem 0;">
                 <?php
                 $languages = array_keys(AppConfig::LINE_OPEN_URL);
                 ?>
@@ -45,7 +45,7 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
               // CSSは自己完結（theme_discovery 非依存）。 ?>
         <div style="padding: 0 1rem; margin-bottom: 1rem;">
             <form method="GET" action="<?php echo url('ranking') ?>" role="search" class="oc-hero-search">
-                <svg class="oc-hero-search__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" style="position:absolute;left:14px;top:50%;width:20px;height:20px;transform:translateY(-50%);fill:#9aa3af;pointer-events:none"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z" /></svg>
+                <svg class="oc-hero-search__icon" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" style="position:absolute;left:14px;top:50%;width:20px;height:20px;transform:translateY(-50%);fill:var(--c-cool-text-weak);pointer-events:none"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z" /></svg>
                 <input id="oc-hero-input" class="oc-hero-search__input" type="search" name="keyword" inputmode="search" enterkeyhint="search"
                     autocomplete="off" autocapitalize="off" spellcheck="false" maxlength="100" required
                     placeholder="<?php echo t('オープンチャットを検索') ?>" aria-label="<?php echo t('オープンチャットを検索') ?>">
@@ -58,14 +58,14 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
         <style>
             /* トップ最上部「オープンチャットを検索」。自己完結CSS（グローバルな汎用 form 枠は打ち消す）。 */
             .oc-hero-search{position:relative;display:block;width:100%;margin:0;padding:0;border:0;background:none;box-shadow:none}
-            .oc-hero-search__icon{position:absolute;left:14px;top:50%;transform:translateY(-50%);width:20px;height:20px;fill:#9aa3af;pointer-events:none}
+            .oc-hero-search__icon{position:absolute;left:14px;top:50%;transform:translateY(-50%);width:20px;height:20px;fill:var(--c-cool-text-weak);pointer-events:none}
             /* iOS Safari のフォーカス時オートズーム回避のため font-size は16px以上 */
-            .oc-hero-search__input{display:block;width:100%;box-sizing:border-box;height:48px;margin:0;padding:0 44px;font-size:16px;color:#0f1620;background:#f6f8fa;border:1.5px solid #e4e8ee;border-radius:12px;outline:none;-webkit-appearance:none;appearance:none;transition:border-color .15s,background .15s,box-shadow .15s}
-            .oc-hero-search__input::placeholder{color:#9aa3af}
+            .oc-hero-search__input{display:block;width:100%;box-sizing:border-box;height:48px;margin:0;padding:0 44px;font-size:16px;color:var(--c-cool-text-deep);background:var(--c-cool-surface);border:1.5px solid var(--c-border-2);border-radius:12px;outline:none;-webkit-appearance:none;appearance:none;transition:border-color .15s,background .15s,box-shadow .15s}
+            .oc-hero-search__input::placeholder{color:var(--c-cool-text-weak)}
             .oc-hero-search__input::-webkit-search-cancel-button{-webkit-appearance:none;appearance:none;display:none}
-            .oc-hero-search__input:focus{background:#fff;border-color:#06c755;box-shadow:0 0 0 3px rgba(6,199,85,.14)}
-            .oc-hero-search__clear{position:absolute;right:6px;top:0;bottom:0;width:40px;display:flex;align-items:center;justify-content:center;color:#9aa3af;font-size:20px;line-height:1;cursor:pointer;-webkit-user-select:none;user-select:none}
-            .oc-hero-search__clear:hover{color:#5b6573}
+            .oc-hero-search__input:focus{background:var(--c-bg);border-color:var(--c-brand);box-shadow:0 0 0 3px var(--c-brand-ring)}
+            .oc-hero-search__clear{position:absolute;right:6px;top:0;bottom:0;width:40px;display:flex;align-items:center;justify-content:center;color:var(--c-cool-text-weak);font-size:20px;line-height:1;cursor:pointer;-webkit-user-select:none;user-select:none}
+            .oc-hero-search__clear:hover{color:var(--c-cool-text)}
             .oc-hero-search__clear[hidden]{display:none}
         </style>
         <script>
@@ -126,7 +126,7 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
         <?php viewComponent('footer_inner') ?>
         <div class="refresh-time" style="width: fit-content; margin: auto; padding-bottom: 0.5rem; margin-top: -9px;">
-            <div class="refresh-icon"></div><time style="font-size: 11px; color: #b7b7b7; margin-left:3px" datetime="<?php echo $_updatedAt->format(\DateTime::ATOM) ?>"><?php echo $_updatedAt->format('Y/n/j G:i') ?></time>
+            <div class="refresh-icon"></div><time style="font-size: 11px; color: var(--c-text-5); margin-left:3px" datetime="<?php echo $_updatedAt->format(\DateTime::ATOM) ?>"><?php echo $_updatedAt->format('Y/n/j G:i') ?></time>
         </div>
     </div>
     <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>

--- a/public/style/pages/blog.css
+++ b/public/style/pages/blog.css
@@ -13,13 +13,14 @@ main.blog-main {
 }
 
 .blog {
-  --g: #06c755;
-  --g-deep: #05a648;
-  --g-soft: #f1faf4;
-  --ink: #111;
-  --text: #3d4043;
-  --muted: #8a9097;
-  --line: #ededf0;
+  /* ローカルエイリアス（.blog スコープ）。実値は tokens.css の共通トークンと同一 */
+  --g: var(--c-brand);
+  --g-deep: var(--c-btn-blog-text);
+  --g-soft: var(--c-btn-blog-bg);
+  --ink: var(--c-text-1);
+  --text: var(--c-text-charcoal);
+  --muted: var(--c-text-steel);
+  --line: var(--c-border-muted);
   max-width: 720px;
   margin: 0 auto;
   padding: 4px 1.15rem 2.5rem;
@@ -51,8 +52,8 @@ main.blog-main {
   -webkit-mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 3 4 9.5V21h5v-6h6v6h5V9.5z"/></svg>') center/contain no-repeat;
   mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 3 4 9.5V21h5v-6h6v6h5V9.5z"/></svg>') center/contain no-repeat;
 }
-.blog-crumb a:hover { background: #e2f6ea; }
-.blog-crumb .sep { color: #c5c9ce; font-weight: 400; }
+.blog-crumb a:hover { background: var(--c-green-pale); }
+.blog-crumb .sep { color: var(--c-text-silver); font-weight: 400; }
 
 /* ---- タイトル・メタ ---- */
 .blog-title {
@@ -80,7 +81,7 @@ main.blog-main {
 }
 .blog-meta .author::before {
   content: ""; width: 15px; height: 15px; border-radius: 50%;
-  background: linear-gradient(135deg, var(--g), #11d871); flex: none;
+  background: linear-gradient(135deg, var(--g), var(--c-brand-2)); flex: none;
 }
 .blog-meta .cat {
   border: 1px solid var(--g); color: var(--g-deep);
@@ -113,7 +114,7 @@ main.blog-main {
 .blog-body a {
   color: var(--g-deep); font-weight: 700;
   text-decoration: underline; text-underline-offset: 0.16em;
-  text-decoration-thickness: 1.5px; text-decoration-color: #a8e6c2;
+  text-decoration-thickness: 1.5px; text-decoration-color: var(--c-green-underline);
   transition: text-decoration-color .15s;
 }
 .blog-body a:hover { text-decoration-color: var(--g); }
@@ -129,7 +130,7 @@ main.blog-main {
   box-sizing: border-box;
   width: 20px; min-width: 20px; height: 20px; padding: 0; /* mvp.css の input{padding:.4rem .8rem} を打ち消し楕円化を防ぐ */
   margin: 0 .55em -.28em 0;
-  border-radius: 50%; background: var(--g-soft); border: 1.5px solid #bfe7cd;
+  border-radius: 50%; background: var(--g-soft); border: 1.5px solid var(--c-blog-icon-border);
   position: relative; flex: none;
 }
 .blog-body input[type="checkbox"]::after {
@@ -142,7 +143,7 @@ main.blog-main {
 .blog-body blockquote {
   margin: 1.4rem 0; padding: .95rem 1.15rem;
   background: var(--g-soft); border-left: 4px solid var(--g);
-  border-radius: 0 10px 10px 0; color: #235f3e;
+  border-radius: 0 10px 10px 0; color: var(--c-green-text-deep);
   font-size: 14.5px; line-height: 1.85;
 }
 .blog-body blockquote p { margin: 0; }
@@ -154,13 +155,13 @@ main.blog-main {
   border: 1.5px solid var(--g); border-radius: 14px;
   background:
     radial-gradient(130% 120% at 0% 0%, #eafaf1 0%, var(--g-soft) 60%);
-  box-shadow: 0 2px 12px rgba(6, 199, 85, .09);
+  box-shadow: 0 2px 12px var(--c-brand-shadow-soft);
 }
 .blog-body .blog-point__label {
   display: inline-flex; align-items: center; gap: 5px;
   margin: 0 0 .7rem; padding: 3px 12px 3px 10px;
   font-size: 12px; font-weight: 800; letter-spacing: .03em;
-  color: #fff; background: var(--g); border-radius: 999px;
+  color: var(--c-text-inverse); background: var(--g); border-radius: 999px;
 }
 .blog-body .blog-point__label::before { content: "🎯"; font-size: 11.5px; }
 .blog-body .blog-point ul { margin: 0; padding-left: 1.3em; }
@@ -179,7 +180,7 @@ main.blog-main {
   background:
     radial-gradient(120% 100% at 0% 0%, var(--g-soft) 0%, rgba(255,255,255,0) 55%),
     #fff;
-  box-shadow: 0 1px 2px rgba(17,17,17,.03);
+  box-shadow: 0 1px 2px var(--c-ink-shadow);
 }
 .blog-cta-h { font-weight: 800; color: var(--ink); margin-bottom: .85rem; font-size: 15px; }
 .blog-cta-h .em { color: var(--g-deep); }
@@ -187,14 +188,14 @@ main.blog-main {
 .blog-btn {
   display: inline-flex; align-items: center; height: 38px; padding: 0 16px;
   border-radius: 999px; font-weight: 700; font-size: 13.5px; text-decoration: none;
-  border: 1px solid var(--line); color: var(--ink); background: #fff;
+  border: 1px solid var(--line); color: var(--ink); background: var(--c-bg);
   transition: background .15s, border-color .15s, transform .05s;
 }
-.blog-btn:hover { background: #fafafa; }
+.blog-btn:hover { background: var(--c-bg-sub); }
 .blog-btn:active { transform: translateY(1px); }
 .blog-btn--primary {
-  background: var(--g); border-color: var(--g); color: #fff;
-  box-shadow: 0 2px 8px rgba(6,199,85,.28);
+  background: var(--g); border-color: var(--g); color: var(--c-text-inverse);
+  box-shadow: 0 2px 8px var(--c-brand-shadow);
 }
 .blog-btn--primary:hover { background: var(--g-deep); border-color: var(--g-deep); }
 
@@ -209,7 +210,7 @@ main.blog-main {
 .blog-faq h3::before {
   content: "Q"; position: absolute; left: 0; top: .92rem;
   width: 1.4rem; height: 1.4rem; border-radius: 8px;
-  background: var(--g); color: #fff; font-weight: 800; font-size: 13px;
+  background: var(--g); color: var(--c-text-inverse); font-weight: 800; font-size: 13px;
   display: flex; align-items: center; justify-content: center;
 }
 .blog-faq h3 + p {
@@ -243,11 +244,11 @@ main.blog-main {
 .blog-cards { list-style: none; padding: 0; margin: 0; display: grid; gap: 14px; }
 .blog-card {
   display: block; padding: 1.1rem 1.2rem; text-decoration: none;
-  border: 1px solid var(--line); border-radius: 16px; background: #fff;
+  border: 1px solid var(--line); border-radius: 16px; background: var(--c-bg);
   transition: border-color .15s, box-shadow .15s, transform .06s;
 }
 .blog-card:hover {
-  border-color: var(--g); box-shadow: 0 4px 16px rgba(6,199,85,.10);
+  border-color: var(--g); box-shadow: 0 4px 16px var(--c-brand-shadow-soft-2);
 }
 .blog-card:active { transform: translateY(1px); }
 .blog-card .t {
@@ -261,7 +262,7 @@ main.blog-main {
 .blog-card .date { font-size: 11.5px; color: var(--muted); }
 /* 説明文は3行で省略し、2カラム時のカード高さの凸凹を防ぐ */
 .blog-card .d {
-  font-size: 13.5px; color: #5b6066; line-height: 1.7; margin: 0;
+  font-size: 13.5px; color: var(--c-text-neutral); line-height: 1.7; margin: 0;
   display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
 }
 .blog-card .go { margin-top: .7rem; font-size: 12.5px; font-weight: 700; color: var(--g-deep); }

--- a/public/style/pages/oc-jump.css
+++ b/public/style/pages/oc-jump.css
@@ -6,23 +6,8 @@
    var(--font-family) を踏襲し、デザインは余白・色・罫線・影で作る。
    ========================================================================= */
 
-:root {
-  --ocj-bg: #f6f5f3;
-  --ocj-card: #ffffff;
-  --ocj-border: #e9e7e3;
-  --ocj-ink: #1c1b19;
-  --ocj-ink-soft: #5c5953;
-  --ocj-ink-mute: #8a857d;
-  --ocj-amber: #d98a00;
-  --ocj-amber-bg: #fdf6e8;
-  --ocj-amber-line: #f0d9a8;
-  --ocj-line-green: #06c755;
-  --ocj-line-green-press: #05a647;
-  --ocj-radius: 14px;
-  --ocj-radius-sm: 10px;
-  --ocj-shadow: 0 1px 2px rgba(28, 27, 25, .04), 0 6px 18px rgba(28, 27, 25, .05);
-  --ocj-shadow-btn: 0 6px 16px rgba(6, 199, 85, .32);
-}
+/* --ocj-* トークンの定義は style/tokens.css に移設済み
+   （色・半径・影をまとめて名前空間 --ocj-* で管理） */
 
 /* ページ全体の地色（カードを浮かせる） */
 body:has(.oc-jump-wrap) {
@@ -78,7 +63,7 @@ body:has(.oc-jump-wrap) {
   height: 26px;
   border-radius: 50%;
   background: var(--ocj-amber);
-  color: #fff;
+  color: var(--c-text-inverse);
   font-size: 16px;
   font-weight: 700;
   line-height: 26px;
@@ -95,14 +80,14 @@ body:has(.oc-jump-wrap) {
   margin: 0;
   font-size: 16px;
   font-weight: 700;
-  color: #8a5800;
+  color: var(--ocj-amber-deep);
   letter-spacing: .01em;
 }
 
 .oc-jump-notice__lead {
   font-size: 12.5px;
   line-height: 1.6;
-  color: #9a7320;
+  color: var(--ocj-amber-soft-text);
 }
 
 /* =========================================================================
@@ -124,7 +109,7 @@ body:has(.oc-jump-wrap) {
   width: 100%;
   aspect-ratio: 1.8;
   object-fit: cover;
-  background: #efeded;
+  background: var(--ocj-bg-dim);
 }
 
 .oc-jump-room {
@@ -156,7 +141,7 @@ body:has(.oc-jump-wrap) {
   gap: 6px;
   align-self: flex-start;
   padding: 4px 11px;
-  background: #f3f2ef;
+  background: var(--ocj-bg-dim-2);
   border-radius: 999px;
   font-size: 12.5px;
   font-weight: 600;
@@ -195,8 +180,8 @@ body:has(.oc-jump-wrap) {
 .oc-jump-about__body {
   margin: 0;
   border-radius: var(--ocj-radius-sm);
-  background: #faf9f7;
-  border: 1px solid #efedea;
+  background: var(--ocj-card-soft);
+  border: 1px solid var(--ocj-border-soft);
   padding: 13px 15px;
   max-height: none;
 }
@@ -206,7 +191,7 @@ body:has(.oc-jump-wrap) {
   text-align: left;
   line-height: 1.85;
   font-size: 13.5px;
-  color: #2c2a27;
+  color: var(--ocj-ink-strong);
 }
 
 .oc-jump-about__body #talkroom-description-btn {
@@ -270,7 +255,7 @@ body:has(.oc-jump-wrap) {
   position: relative;
   margin: 0;
   padding: 13px 0 13px 34px;
-  border-top: 1px solid #f0eeea;
+  border-top: 1px solid var(--ocj-border-faint);
   list-style: none;
 }
 
@@ -287,8 +272,8 @@ body:has(.oc-jump-wrap) {
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: #eef7f0;
-  color: #1f9d54;
+  background: var(--ocj-green-bg);
+  color: var(--ocj-green-text);
   font-size: 11.5px;
   font-weight: 700;
   line-height: 22px;
@@ -385,7 +370,7 @@ body:has(.oc-jump-wrap) {
     #12cfcd 83.85%,
     #16c2c1
   );
-  color: #fff;
+  color: var(--c-text-inverse);
   font-size: 16px;
   font-weight: 700;
   letter-spacing: .02em;
@@ -398,13 +383,13 @@ body:has(.oc-jump-wrap) {
 .oc-jump-line-button:hover {
   /* グラデを保ったまま明度＋影で押下感を出す(flat緑に戻すとグラデが消えるため) */
   filter: brightness(1.04);
-  box-shadow: 0 8px 20px rgba(6, 199, 85, .38);
+  box-shadow: var(--ocj-shadow-btn-hover);
 }
 
 .oc-jump-line-button:active {
   transform: translateY(1px) scale(.995);
   filter: brightness(.98);
-  box-shadow: 0 3px 10px rgba(6, 199, 85, .3);
+  box-shadow: var(--ocj-shadow-btn-press);
 }
 
 .oc-jump-line-button-content {
@@ -415,7 +400,7 @@ body:has(.oc-jump-wrap) {
 
 .oc-jump-line-button svg {
   height: 15px;
-  fill: #fff;
+  fill: var(--c-text-inverse);
   margin-right: 5px;
 }
 

--- a/public/style/pages/recommend_page.css
+++ b/public/style/pages/recommend_page.css
@@ -21,7 +21,7 @@ li {
 
 .recommend-header-time {
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .ranking-page-main {
@@ -38,7 +38,7 @@ li {
 
 .ranking-page-main .talkroom_banner_img_figure figcaption {
   font-size: 9px;
-  color: #b7b7b7;
+  color: var(--c-text-5);
   display: block;
   /*   text-overflow: ellipsis;
   white-space: nowrap;
@@ -97,7 +97,7 @@ li {
   font-size: 21px;
   font-weight: bold;
   line-height: 1.25;
-  color: #111;
+  color: var(--c-text-1);
   display: block;
   white-space: break-spaces;
   margin-bottom: 4px;
@@ -121,28 +121,28 @@ li {
 
 .recommend-data-desc {
   font-size: 13px;
-  color: #06c755;
+  color: var(--c-brand);
 }
 
 .recommend-header-desc {
   display: block;
   padding: 0 1rem;
   font-size: 14px;
-  color: #555;
+  color: var(--c-text-mid-2);
   line-height: 1.3;
   margin-bottom: 8px;
 }
 
 .recommend-header-desc.desc-bottom {
   font-size: 15px;
-  color: #555;
+  color: var(--c-text-mid-2);
   line-height: 1.6;
   margin: 0;
 }
 
 .recommend-header-desc.desc-bottom .desc-aside {
   font-size: 12px;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .top-ranking-list-aside {
@@ -269,11 +269,11 @@ li {
   text-decoration: none;
   cursor: pointer;
   align-items: center;
-  background-color: #fff;
-  border: 1px solid #e8e8e8;
+  background-color: var(--c-bg);
+  border: 1px solid var(--c-border-plain);
   border-radius: 36px;
   box-sizing: border-box;
-  color: #111;
+  color: var(--c-text-1);
   display: inline-flex;
   font-size: 13px;
   height: 36px;
@@ -296,13 +296,13 @@ li {
 }
 
 .recommend-desc {
-  color: #555;
+  color: var(--c-text-mid-2);
   font-size: 14px;
   line-height: 1.9;
 }
 
 .recommend-desc2 {
-  color: #555;
+  color: var(--c-text-mid-2);
   font-size: 14px;
   line-height: 1.9;
 }
@@ -327,7 +327,7 @@ section aside:hover {
 }
 
 .list-title {
-  color: #111;
+  color: var(--c-text-1);
   font-size: 15px;
   margin-bottom: 6px;
   display: flex;
@@ -344,7 +344,7 @@ section aside:hover {
 .list-aside details {
   margin: 0;
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
   font-weight: normal;
 }
 
@@ -362,7 +362,7 @@ section aside:hover {
 
 .list-aside-desc {
   font-size: 13px;
-  color: #555;
+  color: var(--c-text-mid-2);
   display: block;
 }
 
@@ -373,7 +373,7 @@ section aside:hover {
   display: inline-block;
   fill: currentcolor;
   flex-shrink: 0;
-  color: rgb(7, 181, 59);
+  color: var(--c-up);
   font-size: 11px;
   margin: -1px -4px;
 }
@@ -393,8 +393,8 @@ section aside:hover {
   content: '';
   width: 6px;
   height: 6px;
-  border-top: 1px solid #111;
-  border-right: 1px solid #111;
+  border-top: 1px solid var(--c-text-1);
+  border-right: 1px solid var(--c-text-1);
   transform: rotate(135deg);
   margin-bottom: 3px;
 }
@@ -404,22 +404,22 @@ section aside:hover {
   display: flex;
   gap: 8px;
   font-size: 12px;
-  color: #888;
+  color: var(--c-text-mid-3);
 }
 
 .diff-member div {
   padding: 2px 4px;
-  border: 1px solid #efefef;
+  border: 1px solid var(--c-border);
   border-radius: 4px;
 }
 
 .app_link a {
   font-size: 13px;
-  color: #777;
+  color: var(--c-text-3);
 }
 
 .recommend-header-desc-text {
-  color: #111;
+  color: var(--c-text-1);
   font-size: 18px;
   white-space: unset;
   font-weight: bold;
@@ -441,7 +441,7 @@ section aside:hover {
 .hr-top.recommend {
   all: unset;
   display: block;
-  border-bottom: 1px solid #efefef;
+  border-bottom: 1px solid var(--c-border);
   margin: 0 auto;
   margin-bottom: 1px;
   padding: 1px 0;
@@ -466,7 +466,7 @@ section aside:hover {
   }
 
   .recommend-header h2 {
-    color: #111;
+    color: var(--c-text-1);
     line-height: 1.5;
     font-size: 21px;
   }
@@ -565,7 +565,7 @@ section aside:hover {
   font-weight: 400;
   line-height: 1.7;
   letter-spacing: 0.005em;
-  color: #6b7178;
+  color: var(--c-rg-text);
 }
 
 @media screen and (min-width: 512px) {
@@ -580,7 +580,7 @@ section aside:hover {
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #9aa0a6;
+  color: var(--c-rg-muted);
   padding: 2px 0 2px 2px;
 }
 
@@ -588,17 +588,17 @@ section aside:hover {
 /* サーバー側でインラインSVGを生成するため JS/Webフォント不要・高さ固定/img は width&height 明示で CLSなし。 */
 /* 順位改善=緑(#06c755) / 悪化=赤橙(#e8553e) / 横ばい=灰(#9aa0a6)。数値は等幅で誠実に揃える。       */
 .recommend-growth {
-  --rg-color: #9aa0a6;
+  --rg-color: var(--c-rg-muted);
   /* 方向色(ヒーロー方向クラスで上書き)。淡い色味も同時に持たせて装飾に使う。 */
   display: block;
   position: relative;
   margin: 12px 1rem 4px;
   padding: 11px 14px 11px;
-  border: 1px solid #eceff3;
+  border: 1px solid var(--c-rg-border);
   border-radius: 14px;
-  background: #fff;
+  background: var(--c-bg);
   /* 白地に白で同化しないよう、極薄2枚のシャドウで唯一の"箱"として持ち上げる(主役化)。 */
-  box-shadow: 0 1px 2px rgba(20, 22, 26, 0.04), 0 4px 16px rgba(20, 22, 26, 0.05);
+  box-shadow: var(--c-rg-shadow);
   overflow: hidden;
   /* 統計の信頼感: 数字は等幅(tabular)で桁を揃える。 */
   font-variant-numeric: tabular-nums;
@@ -638,13 +638,13 @@ section aside:hover {
 /* 2つのアイコンをわずかに重ねて「LINE×オプチャ」のアプリ・ロックアップに見せる。 */
 .recommend-growth__brandimg--oc {
   margin-left: -5px;
-  box-shadow: -1px 0 0 0 #fff, 0 0 0 1.5px #fff;
+  box-shadow: -1px 0 0 0 var(--c-bg), 0 0 0 1.5px var(--c-bg);
 }
 
 .recommend-growth__brandtext {
   font-size: 12px;
   font-weight: 700;
-  color: #2b2f36;
+  color: var(--c-rg-text-strong);
   letter-spacing: 0.01em;
   white-space: nowrap;
   overflow: hidden;
@@ -656,7 +656,7 @@ section aside:hover {
   margin: 0 0 1px;
   font-size: 16px;
   font-weight: 800;
-  color: #1f2328;
+  color: var(--c-rg-text-heading);
   letter-spacing: 0.01em;
   line-height: 1.25;
 }
@@ -666,7 +666,7 @@ section aside:hover {
   margin: 0 0 10px;
   font-size: 11px;
   font-weight: 500;
-  color: #7b828b;
+  color: var(--c-rg-text-soft);
   letter-spacing: 0.02em;
   line-height: 1.4;
 }
@@ -677,7 +677,7 @@ section aside:hover {
   font-size: 13px;
   font-weight: 600;
   line-height: 1.55;
-  color: #2b2f36;
+  color: var(--c-rg-text-strong);
 }
 
 /* どの部屋の話か: 最高順位を持つ部屋への小さなリンク(サムネ+名前+順位+人数)。 */
@@ -687,17 +687,17 @@ section aside:hover {
   gap: 9px;
   margin-top: 11px;
   padding: 7px 9px;
-  border: 1px solid #e7eaee;
+  border: 1px solid var(--c-rg-line);
   border-radius: 11px;
-  background: #f7f8fa;
+  background: var(--c-rg-surface);
   text-decoration: none;
   color: inherit;
   -webkit-tap-highlight-color: transparent;
 }
 
 .recommend-growth__leader:hover {
-  background: #eef6f0;
-  border-color: #cfe9d9;
+  background: var(--c-rg-green-bg);
+  border-color: var(--c-rg-green-border);
 }
 
 .recommend-growth__leader-img {
@@ -706,7 +706,7 @@ section aside:hover {
   height: 36px;
   border-radius: 8px;
   object-fit: cover;
-  background: #e7eaee;
+  background: var(--c-rg-line);
 }
 
 .recommend-growth__leader-body {
@@ -720,7 +720,7 @@ section aside:hover {
 .recommend-growth__leader-name {
   font-size: 12.5px;
   font-weight: 700;
-  color: #2b2f36;
+  color: var(--c-rg-text-strong);
   line-height: 1.35;
   white-space: nowrap;
   overflow: hidden;
@@ -730,7 +730,7 @@ section aside:hover {
 .recommend-growth__leader-meta {
   font-size: 11px;
   font-weight: 600;
-  color: #777e87;
+  color: var(--c-rg-text-mid);
   line-height: 1.3;
 }
 
@@ -738,7 +738,7 @@ section aside:hover {
   flex-shrink: 0;
   font-size: 18px;
   font-weight: 700;
-  color: var(--rg-color, #9aa0a6);
+  color: var(--rg-color, var(--c-rg-muted));
   line-height: 1;
   transition: transform 140ms ease;
 }
@@ -757,7 +757,7 @@ section aside:hover {
   margin-top: 4px;
   font-size: 10.5px;
   font-weight: 600;
-  color: #9aa0a6;
+  color: var(--c-rg-muted);
   letter-spacing: 0.02em;
 }
 

--- a/public/style/pages/terms.css
+++ b/public/style/pages/terms.css
@@ -1,5 +1,5 @@
 main {
-  color: #616161;
+  color: var(--c-text-mid);
   max-width: 812px;
   margin: auto;
 }
@@ -28,7 +28,7 @@ h1 {
   letter-spacing: 0.1em;
   margin: 0;
   text-align: center;
-  color: #333;
+  color: var(--c-text-2);
   font-size: 21px;
 }
 
@@ -48,11 +48,11 @@ h1 {
   font-weight: 700;
   line-height: 1.5;
   outline: 0;
-  color: #333;
+  color: var(--c-text-2);
 }
 
 .terms section h3 {
-  color: #333;
+  color: var(--c-text-2);
   margin-top: 2.5rem;
   font-size: 18px;
 }
@@ -66,20 +66,20 @@ h1 {
 }
 
 #comment-root .MuiPaper-outlined.MuiPaper-rounded {
-  border: 1px solid rgb(207, 217, 222);
+  border: 1px solid var(--c-border-3);
 }
 
 #comment-root .comment-term-text-color {
-  color: #b7b7b7;
+  color: var(--c-text-5);
 }
 
 .terms .ranking-readMore {
-  color: #333;
+  color: var(--c-text-2);
 }
 
 .terms .ranking-readMore::after {
-  border-top: 1px solid #333;
-  border-right: 1px solid #333;
+  border-top: 1px solid var(--c-text-2);
+  border-right: 1px solid var(--c-text-2);
   margin-bottom: 2px;
 }
 
@@ -88,6 +88,6 @@ h1 {
   width: 87.5%;
   margin: auto;
   margin-bottom: 2rem;
-  box-shadow: 1px 3px 15px -5px #777;
+  box-shadow: 1px 3px 15px -5px var(--c-shadow-3);
   border-radius: 4px;
 }

--- a/public/style/tokens.css
+++ b/public/style/tokens.css
@@ -188,6 +188,35 @@
   --c-grad-blue-btn: linear-gradient(135deg, #7eb8ff, #3a7bd5);
   --c-grad-orange-btn: linear-gradient(135deg, #ffa751, #e85d04);
 
+  /* ブログ系 */
+  --c-green-pale: #e2f6ea;           /* パンくず hover */
+  --c-green-underline: #a8e6c2;      /* リンク下線 */
+  --c-green-text-deep: #235f3e;      /* 引用ブロック文字 */
+  --c-text-silver: #c5c9ce;          /* パンくず区切り */
+  --c-blog-icon-border: #bfe7cd;     /* 記事アイコンの淡緑枠（統合候補: --c-chip-hot-border） */
+  --c-brand-shadow: rgba(6, 199, 85, 0.28);
+  --c-brand-shadow-soft: rgba(6, 199, 85, 0.09);
+  --c-brand-shadow-soft-2: rgba(6, 199, 85, 0.1);
+  --c-ink-shadow: rgba(17, 17, 17, 0.03);
+  --c-shadow-3: #777;                /* terms カードのぼかし影 */
+  --c-border-plain-2: #e6e6e6;       /* labs フォーム枠（統合候補: --c-border-plain） */
+  --c-border-mid: #ccc;              /* 管理プレビュー枠 */
+  --c-text-mid-3: #888;              /* 統合候補: --c-text-3 */
+
+  /* recommend グループUI（--c-rg-*） */
+  --c-rg-text-strong: #2b2f36;
+  --c-rg-text-heading: #1f2328;
+  --c-rg-text: #6b7178;
+  --c-rg-text-soft: #7b828b;
+  --c-rg-text-mid: #777e87;
+  --c-rg-muted: #9aa0a6;
+  --c-rg-border: #eceff3;
+  --c-rg-line: #e7eaee;              /* 枠と淡面の兼用 */
+  --c-rg-surface: #f7f8fa;
+  --c-rg-green-bg: #eef6f0;
+  --c-rg-green-border: #cfe9d9;
+  --c-rg-shadow: 0 1px 2px rgba(20, 22, 26, 0.04), 0 4px 16px rgba(20, 22, 26, 0.05);
+
   /* テーマチップ（hot・緑系） */
   --c-chip-hot-text: #067a37;
   --c-chip-hot-bg: #eefcf3;
@@ -201,4 +230,39 @@
   --c-legacy-table: #118bee;             /* テーブルヘッダ青 */
   --c-legacy-secondary: #920de9;         /* aside 縁・sup 背景の紫 */
   --c-legacy-secondary-accent: #920de90b;
+}
+
+/* ------------------------------------------------------------
+   入室確認ページ（/oc/{id}/jump）の名前空間トークン --ocj-*
+   「公式の安全確認ゲート」: 紙色背景 + 警告=琥珀 / 行動=LINEグリーン。
+   定義は oc-jump.css から移設（半径・影トークンも色と同様にここで管理）。
+   ------------------------------------------------------------ */
+:root {
+  --ocj-bg: #f6f5f3;
+  --ocj-bg-dim: #efeded;
+  --ocj-bg-dim-2: #f3f2ef;
+  --ocj-card: #ffffff;
+  --ocj-card-soft: #faf9f7;
+  --ocj-border: #e9e7e3;
+  --ocj-border-soft: #efedea;
+  --ocj-border-faint: #f0eeea;
+  --ocj-ink: #1c1b19;
+  --ocj-ink-strong: #2c2a27;
+  --ocj-ink-soft: #5c5953;
+  --ocj-ink-mute: #8a857d;
+  --ocj-amber: #d98a00;
+  --ocj-amber-deep: #8a5800;
+  --ocj-amber-soft-text: #9a7320;
+  --ocj-amber-bg: #fdf6e8;
+  --ocj-amber-line: #f0d9a8;
+  --ocj-line-green: var(--green-line);
+  --ocj-line-green-press: #05a647;
+  --ocj-green-bg: #eef7f0;
+  --ocj-green-text: #1f9d54;
+  --ocj-radius: 14px;
+  --ocj-radius-sm: 10px;
+  --ocj-shadow: 0 1px 2px rgba(28, 27, 25, 0.04), 0 6px 18px rgba(28, 27, 25, 0.05);
+  --ocj-shadow-btn: 0 6px 16px rgba(6, 199, 85, 0.32);
+  --ocj-shadow-btn-hover: 0 8px 20px rgba(6, 199, 85, 0.38);
+  --ocj-shadow-btn-press: 0 3px 10px rgba(6, 199, 85, 0.3);
 }

--- a/scripts/check-css-colors.sh
+++ b/scripts/check-css-colors.sh
@@ -45,6 +45,10 @@ MIGRATED=(
   public/style/pages/room_page.css
   public/style/pages/graph_page.css
   public/style/pages/live_ana.css
+  public/style/pages/recommend_page.css
+  public/style/pages/blog.css
+  public/style/pages/oc-jump.css
+  public/style/pages/terms.css
   app/Views/components/head.php
   app/Views/components/oc_head.php
   app/Views/components/policy_head.php
@@ -59,7 +63,7 @@ for f in "${MIGRATED[@]}"; do
     fail=1
     continue
   fi
-  hits=$(grep -nE "$PATTERN" "$f")
+  hits=$(grep -nE "$PATTERN" "$f" | grep -vE '&#[0-9]+;' || true)
   if [ -n "$hits" ]; then
     echo "✗ $f に生色リテラル:"
     echo "$hits" | head -20 | sed 's/^/    /'
@@ -85,9 +89,9 @@ done < <(grep -rl "style/base/mvp" app/Views --include='*.php')
 
 echo
 echo "== 未移行領域の残数（参考） =="
-css_count=$(grep -roE "$PATTERN" public/style --include='*.css' 2>/dev/null | grep -cv '^public/style/tokens\.css:' || true)
-views_count=$(grep -roE "$PATTERN" app/Views --include='*.php' 2>/dev/null | grep -cv '^app/Views/admin/' || true)
-frontend_count=$(grep -roE "$PATTERN" frontend/*/src --include='*.ts' --include='*.tsx' --include='*.css' 2>/dev/null | grep -cvE '/(theme|themeColors)[^/]*\.ts:' || true)
+css_count=$(grep -rnE "$PATTERN" public/style --include='*.css' 2>/dev/null | grep -v '^public/style/tokens\.css:' | grep -vE '&#[0-9]+;' | wc -l)
+views_count=$(grep -rnE "$PATTERN" app/Views --include='*.php' 2>/dev/null | grep -v '^app/Views/admin/' | grep -vE '&#[0-9]+;' | wc -l)
+frontend_count=$(grep -rnE "$PATTERN" frontend/*/src --include='*.ts' --include='*.tsx' --include='*.css' 2>/dev/null | grep -vE '/(theme|themeColors)[^/]*\.ts:' | wc -l)
 printf '  %-32s %s件\n' "public/style (tokens.css除く):" "$css_count"
 printf '  %-32s %s件\n' "app/Views (admin除く):" "$views_count"
 printf '  %-32s %s件\n' "frontend src (theme系除く):" "$frontend_count"


### PR DESCRIPTION
## 概要

ダークモード導入プロジェクトの第6弾（#334〜#338 の続き）。コンテンツ系ページのCSSと、公開テンプレート全体に散らばっていたインライン色指定を一掃します。**見た目は一切変わりません**。これで PHP/CSS 側の色移行が完了し、残るは React 系のみになります。

## 変更内容

1. **recommend_page / blog / oc-jump / terms の4CSSをトークン化**
   - blog のローカル変数（`--g` 等）は値が全て共通トークンと同一だったため参照エイリアス化
   - 入室確認ページの `--ocj-*` トークン定義を tokens.css へ移設（名前空間ごと一元管理）
   - recommend グループUIのクールグレー系を `--c-rg-*` として体系化
2. **公開テンプレート約30ファイル・約70箇所の `style=` 属性/小規模 `<style>` の色を一掃**（app/Views の残数 **74→0件**）
   - PHP の三項演算子で色を出し分ける2箇所（タグ統計の増減色・成長チャート）は var() 文字列出力に変更
   - 成長チャートのSVGは `stop-color`/`stroke` を属性→style属性に変更（属性値では CSS変数が効かないため。描画は同一でcomputed-style比較でも検証済み）
3. **検査スクリプト改善**: HTML実体参照（`&#10005;`）の誤検知除外。なお「同一行に var() と生色が共存」する取りこぼし3件をこのスクリプト自身が検出→修正済み（ゲートとして機能）

## 検証

- トップ / おすすめタグ / ブログ / 入室確認 / ポリシー / labs の全DOM computed-style before/after 比較 → **全ページ差分0行**
- `make css-check`: 移行済み22ファイルクリーン。**残る生色は React 系のみ**（react/*.css 51件・frontend src 63件 = 第7弾）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
