### PR TITLE
[STG] fix: ダークモードでグラフの日時指定線が見えない問題とスマホでチップが白く浮く問題を修正

### DIFF
--- a/frontend/oc-app/src/graph/classes/ChartJS/Plugin/getTooltipAndLineCallback.ts
+++ b/frontend/oc-app/src/graph/classes/ChartJS/Plugin/getTooltipAndLineCallback.ts
@@ -8,9 +8,9 @@ import {
 } from 'chart.js'
 import OpenChatChart from '../../OpenChatChart'
 import { resetTooltip } from './getEventCatcherPlugin'
+import { getColors } from '../../../util/theme'
 
 const defaultVerticalLine = {
-  color: 'black',
   lineWidth: 1,
   setLineDash: [6, 6],
 }
@@ -99,7 +99,7 @@ export const getTooltipAndLineCallback =
 
     // 1週間表示時以外
     if (!(ocChart.limit === 8 || ocChart.zoomWeekday === 2) && pos.x != null) {
-      verticalLine(ocChart.chart, defaultVerticalLine, pos.x)
+      verticalLine(ocChart.chart, { ...defaultVerticalLine, color: getColors().verticalLine }, pos.x)
     }
 
     isShow = true

--- a/public/style/pages/graph_page.css
+++ b/public/style/pages/graph_page.css
@@ -89,9 +89,11 @@
     background-color: var(--c-surface);
   }
 
+  /* タッチで :hover が残留しても基本状態と同色に固定する（ランキングページのチップと同じ
+     OpenChat.css の .selected と同色トークン。--c-text-1 だとダークで白背景×白文字に白浮きする） */
   .MuiChip-root.openchat-item-header-chip.graph.selected:hover {
     color: var(--c-text-inverse);
-    background-color: var(--c-text-1);
+    background-color: var(--c-chip-dark);
   }
 }
 


### PR DESCRIPTION
## 問題の概要

ダークモードのグラフ表示で2つの視認性バグがあった。

### 1. ツールチップの日時指定線（縦の破線）が背景と同化して見えない

グラフをタップ・ホバーした位置に表示される縦の破線が黒色固定のため、ダークモードでは黒背景に溶けて見えなかった。

**原因**: [`getTooltipAndLineCallback.ts`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/frontend/oc-app/src/graph/classes/ChartJS/Plugin/getTooltipAndLineCallback.ts) が縦線の色を `'black'` 直書きにしており、テーマパレット（`theme.ts`）に定義済みの `verticalLine` トークン（ダーク: slate-300 の明るいグレー）が未配線だった。

**対処**: 旧試験実装（配色の正）と同じく、描画時に `getColors().verticalLine` からテーマに応じた色を取得するよう修正。ライトモードも真っ黒から旧実装どおりの柔らかいグレー（30%黒）になる。

### 2. スマホタップ後に「ランキング・急上昇」チップが白く浮く

スマホでグラフ下の「ランキング」「急上昇」チップをタップすると、タッチ特有の :hover 残留により、選択中チップが白背景×白文字の読めない状態になっていた。

**原因**: スマホ幅専用の hover 固定ルール（[`graph_page.css`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/public/style/pages/graph_page.css)）が、選択中チップの背景色に「チップの黒面」トークンではなく「本文文字色」トークンを誤用していた。ライトモードでは両者がほぼ同じ黒のため発覚しなかったが、ダークモードでは文字色トークンがほぼ白になるため白浮きした。

**対処**: ランキングページのチップ（1時間・24時間など）と同じ「選択中チップの面」トークンに統一。タップ後も中明度グレー＋白文字で安定する。

## 確認内容

- ダークモード実機相当（DevTools モバイル幅）で縦線がグレー破線で視認できること
- 選択中チップが hover 残留時もランキングページと同色（slate-600 系）になること
- ライトモードのチップ外観に実質変化がないこと（#111 → #1f1f1f の同系色）

🤖 Generated with [Claude Code](https://claude.com/claude-code)