### PR TITLE
React部分の配色を一元管理化（見た目の変更なし・ダークモード準備 第7弾完結）

### DIFF
--- a/frontend/oc-app/src/comments/components/Button/ImageReportButton.tsx
+++ b/frontend/oc-app/src/comments/components/Button/ImageReportButton.tsx
@@ -15,13 +15,13 @@ export default memo(function ImageReportButton({ imageId, commentNo }: { imageId
       variant="text"
       onClick={onClick}
       sx={{
-        color: 'rgba(255,255,255,0.7)',
+        color: 'var(--c-overlay-text)',
         fontSize: '14px',
         fontWeight: 500,
         padding: '6px 12px',
         borderRadius: '4px',
-        backgroundColor: 'rgba(255,255,255,0.15)',
-        '&:hover': { backgroundColor: 'rgba(255,255,255,0.25)', color: '#fff' },
+        backgroundColor: 'var(--c-overlay-btn)',
+        '&:hover': { backgroundColor: 'var(--c-overlay-btn-hover)', color: 'var(--c-text-inverse)' },
         minWidth: 0,
       }}
     >

--- a/frontend/oc-app/src/comments/components/Button/LikeButtonUi.tsx
+++ b/frontend/oc-app/src/comments/components/Button/LikeButtonUi.tsx
@@ -34,7 +34,7 @@ function Btn(props: BtnProps) {
       color="error"
       onClick={() => handler(type)}
       disabled={disabled}
-      sx={{ border: '1px solid #efefef', minHeight: '28px' }}
+      sx={{ border: '1px solid var(--c-border)', minHeight: '28px' }}
     >
       <Stack gap="2px" direction="row" alignItems="center">
         <Stack direction="row" alignItems="center" gap={'4px'}>

--- a/frontend/oc-app/src/comments/components/CommentImageGallery.tsx
+++ b/frontend/oc-app/src/comments/components/CommentImageGallery.tsx
@@ -127,7 +127,7 @@ export default function CommentImageGallery({ images, posterName, commentNo, isO
               objectFit: 'cover',
               borderRadius: 1,
               cursor: 'pointer',
-              border: '1px solid #e0e0e0',
+              border: '1px solid var(--c-border-gray)',
               '&:hover': { opacity: 0.85 },
             }}
           />

--- a/frontend/oc-app/src/comments/components/CommentListChildren/CommentItem.tsx
+++ b/frontend/oc-app/src/comments/components/CommentListChildren/CommentItem.tsx
@@ -51,7 +51,7 @@ export default memo(function CommentItem(props: CommentItemApi & LikeBtnApi & { 
               wordBreak: 'break-all',
               whiteSpace: 'pre-line',
               fontSize: '15px',
-              color: text.length ? undefined : '#aaa',
+              color: text.length ? undefined : 'var(--c-text-4)',
             }}
           >
             {text.length ? linkify(text.replace(/(\r?\n|\r){3,}/g, '\n\n')) : '削除されたコメント😇'}

--- a/frontend/oc-app/src/comments/components/GradientCircularProgress.tsx
+++ b/frontend/oc-app/src/comments/components/GradientCircularProgress.tsx
@@ -6,8 +6,8 @@ export default function GradientCircularProgress({ margin = 'auto' }: { margin?:
       <svg width={0} height={0}>
         <defs>
           <linearGradient id="my_gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor="#e01cd5" />
-            <stop offset="100%" stopColor="#1CB5E0" />
+            <stop offset="0%" style={{ stopColor: 'var(--c-spinner-grad-1)' }} />
+            <stop offset="100%" style={{ stopColor: 'var(--c-spinner-grad-2)' }} />
           </linearGradient>
         </defs>
       </svg>

--- a/frontend/oc-app/src/comments/components/ImageAttachmentInput.tsx
+++ b/frontend/oc-app/src/comments/components/ImageAttachmentInput.tsx
@@ -204,8 +204,8 @@ export default function ImageAttachmentInput() {
 
   const badgeSx = {
     '& .MuiBadge-badge': {
-      bgcolor: 'rgba(0,0,0,0.6)',
-      color: '#fff',
+      bgcolor: 'var(--c-overlay-60)',
+      color: 'var(--c-text-inverse)',
       width: 20,
       height: 20,
       minWidth: 20,
@@ -226,7 +226,7 @@ export default function ImageAttachmentInput() {
           gap: 1,
           flexWrap: 'wrap',
           p: totalCount > 0 ? 1 : 0,
-          border: dragOver ? '2px dashed #1976d2' : totalCount > 0 ? '1px solid #e0e0e0' : 'none',
+          border: dragOver ? '2px dashed var(--c-mui-blue)' : totalCount > 0 ? '1px solid var(--c-border-gray)' : 'none',
           borderRadius: 1,
           transition: 'border 0.2s',
         }}

--- a/frontend/oc-app/src/comments/utils/linkify.tsx
+++ b/frontend/oc-app/src/comments/utils/linkify.tsx
@@ -6,7 +6,7 @@ export function linkify(text: string): ReactNode[] {
   const parts = text.split(URL_REGEX)
   return parts.map((part, i) =>
     URL_REGEX.test(part) ? (
-      <a key={i} href={part} target="_blank" rel="noopener noreferrer" style={{ color: '#111' }}>
+      <a key={i} href={part} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--c-text-1)' }}>
         {part}
       </a>
     ) : (

--- a/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
+++ b/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
@@ -60,7 +60,7 @@ export default function ChartLimitBtns() {
   return (
     <>
       <Box
-        sx={{ borderBottom: 1, borderColor: '#efefef', width: '100%' }}
+        sx={{ borderBottom: 1, borderColor: 'var(--c-border)', width: '100%' }}
         className="limit-btns category-tab"
       >
         <Tabs onChange={handleChange} variant="fullWidth" value={limit}>

--- a/frontend/oc-app/src/graph/components/ToggleButtons.tsx
+++ b/frontend/oc-app/src/graph/components/ToggleButtons.tsx
@@ -97,7 +97,7 @@ export default function ToggleButtons() {
         alignItems="center"
         justifyContent={isPc ? 'space-around' : 'space-between'}
       >
-        <Typography variant="h3" fontSize="13px" fontWeight="bold" color="#111">
+        <Typography variant="h3" fontSize="13px" fontWeight="bold" color="var(--c-text-1)">
           {t('ランキングの順位を表示')}
         </Typography>
         {limit === 0 && !isPc && <SwitchLabels />}

--- a/frontend/ranking/src/components/CategoryListAppBar.tsx
+++ b/frontend/ranking/src/components/CategoryListAppBar.tsx
@@ -86,9 +86,9 @@ export const CategoryListAppBar = memo(function HideListAppBar() {
             zIndex: 1000,
             top: matches ? 'auto' : '78px',
             borderBottom: 1,
-            borderColor: '#efefef',
+            borderColor: 'var(--c-border)',
             position: matches ? 'static' : 'fixed',
-            background: 'rgba(255,255,255,1)',
+            background: 'var(--c-bg)',
             width: '100%',
           }}
         >

--- a/frontend/ranking/src/components/OCListDescPopover.tsx
+++ b/frontend/ranking/src/components/OCListDescPopover.tsx
@@ -6,7 +6,7 @@ import { Box, IconButton, useMediaQuery } from '@mui/material'
 export function HelpIcon() {
   const matches = useMediaQuery('(min-width:600px)') // 599px以下で false
   return (
-    <HelpOutlineIcon sx={{ color: 'rgba(0, 0, 0, 0.12)', fontSize: matches ? '24px' : '22px' }} />
+    <HelpOutlineIcon sx={{ color: 'var(--c-icon-ghost)', fontSize: matches ? '24px' : '22px' }} />
   )
 }
 

--- a/frontend/ranking/src/components/OCListSortMenu.tsx
+++ b/frontend/ranking/src/components/OCListSortMenu.tsx
@@ -60,10 +60,10 @@ export const OCListSortMenu = memo(function OCListSortMenu({
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClickListItem}
-        sx={{ fontSize: under359 ? '12.5px' : '14px', color: '#000', minWidth: 36, minHeight: 36 }}
+        sx={{ fontSize: under359 ? '12.5px' : '14px', color: 'var(--c-text-black)', minWidth: 36, minHeight: 36 }}
         color="success"
       >
-        {!under359 && <SortIcon sx={{ marginRight: '4px', fontSize: '20px', color: '#000' }} />}
+        {!under359 && <SortIcon sx={{ marginRight: '4px', fontSize: '20px', color: 'var(--c-text-black)' }} />}
         {isSP() || under359 ? `${options[selectedIndex][0][1]}` : options[selectedIndex][0][0]}
       </Button>
       <Menu

--- a/frontend/ranking/src/components/OcListMainTabsVertical.tsx
+++ b/frontend/ranking/src/components/OcListMainTabsVertical.tsx
@@ -99,7 +99,7 @@ export default function OcListMainTabsVertical({ cateIndex }: { cateIndex: numbe
           width: `calc(100% - ${tabsWidth}px)`,
           borderLeft: 1,
           borderRight: 1,
-          borderColor: '#efefef',
+          borderColor: 'var(--c-border)',
           minHeight: '100vh',
         }}
       >

--- a/frontend/ranking/src/components/OpenChatListItem.tsx
+++ b/frontend/ranking/src/components/OpenChatListItem.tsx
@@ -91,7 +91,7 @@ export default function OpenChatListItem({
           {name}
         </a>
         {showNorth && (
-          <NorthIcon className="show-north" sx={{ fontSize: '14px', color: '#07B53B' }} />
+          <NorthIcon className="show-north" sx={{ fontSize: '14px', color: 'var(--c-up)' }} />
         )}
       </h3>
       <p className="item-desc">{desc}</p>

--- a/frontend/ranking/src/components/RecommendThemeShelf.tsx
+++ b/frontend/ranking/src/components/RecommendThemeShelf.tsx
@@ -65,14 +65,14 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf() {
           gap: 6,
           fontSize: 13,
           fontWeight: 800,
-          color: '#06a34a',
+          color: 'var(--c-green-shelf)',
           marginBottom: 8,
           letterSpacing: '0.02em',
         }}
       >
         <span
           aria-hidden="true"
-          style={{ flex: '0 0 auto', width: 3, height: 14, background: '#06c755', borderRadius: 2 }}
+          style={{ flex: '0 0 auto', width: 3, height: 14, background: 'var(--c-brand)', borderRadius: 2 }}
         />
         {t('関連テーマ')}
         <span aria-hidden="true" style={{ fontSize: 12 }}>✨</span>
@@ -114,7 +114,7 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf() {
               height: '100%',
               width: 36,
               pointerEvents: 'none',
-              background: 'linear-gradient(270deg, #fff 35%, rgba(255,255,255,0) 100%)',
+              background: 'linear-gradient(270deg, var(--c-bg) 35%, var(--c-bg-fade-end) 100%)',
             }}
           />
         )}

--- a/frontend/ranking/src/components/SiteHeader.tsx
+++ b/frontend/ranking/src/components/SiteHeader.tsx
@@ -12,14 +12,14 @@ export function BetaIcon() {
         fontWeight: 'normal',
         display: 'inline-flex',
         alignItems: 'center',
-        color: '#000',
+        color: 'var(--c-text-black)',
         position: 'relative',
         height: '8px',
         width: '8px',
       }}
     >
       <SvgIcon
-        sx={{ fill: '#777', fontSize: '14px', top: '-2px', left: '-6px', position: 'absolute' }}
+        sx={{ fill: 'var(--c-text-3)', fontSize: '14px', top: '-2px', left: '-6px', position: 'absolute' }}
       >
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 847 847" style={{ rotate: '17deg' }}>
           <path d="M284 796c9 15 5 34-10 43-15 10-34 5-44-10-17-29-42-247-36-451 3-133 18-262 54-335 31-62 290-60 323 56 14 49-15 87-55 109 77 28 148 86 137 176-19 149-209 194-332 173-17-3-29-20-26-37s20-29 37-26c85 15 244-8 258-117 14-115-232-134-263-133s-33-64 0-63c34 0 199-9 183-64-19-67-161-52-210-35-28 66-40 180-43 297-5 194 13 394 27 417z" />

--- a/frontend/ranking/src/components/SiteHeaderSearch.tsx
+++ b/frontend/ranking/src/components/SiteHeaderSearch.tsx
@@ -109,7 +109,7 @@ export default function SiteHeaderSearch({
                 sx={{ position: 'absolute', right: '5px', top: '7px', zIndex: 2004 }}
                 onClick={deleteInput}
               >
-                <HighlightOffIcon sx={{ fontSize: '22px', color: '#777' }} />
+                <HighlightOffIcon sx={{ fontSize: '22px', color: 'var(--c-text-3)' }} />
               </IconButton>
             )}
           </Box>

--- a/frontend/ranking/src/components/SiteHeaderVerticalSearch.tsx
+++ b/frontend/ranking/src/components/SiteHeaderVerticalSearch.tsx
@@ -57,9 +57,9 @@ export default function SiteHeaderVerticalSearch() {
             method="GET"
             action={`${rankingArgDto.baseUrl}/search`}
             style={{
-              background: '#fff',
+              background: 'var(--c-bg)',
               padding: '0.5rem',
-              boxShadow: 'rgba(0, 0, 0, 0.3) 0px 3px 8px',
+              boxShadow: 'var(--c-shadow-strong) 0px 3px 8px',
               borderRadius: '4px',
               position: 'absolute',
               width: '300px',
@@ -95,7 +95,7 @@ export default function SiteHeaderVerticalSearch() {
                   sx={{ position: 'absolute', right: '5px', top: '0px', zIndex: 2004 }}
                   onClick={deleteInput}
                 >
-                  <HighlightOffIcon sx={{ fontSize: '22px', color: '#777' }} />
+                  <HighlightOffIcon sx={{ fontSize: '22px', color: 'var(--c-text-3)' }} />
                 </IconButton>
               )}
             </Box>

--- a/frontend/ranking/src/components/SubCategoryChips.tsx
+++ b/frontend/ranking/src/components/SubCategoryChips.tsx
@@ -42,7 +42,7 @@ const Chips = memo(function Chips({
           fontFamily: 'var(--font-family, sans-serif)',
           fontSize: '12px',
           fontWeight: 700,
-          color: '#5b6573',
+          color: 'var(--c-cool-text)',
           whiteSpace: 'nowrap',
           paddingRight: '2px',
         }}
@@ -76,7 +76,7 @@ const chevronBradientBoxSx = (gradientDeg: number) => ({
   position: 'absolute',
   zIndex: 1155,
   top: 0,
-  background: `linear-gradient(${gradientDeg}deg, rgba(255,255,255,1) 55%, rgba(0,0,0,0) 100%)`,
+  background: `linear-gradient(${gradientDeg}deg, var(--c-bg) 55%, transparent 100%)`,
 })
 
 const buttonSx = { minWidth: 40, minHeight: 48 }
@@ -140,7 +140,7 @@ const gradientBoxSx = {
   minWidth: 52,
   minHeight: 43,
   right: 0,
-  background: 'linear-gradient(270deg, rgba(255,255,255,0.93) 50%, rgba(0,0,0,0) 100%)',
+  background: 'linear-gradient(270deg, var(--c-bg-93) 50%, transparent 100%)',
 }
 
 function SubCategoryChipsSP2(props: SubCategoryChipsProps) {

--- a/public/style/react/OpenChat.css
+++ b/public/style/react/OpenChat.css
@@ -38,15 +38,15 @@
 }
 
 .show-north {
-  color: #07b53b;
+  color: var(--c-up);
 }
 
 .stats-wrapper.positive {
-  color: #4d73ff;
+  color: var(--c-accent-blue);
 }
 
 .stats-wrapper.negative {
-  color: #ff5d6d;
+  color: var(--c-down);
 }
 
 .visually-hidden {
@@ -64,36 +64,36 @@
 }
 
 .MuiTabs-root.category-tab {
-  border-color: #efefef;
+  border-color: var(--c-border);
   min-height: 39px;
 }
 
 .category-tab .MuiTab-root.MuiTab-textColorPrimary {
   font-weight: 700;
-  color: #aaa;
+  color: var(--c-text-4);
   min-height: 39px;
   padding: 0 16px;
 }
 
 .category-tab-pc .MuiTab-root.MuiTab-textColorPrimary {
-  color: rgba(0, 0, 0, 0.47);
+  color: var(--c-text-soft-black);
 }
 
 .category-tab .MuiButtonBase-root.Mui-selected {
   font-weight: 700;
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .category-tab-pc .MuiButtonBase-root.Mui-selected {
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .category-tab .MuiTabs-indicator {
-  background-color: #111;
+  background-color: var(--c-text-1);
 }
 
 .category-tab-pc .MuiTabs-indicator {
-  background-color: #111;
+  background-color: var(--c-text-1);
   width: 3px;
 }
 
@@ -108,8 +108,8 @@
 }
 
 .MuiChip-root.openchat-item-header-chip {
-  background-color: #f5f5f5;
-  color: #111;
+  background-color: var(--c-surface);
+  color: var(--c-text-1);
   user-select: none;
   font-weight: 500;
   font-size: 14px;
@@ -125,13 +125,13 @@
 }
 
 .MuiChip-root.openchat-item-header-chip.category:hover {
-  background-color: #f5f5f5;
+  background-color: var(--c-surface);
 }
 
 /* 急上昇テーマ送客チップ（/ranking → /recommend）。形は既存 .category と共通（角丸8px）で、色だけ緑にしてサブカテゴリ絞り込みと区別する。-webkit-user-drag でリンクのネイティブドラッグを抑止（ドラッグ横スクロールを邪魔しない）。 */
 .MuiChip-root.openchat-item-header-chip.theme-link {
-  background-color: #eefcf3;
-  color: #067a37;
+  background-color: var(--c-chip-hot-bg);
+  color: var(--c-chip-hot-text);
   font-weight: 700;
   font-size: 14px;
   height: 32px;
@@ -140,21 +140,21 @@
 }
 
 .MuiChip-root.openchat-item-header-chip.theme-link:hover {
-  background-color: #e2f9ea;
+  background-color: var(--c-chip-hot-bg-hover);
 }
 
 .MuiChip-root.openchat-item-header-chip.selected {
-  background-color: #1f1f1f;
-  color: #fff;
+  background-color: var(--c-chip-dark);
+  color: var(--c-text-inverse);
 }
 
 .MuiChip-root.openchat-item-header-chip.selected:hover {
-  background-color: #1f1f1f;
-  color: #fff;
+  background-color: var(--c-chip-dark);
+  color: var(--c-text-inverse);
 }
 
 .MuiChip-root.openchat-item-header-chip .MuiChip-deleteIcon {
-  color: rgba(255, 255, 255, 1);
+  color: var(--c-text-inverse);
 }
 
 .fix-min-width .MuiTabs-scroller a {
@@ -163,11 +163,11 @@
 
 @media screen and (width >=600px) {
   .MuiChip-root.openchat-item-header-chip.category:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--c-shadow);
   }
 
   .MuiChip-root.openchat-item-header-chip.selected:hover {
-    background-color: #1f1f1f;
+    background-color: var(--c-chip-dark);
   }
 }
 

--- a/public/style/react/OpenChatList.css
+++ b/public/style/react/OpenChatList.css
@@ -26,7 +26,7 @@ html {
 
 .record-count {
   font-size: 11px;
-  color: #111;
+  color: var(--c-text-1);
 }
 
 .record-count.middle {
@@ -58,7 +58,7 @@ html {
   margin-right: 1.5rem;
   padding-left: 65px;
   min-height: 58px;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.05);
+  -webkit-tap-highlight-color: var(--c-tap-highlight-weak);
 }
 
 .overlay-link {
@@ -124,7 +124,7 @@ html {
 
 .item-desc {
   all: unset;
-  color: #777;
+  color: var(--c-text-3);
   font-size: 13px;
   line-height: 130%;
   display: -webkit-box;
@@ -145,14 +145,14 @@ html {
 
 .item-lower-stats {
   display: flex;
-  color: #aaa;
+  color: var(--c-text-4);
   font-size: 13px;
   line-height: 1.1rem;
   gap: 12px;
 }
 
 .api-created-at {
-  color: #4d73ff;
+  color: var(--c-accent-blue);
 }
 
 .item-lower-category {
@@ -161,7 +161,7 @@ html {
 }
 
 .item-lower-category .MuiChip-sizeSmall {
-  background-color: #f5f5f5;
+  background-color: var(--c-surface);
   color: RGB(124, 124, 124);
   font-size: 12px;
   border-radius: 4px;
@@ -178,7 +178,7 @@ html {
   left: -7px;
   width: 2px;
   height: 2px;
-  background-color: #aaa;
+  background-color: var(--c-text-4);
 }
 
 @media screen and (width >= 600px) {

--- a/public/style/react/SiteHeader.css
+++ b/public/style/react/SiteHeader.css
@@ -3,16 +3,15 @@
   z-index: 1160;
   left: 0;
   right: 0;
-  background-color: rgba(255, 255, 255, 1);
-  box-shadow: '0 4px 2px -2px rgba(0,0,0,.2)';
+  background-color: var(--c-bg);
 }
 
 .site_header_outer {
   all: unset;
   display: block;
-  --search: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 27' class='search-icon'%3E%3Cpath d='M11.56,3.43a8.26,8.26,0,0,0,0,16.52,8.18,8.18,0,0,0,5-1.72l4.7,4.7a1.1,1.1,0,0,0,1.56,0,1.09,1.09,0,0,0,0-1.55l0,0-4.7-4.7a8.18,8.18,0,0,0,1.72-5A8.28,8.28,0,0,0,11.56,3.43Zm0,2.2A6.06,6.06,0,1,1,5.5,11.69,6,6,0,0,1,11.56,5.63Z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E");
+  /* 色・アイコンは tokens.css（--icon-search / --c-bg-sub）を参照。
+     /ranking は mvp.css を読まないため、レイアウト変数のみローカル定義 */
   --width: 802px;
-  --hover: rgb(250, 250, 250);
   --border-radius: 5px;
 }
 
@@ -70,7 +69,7 @@
     'Helvetica Neue',
     Arial,
     sans-serif;
-  color: #111;
+  color: var(--c-text-1);
   line-height: 1.75;
   letter-spacing: normal;
 }
@@ -78,7 +77,7 @@
 .header_site_title.thi h1,
 .header_site_title.thi p {
   white-space: pre;
-  color: #111;
+  color: var(--c-text-1);
   line-height: 1.3;
   font-size: 13px;
 }
@@ -114,7 +113,7 @@
   margin: auto;
   width: 24px;
   height: 24px;
-  background-image: var(--search);
+  background-image: var(--icon-search);
 }
 
 .search-form {
@@ -135,7 +134,7 @@
   position: absolute;
   width: 20px;
   height: 20px;
-  background-image: var(--search);
+  background-image: var(--icon-search);
 }
 
 .backdrop {
@@ -157,14 +156,14 @@
 .refresh-icon {
   height: 11px;
   aspect-ratio: 1/1;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23b7b7b7' d='M256 0C179.9 0 111.7 33.4 64.9 86.2L0 21.3V192h170.7l-60.2-60.2C145.6 90.5 197.5 64 256 64c106 0 192 85.9 192 192s-86 192-192 192c-53 0-101-21.5-135.8-56.2L75 437c46.4 46.3 110.4 75 181 75 141.4 0 256-114.6 256-256S397.4 0 256 0zm-21.3 106.7v170.7h128v-42.7h-85.3v-128h-42.7z' /%3E%3C/svg%3E");
+  background-image: var(--icon-refresh);
   margin: auto 0;
 }
 
 .refresh-time time {
   margin: auto 0;
   margin-left: 2px;
-  color: #b7b7b7;
+  color: var(--c-text-5);
   font-size: 12px;
   font-family:
     'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
@@ -172,7 +171,7 @@
 }
 
 .MuiInputBase-colorPrimary.search-input:after {
-  border-bottom: 2px solid #4d73ff;
+  border-bottom: 2px solid var(--c-accent-blue);
 }
 
 @media screen and (min-width: 512px) {
@@ -191,7 +190,7 @@ ins.adsbygoogle[data-anchor-status='dismissed'] {
 }
 
 ins.adsbygoogle[data-ad-status='unfilled'] {
-  background: rgb(250, 250, 250);
+  background: var(--c-bg-sub);
   position: relative;
   display: block;
 }
@@ -200,7 +199,7 @@ ins.adsbygoogle[data-ad-status='unfilled']::before {
   display: block;
   content: '広告配信なし';
   font-size: 13px;
-  color: #aaa;
+  color: var(--c-text-4);
   position: absolute;
   top: 50%;
   left: 50%;
@@ -209,34 +208,34 @@ ins.adsbygoogle[data-ad-status='unfilled']::before {
 
 .rectangle-ads {
   aspect-ratio: 21 / 9;
-  background: rgb(250, 250, 250);
+  background: var(--c-bg-sub);
 }
 
 .rectangle2-ads {
   aspect-ratio: 16 / 9;
-  background: rgb(250, 250, 250);
+  background: var(--c-bg-sub);
 }
 
 @media screen and (min-width: 376px) {
   .rectangle-ads {
     aspect-ratio: 1.35;
-    background: rgb(250, 250, 250);
+    background: var(--c-bg-sub);
   }
 
   .rectangle2-ads {
     aspect-ratio: 1.2;
-    background: rgb(250, 250, 250);
+    background: var(--c-bg-sub);
   }
 }
 
 @media screen and (min-width: 512px) {
   .rectangle-ads {
     aspect-ratio: 16 / 9;
-    background: rgb(250, 250, 250);
+    background: var(--c-bg-sub);
   }
 
   .rectangle2-ads {
     aspect-ratio: 16 / 9;
-    background: rgb(250, 250, 250);
+    background: var(--c-bg-sub);
   }
 }

--- a/public/style/tokens.css
+++ b/public/style/tokens.css
@@ -217,6 +217,24 @@
   --c-rg-green-border: #cfe9d9;
   --c-rg-shadow: 0 1px 2px rgba(20, 22, 26, 0.04), 0 4px 16px rgba(20, 22, 26, 0.05);
 
+  /* React UI 系 */
+  --c-tap-highlight-weak: rgba(0, 0, 0, 0.05);
+  --c-text-soft-black: rgba(0, 0, 0, 0.47);   /* 補足テキスト */
+  --c-chip-dark: #1f1f1f;                     /* 選択中チップの黒面 */
+  --c-icon-ghost: rgba(0, 0, 0, 0.12);        /* ヘルプアイコン等の極薄 */
+  --c-shadow-strong: rgba(0, 0, 0, 0.3);      /* 検索オーバーレイの影 */
+  --c-border-gray: #e0e0e0;                   /* 画像添付・ギャラリー枠 */
+  --c-mui-blue: #1976d2;                      /* ドラッグ中の枠（MUI標準青） */
+  --c-green-shelf: #06a34a;                   /* テーマ棚の緑文字（統合候補: --c-btn-blog-text） */
+  --c-overlay-60: rgba(0, 0, 0, 0.6);         /* 画像プレビュー黒幕 */
+  --c-overlay-text: rgba(255, 255, 255, 0.7); /* 黒幕上の白70% */
+  --c-overlay-btn: rgba(255, 255, 255, 0.15);
+  --c-overlay-btn-hover: rgba(255, 255, 255, 0.25);
+  --c-bg-fade-end: rgba(255, 255, 255, 0);        /* 白→透明フェードの終端（ダーク時は背景色側に追従） */
+  --c-bg-93: rgba(255, 255, 255, 0.93);       /* チップ列の白フェード */
+  --c-spinner-grad-1: #e01cd5;                /* グラデスピナー */
+  --c-spinner-grad-2: #1cb5e0;
+
   /* テーマチップ（hot・緑系） */
   --c-chip-hot-text: #067a37;
   --c-chip-hot-bg: #eefcf3;

--- a/scripts/check-css-colors.sh
+++ b/scripts/check-css-colors.sh
@@ -49,6 +49,9 @@ MIGRATED=(
   public/style/pages/blog.css
   public/style/pages/oc-jump.css
   public/style/pages/terms.css
+  public/style/react/SiteHeader.css
+  public/style/react/OpenChatList.css
+  public/style/react/OpenChat.css
   app/Views/components/head.php
   app/Views/components/oc_head.php
   app/Views/components/policy_head.php


### PR DESCRIPTION
## 概要

ダークモード導入プロジェクトの第7弾（#334〜#339 の続き）。React側のCSS・コンポーネント内の色指定をデザイントークンに移行します。**見た目は一切変わりません**。これで**視覚ゼロチェンジのリファクタ工程（第1〜7弾）が完了**し、次からダークモード本体の実装に入ります。

## 変更内容

1. **React用CSS 3ファイルをトークン化**: ローカル定義されていた色変数・検索アイコンURIをグローバルトークンへ統一。引用符付きで常に無効だった `box-shadow` の死に宣言も削除
2. **React コンポーネント19ファイル・約32箇所の sx / inline style 色を `var(--c-*)` 化**（CSS-in-JSはCSS文字列値のためそのまま変数参照可能）
   - SVGの `stopColor` 属性は style 属性方式へ（属性値ではCSS変数が効かないため）
3. **Chart.js の canvas 描画色（34箇所）は意図的に対象外**: canvasにはCSS変数が届かないため、ダーク対応PR（第9弾）で旧実験実装の theme.ts パターンに集約します

## 検証

- /ranking・/oc の computed-style before/after 比較: 差分は sx 文字列変更に伴う **emotion クラス名の改名のみ**で、全要素のスタイル計算値（色10プロパティ）は**完全一致**
- `npm run build`（ranking / oc-app）成功
- `make css-check`: 残る生色は Chart.js canvas 分のみ（CSS 0件 / テンプレート 0件 / frontend 34件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
