### PR TITLE
ダークモードを導入（手動切替＋OS設定連動・第8弾）

### DIFF
--- a/app/Views/admin/admin_confirm_page.php
+++ b/app/Views/admin/admin_confirm_page.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="jp" data-theme="light">
 
 <head>
     <meta charset="UTF-8">

--- a/app/Views/admin/admin_message_page.php
+++ b/app/Views/admin/admin_message_page.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="jp" data-theme="light">
 
 <head>
     <meta charset="UTF-8">

--- a/app/Views/admin/admin_page_template.php
+++ b/app/Views/admin/admin_page_template.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="jp" data-theme="light">
 
 <head>
     <meta charset="UTF-8">

--- a/app/Views/admin/ads_register.php
+++ b/app/Views/admin/ads_register.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="jp" data-theme="light">
 
 <head>
     <meta charset="UTF-8">

--- a/app/Views/admin/dash_my_list.php
+++ b/app/Views/admin/dash_my_list.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="jp" data-theme="light">
 
 <head>
     <meta charset="UTF-8">

--- a/app/Views/admin_comment_images_content.php
+++ b/app/Views/admin_comment_images_content.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="ja" data-theme="light">
 
 <?php
 $_meta = meta();

--- a/app/Views/components/head.php
+++ b/app/Views/components/head.php
@@ -7,6 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
+    <?php /* テーマ確定はCSSより先（FOUC防止のため同期読み込み） */ ?>
+    <script src="<?php echo fileUrl('/js/theme.js', urlRoot: '') ?>"></script>
     <link rel="stylesheet" href="<?php echo fileUrl('style/tokens.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/mvp.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/unset.css', urlRoot: '') ?>">

--- a/app/Views/components/oc_head.php
+++ b/app/Views/components/oc_head.php
@@ -8,6 +8,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
+    <?php /* テーマ確定はCSSより先（FOUC防止のため同期読み込み） */ ?>
+    <script src="<?php echo fileUrl('/js/theme.js', urlRoot: '') ?>"></script>
     <link rel="stylesheet" href="<?php echo fileUrl('style/tokens.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/mvpmin.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/unset.css', urlRoot: '') ?>">

--- a/app/Views/components/policy_head.php
+++ b/app/Views/components/policy_head.php
@@ -7,6 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
+    <?php /* テーマ確定はCSSより先（FOUC防止のため同期読み込み） */ ?>
+    <script src="<?php echo fileUrl('/js/theme.js', urlRoot: '') ?>"></script>
     <link rel="stylesheet" href="<?php echo fileUrl('style/tokens.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/mvpmin.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/unset.css', urlRoot: '') ?>">

--- a/app/Views/components/site_header.php
+++ b/app/Views/components/site_header.php
@@ -21,6 +21,11 @@
             </a>
         </div>
         <nav class="header-nav unset" style="height: 48px;<?php if ($hideSearchButton ?? false) echo ' display: none;' ?>">
+            <?php // ダークモード切替（実装は public/js/theme.js。アイコンの出し分けは site_header.css） ?>
+            <button class="header-button unset theme-toggle-btn" type="button" aria-label="<?php echo t('ダークモード切替') ?>">
+                <svg class="theme-icon-moon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="theme-icon-sun" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            </button>
             <button class="header-button unset" id="search_button" aria-label="><?php echo t('検索') ?>">
                 <span class="search-button-icon"></span>
             </button>

--- a/app/Views/errors/oc_error.php
+++ b/app/Views/errors/oc_error.php
@@ -9,6 +9,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?php echo $_meta ?>
+    <?php /* テーマ確定はCSSより先（FOUC防止のため同期読み込み） */ ?>
+    <script src="<?php echo fileUrl('/js/theme.js', urlRoot: '') ?>"></script>
     <link rel="stylesheet" href="<?php echo fileUrl('style/tokens.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/mvpmin.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/unset.css', urlRoot: '') ?>">

--- a/app/Views/ranking_react_content.php
+++ b/app/Views/ranking_react_content.php
@@ -10,6 +10,8 @@ $enableAdsense = true;
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <?php echo $_meta ?>
     <link rel="icon" type="image/png" href="<?php echo fileUrl(\App\Config\AppConfig::SITE_ICON_FILE_PATH, urlRoot: '') ?>">
+    <?php /* テーマ確定はCSSより先（FOUC防止のため同期読み込み） */ ?>
+    <script src="<?php echo fileUrl('/js/theme.js', urlRoot: '') ?>"></script>
     <link rel="stylesheet" href="<?php echo fileUrl('style/tokens.css', urlRoot: '') ?>">
     <?php foreach ($_css as $css) : ?>
         <link rel="stylesheet" href="<?php echo fileUrl($css, urlRoot: '') ?>">

--- a/app/Views/term_content.php
+++ b/app/Views/term_content.php
@@ -22,6 +22,8 @@ use App\Config\AppConfig;
     <meta property="og:site_name" content="openchat-review.me">
     <meta name="twitter:card" content="summary">
     <link rel="icon" type="image/png" href="<?php echo fileUrl('assets/icon-192x192.png', urlRoot: '') ?>">
+    <?php /* テーマ確定はCSSより先（FOUC防止のため同期読み込み） */ ?>
+    <script src="<?php echo fileUrl('/js/theme.js', urlRoot: '') ?>"></script>
     <link rel="stylesheet" href="<?php echo fileUrl('style/tokens.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/mvp.css', urlRoot: '') ?>">
     <link rel="stylesheet" href="<?php echo fileUrl('style/base/unset.css', urlRoot: '') ?>">

--- a/frontend/ranking/src/components/SiteHeaderSearch.tsx
+++ b/frontend/ranking/src/components/SiteHeaderSearch.tsx
@@ -56,6 +56,11 @@ export default function SiteHeaderSearch({
       >
         {children}
         <nav className="header-nav">
+          {/* ダークモード切替（実装は public/js/theme.js のクリックデリゲーション） */}
+          <button className="theme-toggle-btn" type="button" aria-label={t('ダークモード切替')}>
+            <svg className="theme-icon-moon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            <svg className="theme-icon-sun" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+          </button>
           <button
             className="header-button"
             id="search_button"

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,0 +1,125 @@
+/* ============================================================
+   テーマ切替（ダークモード）
+   - 解決順: localStorage('theme') > OS設定(prefers-color-scheme)
+   - <head> 内で同期実行され、描画前に data-theme を確定する（FOUC防止）。
+     そのため defer/async を付けずに読み込むこと。
+   - 公開API: window.ocTheme
+       .resolved()      … 'dark' | 'light'（現在の見た目）
+       .stored()        … 'dark' | 'light' | null（明示選択。null=OS連動）
+       .set(t)          … 'dark' | 'light' | null を保存して即適用
+       .toggle()        … 見た目を反転して保存
+     変更時は document に CustomEvent('octhemechange', {detail:{theme}}) を発火
+     （React/Chart.js 側はこれを購読して再描画する）。
+   - meta[name=theme-color] も解決テーマに合わせて更新する。
+   ============================================================ */
+(function () {
+  'use strict';
+
+  var KEY = 'theme';
+  var META_LIGHT = '#ffffff';
+  var META_DARK = '#0f172a'; /* tokens.css の --c-bg (slate-900) と同期 */
+
+  function stored() {
+    try {
+      var t = localStorage.getItem(KEY);
+      return t === 'dark' || t === 'light' ? t : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function osPrefersDark() {
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
+  function resolved() {
+    var t = stored();
+    if (t) return t;
+    return osPrefersDark() ? 'dark' : 'light';
+  }
+
+  function applyMeta(theme) {
+    var meta = document.querySelector('meta[name="theme-color"]');
+    if (!meta) {
+      meta = document.createElement('meta');
+      meta.setAttribute('name', 'theme-color');
+      (document.head || document.documentElement).appendChild(meta);
+    }
+    meta.setAttribute('content', theme === 'dark' ? META_DARK : META_LIGHT);
+  }
+
+  function apply(fire) {
+    var t = stored();
+    var root = document.documentElement;
+    if (t) {
+      root.setAttribute('data-theme', t);
+    } else {
+      root.removeAttribute('data-theme'); /* OS連動（CSSの media query に委ねる） */
+    }
+    var r = resolved();
+    applyMeta(r);
+    if (fire) {
+      try {
+        document.dispatchEvent(new CustomEvent('octhemechange', { detail: { theme: r } }));
+      } catch (e) { /* 古いブラウザは無視 */ }
+    }
+    return r;
+  }
+
+  /* テーマ切替の瞬間だけ全 transition を殺す。
+     理由(実測): transition を持つ要素（MUI Chip の background-color 0.3s 等）は、
+     ルート属性切替による var() 端点の変化と進行中 transition が競合すると
+     Chromium が旧テーマの値で固まることがある。切替を「遷移なしの一発置換」に
+     することでこれを根絶し、ライト/ダークの混在フェードも防ぐ。 */
+  function withoutTransitions(fn) {
+    var style = document.createElement('style');
+    style.textContent = '*,*::before,*::after{transition:none!important}';
+    (document.head || document.documentElement).appendChild(style);
+    var result = fn();
+    void document.documentElement.offsetWidth; /* 強制リフロー（無遷移状態で再計算させる） */
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () {
+        style.remove();
+      });
+    });
+    return result;
+  }
+
+  function set(t) {
+    try {
+      if (t === 'dark' || t === 'light') localStorage.setItem(KEY, t);
+      else localStorage.removeItem(KEY);
+    } catch (e) { /* private mode 等は無視 */ }
+    return withoutTransitions(function () {
+      return apply(true);
+    });
+  }
+
+  /* OS設定の変化に追従（明示選択が無い場合のみ見た目が変わる） */
+  if (window.matchMedia) {
+    try {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
+        if (!stored()) apply(true);
+      });
+    } catch (e) { /* Safari<14 の addListener 差異は無視（次回訪問時に反映） */ }
+  }
+
+  window.ocTheme = {
+    resolved: resolved,
+    stored: stored,
+    set: set,
+    toggle: function () {
+      return set(resolved() === 'dark' ? 'light' : 'dark');
+    },
+  };
+
+  /* トグルボタン（.theme-toggle-btn）はイベントデリゲーションで拾う。
+     PHPヘッダ/Reactヘッダのどちらでも、ボタンを置くだけで動く */
+  document.addEventListener('click', function (e) {
+    var btn = e.target && e.target.closest && e.target.closest('.theme-toggle-btn');
+    if (btn) window.ocTheme.toggle();
+  });
+
+  /* 初期適用（head 内同期実行 = 最初の描画前） */
+  apply(false);
+})();

--- a/public/style/components/site_header.css
+++ b/public/style/components/site_header.css
@@ -234,6 +234,41 @@ body::before {
   text-wrap: nowrap;
 }
 
+/* ---------- ダークモード切替ボタン ---------- */
+
+.theme-toggle-btn {
+  color: var(--c-text-1);
+}
+
+.theme-toggle-btn svg {
+  margin: auto;
+}
+
+/* ライト時: 月（=ダークへ切替）を表示。ダーク時: 太陽を表示。
+   OS連動（data-theme なし）のときは prefers-color-scheme 側のブロックが効く。
+   ★ tokens.css のダーク2系統と同じ同期ルール */
+.theme-icon-sun {
+  display: none;
+}
+
+:root[data-theme="dark"] .theme-icon-sun {
+  display: block;
+}
+
+:root[data-theme="dark"] .theme-icon-moon {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .theme-icon-sun {
+    display: block;
+  }
+
+  :root:not([data-theme="light"]) .theme-icon-moon {
+    display: none;
+  }
+}
+
 /* ---------- 検索フォーム ---------- */
 
 .header-button {

--- a/public/style/react/SiteHeader.css
+++ b/public/style/react/SiteHeader.css
@@ -239,3 +239,45 @@ ins.adsbygoogle[data-ad-status='unfilled']::before {
     background: var(--c-bg-sub);
   }
 }
+
+/* ---------- ダークモード切替ボタン（PHP ヘッダ側と同一ルール） ---------- */
+
+.theme-toggle-btn {
+  all: unset;
+  display: flex;
+  height: 38px;
+  width: 40px;
+  cursor: pointer;
+  color: var(--c-text-1);
+  border-radius: 99rem;
+}
+
+.theme-toggle-btn svg {
+  margin: auto;
+}
+
+.theme-toggle-btn:hover {
+  background-color: var(--c-bg-sub);
+}
+
+.theme-icon-sun {
+  display: none;
+}
+
+:root[data-theme="dark"] .theme-icon-sun {
+  display: block;
+}
+
+:root[data-theme="dark"] .theme-icon-moon {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .theme-icon-sun {
+    display: block;
+  }
+
+  :root:not([data-theme="light"]) .theme-icon-moon {
+    display: none;
+  }
+}

--- a/public/style/tokens.css
+++ b/public/style/tokens.css
@@ -14,11 +14,11 @@
      （例: 緑 #06c755 / #07b53b / #11d871、青 #1a73e8 / #4d73ff は別トークン）。
 
    【ダークモード】
-   ダーク値（Slate系）はダークモード導入 PR で投入する。
-   それまで [data-theme="dark"] / prefers-color-scheme ブロックは
-   意図的に置かない（OSダーク設定ユーザーへの中途半端な暗転を防ぐ）。
+   末尾の「3) ダークモード」ブロック参照（Slate系・shadcn/ui 準拠）。
+   手動トグル（[data-theme]）と OS 連動（prefers-color-scheme）の
+   2系統があり、両ブロックの内容は常に同期させること。
    ダーク値の正: 旧試験実装 Open-Chat-Graph-Frontend-Stats-Graph の
-   src/util/theme.ts / src/app.tsx（値を変えずに移植する）。
+   src/util/theme.ts / src/app.tsx（値を変えずに移植）。
    ============================================================ */
 
 /* ------------------------------------------------------------
@@ -34,6 +34,21 @@
   --grad-green-3: #11d593;
   --grad-green-4: #12cfcd;
   --grad-green-5: #16c2c1;
+
+  /* Slate スケール（ダークモード用・shadcn/ui 準拠 + 中間2段） */
+  --slate-50: #f8fafc;
+  --slate-100: #f1f5f9;
+  --slate-200: #e2e8f0;
+  --slate-300: #cbd5e1;
+  --slate-400: #94a3b8;
+  --slate-500: #64748b;
+  --slate-600: #475569;
+  --slate-700: #334155;
+  --slate-750: #293548;
+  --slate-800: #1e293b;
+  --slate-850: #172033;
+  --slate-900: #0f172a;
+  --slate-950: #020617;
 
   /* 合成グラデーション（チェックボックス等の 332deg 帯） */
   --c-brand-gradient: linear-gradient(
@@ -283,4 +298,405 @@
   --ocj-shadow-btn: 0 6px 16px rgba(6, 199, 85, 0.32);
   --ocj-shadow-btn-hover: 0 8px 20px rgba(6, 199, 85, 0.38);
   --ocj-shadow-btn-press: 0 3px 10px rgba(6, 199, 85, 0.3);
+}
+
+/* ------------------------------------------------------------
+   3) ダークモード
+   ------------------------------------------------------------ */
+:root[data-theme="dark"] {
+/* ============================================================
+   ダークモード（Slate系・shadcn/ui 準拠）
+   - 値の正: 旧試験実装 Open-Chat-Graph-Frontend-Stats-Graph の
+     theme.ts / app.tsx（グラフ・MUI まで調整済みの完成形）。
+     対応が無いトークンのみ slate スケールから補完（「要調整」コメント付き
+     → 仕上げPRの実画面確認で確定）。
+   - ダーク値は var(--slate-*) を参照せずリテラルで書く
+     （属性切替時に Chromium が連鎖 var() の再計算を取りこぼし、
+      ライブトグルで旧値が残留する実バグを確認したため）。
+   - 適用は2系統で同値を維持すること:
+     1) [data-theme="dark"]            … 手動トグル
+     2) prefers-color-scheme + 非light … OS設定連動（明示ライト選択を尊重）
+   ============================================================ */
+  color-scheme: dark;
+
+  /* テキスト */
+  --c-text-1: #e2e8f0 /* slate-200 */;      /* theme.ts text.primary #e2e8f0 */
+  --c-text-2: #cbd5e1 /* slate-300 */;
+  --c-text-3: #94a3b8 /* slate-400 */;      /* theme.ts text.secondary #94a3b8 */
+  --c-text-4: #64748b /* slate-500 */;
+  --c-text-5: #64748b /* slate-500 */;      /* 要調整: text-4 と同値に集約 */
+  --c-text-steel: #94a3b8 /* slate-400 */;
+  --c-text-link: #5b9cf6;            /* app.tsx primary.main */
+  /* --c-text-inverse は変更なし（緑グラデ・黒幕上の白文字は共通） */
+
+  /* 背景・サーフェス */
+  --c-bg: #0f172a /* slate-900 */;          /* app.tsx background.default #0f172a */
+  --c-bg-sub: #172033 /* slate-850 */;
+  --c-surface: #1e293b /* slate-800 */;     /* app.tsx background.paper #1e293b */
+  --c-surface-2: #334155 /* slate-700 */;
+  --c-surface-3: #293548 /* slate-750 */;
+  --c-surface-gray: #1e293b /* slate-800 */;
+  --c-surface-slate: #293548 /* slate-750 */;
+  --c-bg-bright: #020617 /* slate-950 */;   /* 要調整: 反転バッジ面 */
+
+  /* ボーダー */
+  --c-border: #334155 /* slate-700 */;      /* theme.ts grid #334155 */
+  --c-border-2: #475569 /* slate-600 */;    /* theme.ts border #475569 */
+  --c-border-3: #475569 /* slate-600 */;
+  --c-border-plain: #334155 /* slate-700 */;
+  --c-border-plain-2: #334155 /* slate-700 */;
+  --c-border-muted: #334155 /* slate-700 */;
+  --c-border-strong: #64748b /* slate-500 */;
+  --c-border-gray: #475569 /* slate-600 */;
+  --c-border-mid: #64748b /* slate-500 */;
+
+  /* ブランド・アクセント（緑は維持、赤系のみ明度を上げる） */
+  --c-accent-blue: #7a9aff;          /* 要調整 */
+  --c-accent-red: #fb7185;           /* theme.ts sunday (rose-400) */
+  --c-red-soft: #fb7185;
+
+  /* 影・エフェクト */
+  --c-shadow: rgba(0, 0, 0, 0.4);
+  --c-shadow-2: rgba(0, 0, 0, 0.35); /* 元はソリッド淡灰 #f4f4f4 */
+  --c-shadow-soft: rgba(0, 0, 0, 0.3);
+  --c-shadow-strong: rgba(0, 0, 0, 0.6);
+  --c-shadow-3: rgba(0, 0, 0, 0.5);
+  --c-tap-highlight: rgba(255, 255, 255, 0.08);
+  --c-tap-highlight-weak: rgba(255, 255, 255, 0.05);
+  --c-ink-shadow: rgba(0, 0, 0, 0.2);
+
+  /* ヘッダー・フッター */
+  --c-header-backdrop: rgba(15, 23, 42, 0.85);
+  --c-outline-highlight: #2dd4bf;    /* 要調整: 淡ティール枠 → teal-400 */
+  --c-text-dim: #cbd5e1 /* slate-300 */;
+  --c-overlay: rgba(2, 6, 23, 0.85);
+
+  /* ブログボタン（緑系・暗面用に反転） */
+  --c-btn-blog-text: #4ade80;        /* 要調整 green-400 */
+  --c-btn-blog-bg: rgba(6, 199, 85, 0.12);
+  --c-btn-blog-border: rgba(6, 199, 85, 0.35);
+
+  /* クールグレー系 → slate へ寄せる */
+  --c-cool-surface: #1e293b /* slate-800 */;
+  --c-cool-surface-hover: #293548 /* slate-750 */;
+  --c-cool-border-soft: #334155 /* slate-700 */;
+  --c-cool-border: #475569 /* slate-600 */;
+  --c-cool-text-weak: #64748b /* slate-500 */;
+  --c-cool-text: #94a3b8 /* slate-400 */;
+  --c-cool-text-strong: #e2e8f0 /* slate-200 */;
+  --c-cool-text-heading: #f1f5f9 /* slate-100 */;
+  --c-cool-text-deep: #f1f5f9 /* slate-100 */;
+
+  /* 一覧ページ系 */
+  --c-text-mid: #94a3b8 /* slate-400 */;
+  --c-text-mid-2: #cbd5e1 /* slate-300 */;
+  --c-text-mid-3: #94a3b8 /* slate-400 */;
+  --c-text-taupe: #94a3b8 /* slate-400 */;
+  --c-text-gray-mid: #94a3b8 /* slate-400 */;
+  --c-text-silver: #64748b /* slate-500 */;
+  --c-text-charcoal: #cbd5e1 /* slate-300 */;
+  --c-text-neutral: #94a3b8 /* slate-400 */;
+  --c-text-black: #e2e8f0 /* slate-200 */;
+  --c-green-soft: rgb(77, 199, 100);  /* ボタン緑は維持 */
+  --c-green-soft-50: rgba(77, 199, 100, 0.5);
+  --c-green-ring: rgba(77, 199, 100, 0.9);
+  --c-green-deep: rgb(52, 134, 67);
+  --c-highlight-teal: rgba(45, 212, 191, 0.15); /* 要調整 */
+  --c-green-mist: rgba(6, 199, 85, 0.08);
+  --c-green-tint: rgba(6, 199, 85, 0.14);
+  --c-red-tint: rgba(251, 113, 133, 0.14);
+  --c-brand-tint: rgba(6, 199, 85, 0.14);
+
+  /* 白フェード → 背景色フェードへ追従 */
+  --c-fade-right: linear-gradient(
+    90deg,
+    rgba(15, 23, 42, 0),
+    rgba(15, 23, 42, 0.95) 37%,
+    rgba(15, 23, 42, 1) 99%
+  );
+  --c-fade-bottom: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 1));
+  --c-fade-right-2: linear-gradient(90deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 1));
+  --c-bg-fade-end: rgba(15, 23, 42, 0);
+  --c-bg-93: rgba(15, 23, 42, 0.93);
+
+  /* ルーム詳細・labs 系 */
+  --c-labs-blue: #5b9cf6;
+  --c-chip-cat-bg: #293548 /* slate-750 */;
+  --c-chip-cat-bg-hover: #334155 /* slate-700 */;
+
+  /* React UI 系 */
+  --c-text-soft-black: rgba(226, 232, 240, 0.55);
+  --c-chip-dark: #e2e8f0 /* slate-200 */;   /* 選択中チップ: 黒面→明面に反転 */
+  --c-icon-ghost: rgba(255, 255, 255, 0.18);
+  --c-mui-blue: #5b9cf6;
+  --c-green-shelf: #4ade80;          /* 要調整 */
+  --c-overlay-60: rgba(0, 0, 0, 0.7);
+
+  /* 公開分析バッジ・チップ */
+  --c-green-tab: rgb(3, 199, 85);
+
+  /* テーマチップ（hot）・ /oc タグチップ */
+  --c-chip-hot-text: #4ade80;        /* 要調整 green-400 */
+  --c-chip-hot-bg: rgba(6, 199, 85, 0.1);
+  --c-chip-hot-border: rgba(6, 199, 85, 0.32);
+  --c-chip-hot-bg-hover: rgba(6, 199, 85, 0.18);
+  --c-chip-hot-border-hover: rgba(6, 199, 85, 0.45);
+  --c-brand-ring: rgba(6, 199, 85, 0.25);
+
+  /* ブログ系 */
+  --c-green-pale: rgba(6, 199, 85, 0.14);
+  --c-green-underline: rgba(6, 199, 85, 0.5);
+  --c-green-text-deep: #6ee7a0;      /* 要調整 */
+  --c-blog-icon-border: rgba(6, 199, 85, 0.3);
+  --c-brand-shadow: rgba(0, 0, 0, 0.5);
+  --c-brand-shadow-soft: rgba(0, 0, 0, 0.35);
+  --c-brand-shadow-soft-2: rgba(0, 0, 0, 0.35);
+
+  /* recommend グループUI */
+  --c-rg-text-strong: #e2e8f0 /* slate-200 */;
+  --c-rg-text-heading: #f1f5f9 /* slate-100 */;
+  --c-rg-text: #94a3b8 /* slate-400 */;
+  --c-rg-text-soft: #64748b /* slate-500 */;
+  --c-rg-text-mid: #94a3b8 /* slate-400 */;
+  --c-rg-muted: #64748b /* slate-500 */;
+  --c-rg-border: #334155 /* slate-700 */;
+  --c-rg-line: #334155 /* slate-700 */;
+  --c-rg-surface: #1e293b /* slate-800 */;
+  --c-rg-green-bg: rgba(6, 199, 85, 0.1);
+  --c-rg-green-border: rgba(6, 199, 85, 0.3);
+  --c-rg-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 4px 16px rgba(0, 0, 0, 0.35);
+
+  /* MVP レガシー */
+  --c-legacy-accent: rgba(91, 156, 246, 0.12);
+  --c-legacy-table: #5b9cf6;
+  --c-legacy-secondary: #a78bfa;     /* 要調整 violet-400 */
+  --c-legacy-secondary-accent: rgba(167, 139, 250, 0.08);
+
+  /* アイコン（fill 差し替え版 URI） */
+  --icon-refresh: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%2394a3b8' d='M256 0C179.9 0 111.7 33.4 64.9 86.2L0 21.3V192h170.7l-60.2-60.2C145.6 90.5 197.5 64 256 64c106 0 192 85.9 192 192s-86 192-192 192c-53 0-101-21.5-135.8-56.2L75 437c46.4 46.3 110.4 75 181 75 141.4 0 256-114.6 256-256S397.4 0 256 0zm-21.3 106.7v170.7h128v-42.7h-85.3v-128h-42.7z' /%3E%3C/svg%3E");
+  --icon-search: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 27' class='search-icon'%3E%3Cpath d='M11.56,3.43a8.26,8.26,0,0,0,0,16.52,8.18,8.18,0,0,0,5-1.72l4.7,4.7a1.1,1.1,0,0,0,1.56,0,1.09,1.09,0,0,0,0-1.55l0,0-4.7-4.7a8.18,8.18,0,0,0,1.72-5A8.28,8.28,0,0,0,11.56,3.43Zm0,2.2A6.06,6.06,0,1,1,5.5,11.69,6,6,0,0,1,11.56,5.63Z' fill='%23e2e8f0'%3E%3C/path%3E%3C/svg%3E");
+  --icon-external-gray: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='%2394a3b8' viewBox='0 0 20 20'%3E%3Cpath d='M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a%0A1 1 0 102 0V4a1 1 0 00-1-1h-5z'/%3E%3Cpath d='M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z'/%3E%3C/svg%3E");
+
+  /* 入室確認ページ（紙色 → 夜の紙色） */
+  --ocj-bg: #0f172a /* slate-900 */;
+  --ocj-bg-dim: #172033 /* slate-850 */;
+  --ocj-bg-dim-2: #172033 /* slate-850 */;
+  --ocj-card: #1e293b /* slate-800 */;
+  --ocj-card-soft: #293548 /* slate-750 */;
+  --ocj-border: #334155 /* slate-700 */;
+  --ocj-border-soft: #334155 /* slate-700 */;
+  --ocj-border-faint: #293548 /* slate-750 */;
+  --ocj-ink: #e2e8f0 /* slate-200 */;
+  --ocj-ink-strong: #f1f5f9 /* slate-100 */;
+  --ocj-ink-soft: #94a3b8 /* slate-400 */;
+  --ocj-ink-mute: #64748b /* slate-500 */;
+  --ocj-amber: #fbbf24;              /* amber-400 */
+  --ocj-amber-deep: #fcd34d;
+  --ocj-amber-soft-text: #eab308;
+  --ocj-amber-bg: rgba(251, 191, 36, 0.1);
+  --ocj-amber-line: rgba(251, 191, 36, 0.35);
+  --ocj-green-bg: rgba(6, 199, 85, 0.12);
+  --ocj-green-text: #4ade80;
+  --ocj-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+/* OS設定がダークで、ユーザーが明示的にライトを選んでいない場合。
+   ★ 上の [data-theme="dark"] ブロックと内容を常に同期させること */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+/* ============================================================
+   ダークモード（Slate系・shadcn/ui 準拠）
+   - 値の正: 旧試験実装 Open-Chat-Graph-Frontend-Stats-Graph の
+     theme.ts / app.tsx（グラフ・MUI まで調整済みの完成形）。
+     対応が無いトークンのみ slate スケールから補完（「要調整」コメント付き
+     → 仕上げPRの実画面確認で確定）。
+   - ダーク値は var(--slate-*) を参照せずリテラルで書く
+     （属性切替時に Chromium が連鎖 var() の再計算を取りこぼし、
+      ライブトグルで旧値が残留する実バグを確認したため）。
+   - 適用は2系統で同値を維持すること:
+     1) [data-theme="dark"]            … 手動トグル
+     2) prefers-color-scheme + 非light … OS設定連動（明示ライト選択を尊重）
+   ============================================================ */
+  color-scheme: dark;
+
+  /* テキスト */
+  --c-text-1: #e2e8f0 /* slate-200 */;      /* theme.ts text.primary #e2e8f0 */
+  --c-text-2: #cbd5e1 /* slate-300 */;
+  --c-text-3: #94a3b8 /* slate-400 */;      /* theme.ts text.secondary #94a3b8 */
+  --c-text-4: #64748b /* slate-500 */;
+  --c-text-5: #64748b /* slate-500 */;      /* 要調整: text-4 と同値に集約 */
+  --c-text-steel: #94a3b8 /* slate-400 */;
+  --c-text-link: #5b9cf6;            /* app.tsx primary.main */
+  /* --c-text-inverse は変更なし（緑グラデ・黒幕上の白文字は共通） */
+
+  /* 背景・サーフェス */
+  --c-bg: #0f172a /* slate-900 */;          /* app.tsx background.default #0f172a */
+  --c-bg-sub: #172033 /* slate-850 */;
+  --c-surface: #1e293b /* slate-800 */;     /* app.tsx background.paper #1e293b */
+  --c-surface-2: #334155 /* slate-700 */;
+  --c-surface-3: #293548 /* slate-750 */;
+  --c-surface-gray: #1e293b /* slate-800 */;
+  --c-surface-slate: #293548 /* slate-750 */;
+  --c-bg-bright: #020617 /* slate-950 */;   /* 要調整: 反転バッジ面 */
+
+  /* ボーダー */
+  --c-border: #334155 /* slate-700 */;      /* theme.ts grid #334155 */
+  --c-border-2: #475569 /* slate-600 */;    /* theme.ts border #475569 */
+  --c-border-3: #475569 /* slate-600 */;
+  --c-border-plain: #334155 /* slate-700 */;
+  --c-border-plain-2: #334155 /* slate-700 */;
+  --c-border-muted: #334155 /* slate-700 */;
+  --c-border-strong: #64748b /* slate-500 */;
+  --c-border-gray: #475569 /* slate-600 */;
+  --c-border-mid: #64748b /* slate-500 */;
+
+  /* ブランド・アクセント（緑は維持、赤系のみ明度を上げる） */
+  --c-accent-blue: #7a9aff;          /* 要調整 */
+  --c-accent-red: #fb7185;           /* theme.ts sunday (rose-400) */
+  --c-red-soft: #fb7185;
+
+  /* 影・エフェクト */
+  --c-shadow: rgba(0, 0, 0, 0.4);
+  --c-shadow-2: rgba(0, 0, 0, 0.35); /* 元はソリッド淡灰 #f4f4f4 */
+  --c-shadow-soft: rgba(0, 0, 0, 0.3);
+  --c-shadow-strong: rgba(0, 0, 0, 0.6);
+  --c-shadow-3: rgba(0, 0, 0, 0.5);
+  --c-tap-highlight: rgba(255, 255, 255, 0.08);
+  --c-tap-highlight-weak: rgba(255, 255, 255, 0.05);
+  --c-ink-shadow: rgba(0, 0, 0, 0.2);
+
+  /* ヘッダー・フッター */
+  --c-header-backdrop: rgba(15, 23, 42, 0.85);
+  --c-outline-highlight: #2dd4bf;    /* 要調整: 淡ティール枠 → teal-400 */
+  --c-text-dim: #cbd5e1 /* slate-300 */;
+  --c-overlay: rgba(2, 6, 23, 0.85);
+
+  /* ブログボタン（緑系・暗面用に反転） */
+  --c-btn-blog-text: #4ade80;        /* 要調整 green-400 */
+  --c-btn-blog-bg: rgba(6, 199, 85, 0.12);
+  --c-btn-blog-border: rgba(6, 199, 85, 0.35);
+
+  /* クールグレー系 → slate へ寄せる */
+  --c-cool-surface: #1e293b /* slate-800 */;
+  --c-cool-surface-hover: #293548 /* slate-750 */;
+  --c-cool-border-soft: #334155 /* slate-700 */;
+  --c-cool-border: #475569 /* slate-600 */;
+  --c-cool-text-weak: #64748b /* slate-500 */;
+  --c-cool-text: #94a3b8 /* slate-400 */;
+  --c-cool-text-strong: #e2e8f0 /* slate-200 */;
+  --c-cool-text-heading: #f1f5f9 /* slate-100 */;
+  --c-cool-text-deep: #f1f5f9 /* slate-100 */;
+
+  /* 一覧ページ系 */
+  --c-text-mid: #94a3b8 /* slate-400 */;
+  --c-text-mid-2: #cbd5e1 /* slate-300 */;
+  --c-text-mid-3: #94a3b8 /* slate-400 */;
+  --c-text-taupe: #94a3b8 /* slate-400 */;
+  --c-text-gray-mid: #94a3b8 /* slate-400 */;
+  --c-text-silver: #64748b /* slate-500 */;
+  --c-text-charcoal: #cbd5e1 /* slate-300 */;
+  --c-text-neutral: #94a3b8 /* slate-400 */;
+  --c-text-black: #e2e8f0 /* slate-200 */;
+  --c-green-soft: rgb(77, 199, 100);  /* ボタン緑は維持 */
+  --c-green-soft-50: rgba(77, 199, 100, 0.5);
+  --c-green-ring: rgba(77, 199, 100, 0.9);
+  --c-green-deep: rgb(52, 134, 67);
+  --c-highlight-teal: rgba(45, 212, 191, 0.15); /* 要調整 */
+  --c-green-mist: rgba(6, 199, 85, 0.08);
+  --c-green-tint: rgba(6, 199, 85, 0.14);
+  --c-red-tint: rgba(251, 113, 133, 0.14);
+  --c-brand-tint: rgba(6, 199, 85, 0.14);
+
+  /* 白フェード → 背景色フェードへ追従 */
+  --c-fade-right: linear-gradient(
+    90deg,
+    rgba(15, 23, 42, 0),
+    rgba(15, 23, 42, 0.95) 37%,
+    rgba(15, 23, 42, 1) 99%
+  );
+  --c-fade-bottom: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 1));
+  --c-fade-right-2: linear-gradient(90deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 1));
+  --c-bg-fade-end: rgba(15, 23, 42, 0);
+  --c-bg-93: rgba(15, 23, 42, 0.93);
+
+  /* ルーム詳細・labs 系 */
+  --c-labs-blue: #5b9cf6;
+  --c-chip-cat-bg: #293548 /* slate-750 */;
+  --c-chip-cat-bg-hover: #334155 /* slate-700 */;
+
+  /* React UI 系 */
+  --c-text-soft-black: rgba(226, 232, 240, 0.55);
+  --c-chip-dark: #e2e8f0 /* slate-200 */;   /* 選択中チップ: 黒面→明面に反転 */
+  --c-icon-ghost: rgba(255, 255, 255, 0.18);
+  --c-mui-blue: #5b9cf6;
+  --c-green-shelf: #4ade80;          /* 要調整 */
+  --c-overlay-60: rgba(0, 0, 0, 0.7);
+
+  /* 公開分析バッジ・チップ */
+  --c-green-tab: rgb(3, 199, 85);
+
+  /* テーマチップ（hot）・ /oc タグチップ */
+  --c-chip-hot-text: #4ade80;        /* 要調整 green-400 */
+  --c-chip-hot-bg: rgba(6, 199, 85, 0.1);
+  --c-chip-hot-border: rgba(6, 199, 85, 0.32);
+  --c-chip-hot-bg-hover: rgba(6, 199, 85, 0.18);
+  --c-chip-hot-border-hover: rgba(6, 199, 85, 0.45);
+  --c-brand-ring: rgba(6, 199, 85, 0.25);
+
+  /* ブログ系 */
+  --c-green-pale: rgba(6, 199, 85, 0.14);
+  --c-green-underline: rgba(6, 199, 85, 0.5);
+  --c-green-text-deep: #6ee7a0;      /* 要調整 */
+  --c-blog-icon-border: rgba(6, 199, 85, 0.3);
+  --c-brand-shadow: rgba(0, 0, 0, 0.5);
+  --c-brand-shadow-soft: rgba(0, 0, 0, 0.35);
+  --c-brand-shadow-soft-2: rgba(0, 0, 0, 0.35);
+
+  /* recommend グループUI */
+  --c-rg-text-strong: #e2e8f0 /* slate-200 */;
+  --c-rg-text-heading: #f1f5f9 /* slate-100 */;
+  --c-rg-text: #94a3b8 /* slate-400 */;
+  --c-rg-text-soft: #64748b /* slate-500 */;
+  --c-rg-text-mid: #94a3b8 /* slate-400 */;
+  --c-rg-muted: #64748b /* slate-500 */;
+  --c-rg-border: #334155 /* slate-700 */;
+  --c-rg-line: #334155 /* slate-700 */;
+  --c-rg-surface: #1e293b /* slate-800 */;
+  --c-rg-green-bg: rgba(6, 199, 85, 0.1);
+  --c-rg-green-border: rgba(6, 199, 85, 0.3);
+  --c-rg-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 4px 16px rgba(0, 0, 0, 0.35);
+
+  /* MVP レガシー */
+  --c-legacy-accent: rgba(91, 156, 246, 0.12);
+  --c-legacy-table: #5b9cf6;
+  --c-legacy-secondary: #a78bfa;     /* 要調整 violet-400 */
+  --c-legacy-secondary-accent: rgba(167, 139, 250, 0.08);
+
+  /* アイコン（fill 差し替え版 URI） */
+  --icon-refresh: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%2394a3b8' d='M256 0C179.9 0 111.7 33.4 64.9 86.2L0 21.3V192h170.7l-60.2-60.2C145.6 90.5 197.5 64 256 64c106 0 192 85.9 192 192s-86 192-192 192c-53 0-101-21.5-135.8-56.2L75 437c46.4 46.3 110.4 75 181 75 141.4 0 256-114.6 256-256S397.4 0 256 0zm-21.3 106.7v170.7h128v-42.7h-85.3v-128h-42.7z' /%3E%3C/svg%3E");
+  --icon-search: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 27' class='search-icon'%3E%3Cpath d='M11.56,3.43a8.26,8.26,0,0,0,0,16.52,8.18,8.18,0,0,0,5-1.72l4.7,4.7a1.1,1.1,0,0,0,1.56,0,1.09,1.09,0,0,0,0-1.55l0,0-4.7-4.7a8.18,8.18,0,0,0,1.72-5A8.28,8.28,0,0,0,11.56,3.43Zm0,2.2A6.06,6.06,0,1,1,5.5,11.69,6,6,0,0,1,11.56,5.63Z' fill='%23e2e8f0'%3E%3C/path%3E%3C/svg%3E");
+  --icon-external-gray: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='w-6 h-6' fill='%2394a3b8' viewBox='0 0 20 20'%3E%3Cpath d='M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a%0A1 1 0 102 0V4a1 1 0 00-1-1h-5z'/%3E%3Cpath d='M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z'/%3E%3C/svg%3E");
+
+  /* 入室確認ページ（紙色 → 夜の紙色） */
+  --ocj-bg: #0f172a /* slate-900 */;
+  --ocj-bg-dim: #172033 /* slate-850 */;
+  --ocj-bg-dim-2: #172033 /* slate-850 */;
+  --ocj-card: #1e293b /* slate-800 */;
+  --ocj-card-soft: #293548 /* slate-750 */;
+  --ocj-border: #334155 /* slate-700 */;
+  --ocj-border-soft: #334155 /* slate-700 */;
+  --ocj-border-faint: #293548 /* slate-750 */;
+  --ocj-ink: #e2e8f0 /* slate-200 */;
+  --ocj-ink-strong: #f1f5f9 /* slate-100 */;
+  --ocj-ink-soft: #94a3b8 /* slate-400 */;
+  --ocj-ink-mute: #64748b /* slate-500 */;
+  --ocj-amber: #fbbf24;              /* amber-400 */
+  --ocj-amber-deep: #fcd34d;
+  --ocj-amber-soft-text: #eab308;
+  --ocj-amber-bg: rgba(251, 191, 36, 0.1);
+  --ocj-amber-line: rgba(251, 191, 36, 0.35);
+  --ocj-green-bg: rgba(6, 199, 85, 0.12);
+  --ocj-green-text: #4ade80;
+  --ocj-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 6px 18px rgba(0, 0, 0, 0.35);
+}
 }


### PR DESCRIPTION
## 概要

**サイト全体にダークモードを導入します**（第1〜7弾のトークン基盤の上に実装）。

- 初回訪問: OS設定（prefers-color-scheme）に自動追従
- ヘッダーの月/太陽ボタンで手動切替（localStorage に保存、以後それを優先）
- 配色は Slate 系（shadcn/ui 準拠）。グラフ・MUI まで調整済みだった旧試験実装（theme.ts / app.tsx）の値を正として踏襲

## 変更内容

1. **tokens.css に全トークンのダーク値を投入**（`[data-theme="dark"]` と OS連動の2系統）。アイコンdata-URIはfill差し替え版に丸ごと切替（描画パス不変）
2. **`public/js/theme.js` 新設**: テーマ解決（localStorage > OS）・FOUC防止（head内同期実行）・`meta[name=theme-color]` 更新・`octhemechange` イベント（後続のChart.js連携用）
3. **トグルボタン**を PHP ヘッダと React ヘッダ（/ranking）の両方に設置
4. **admin系は `data-theme="light"` 固定**（独自デザインシステムを保護）

### 実装上の知見（ハマりどころ2件）

- **連鎖 var() の再解決取りこぼし**: ダーク値を `var(--slate-800)` のような参照で書くと、属性切替時に Chromium が一部要素の再解決を取りこぼす実バグを確認 → ダーク値はリテラル直書きに
- **transition との競合**: `transition: background-color .3s` を持つ要素（MUI Chip等）が切替時に旧テーマ色のまま固まる → 切替の瞬間だけ全 transition を無効化する標準テクニックで根絶（ライト/ダーク混在フェードも防止）

## 検証

- **ライトモードは無変更**: 明示ライトでの computed-style 比較で既存要素の差分0行（新設トグルボタンのDOM 5行のみ）
- ダーク実画面をトップ / ルーム詳細 / ランキング（React/MUI）で目視確認 — Slate基調にブランド緑・グラデが映える仕上がり
- トグル往復・永続化・meta theme-color・OS連動の動作確認済み

## 残作業（後続PR）

- 第9弾: グラフ（Chart.js canvas）と MUI コンポーネントのダーク対応（旧 theme.ts の忠実移植）
- 第10弾: 全ページのダークQA・コントラスト監査・「要調整」トークンの微調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)
