### PR TITLE
[PROD] fix: ダークモードでグラフの日時指定線が見えない問題とスマホでチップが白く浮く問題を修正

### DIFF
--- a/frontend/oc-app/src/graph/classes/ChartJS/Plugin/getTooltipAndLineCallback.ts
+++ b/frontend/oc-app/src/graph/classes/ChartJS/Plugin/getTooltipAndLineCallback.ts
@@ -8,9 +8,9 @@ import {
 } from 'chart.js'
 import OpenChatChart from '../../OpenChatChart'
 import { resetTooltip } from './getEventCatcherPlugin'
+import { getColors } from '../../../util/theme'
 
 const defaultVerticalLine = {
-  color: 'black',
   lineWidth: 1,
   setLineDash: [6, 6],
 }
@@ -99,7 +99,7 @@ export const getTooltipAndLineCallback =
 
     // 1週間表示時以外
     if (!(ocChart.limit === 8 || ocChart.zoomWeekday === 2) && pos.x != null) {
-      verticalLine(ocChart.chart, defaultVerticalLine, pos.x)
+      verticalLine(ocChart.chart, { ...defaultVerticalLine, color: getColors().verticalLine }, pos.x)
     }
 
     isShow = true

--- a/public/style/pages/graph_page.css
+++ b/public/style/pages/graph_page.css
@@ -89,9 +89,11 @@
     background-color: var(--c-surface);
   }
 
+  /* タッチで :hover が残留しても基本状態と同色に固定する（ランキングページのチップと同じ
+     OpenChat.css の .selected と同色トークン。--c-text-1 だとダークで白背景×白文字に白浮きする） */
   .MuiChip-root.openchat-item-header-chip.graph.selected:hover {
     color: var(--c-text-inverse);
-    background-color: var(--c-text-1);
+    background-color: var(--c-chip-dark);
   }
 }
 


### PR DESCRIPTION
#355 の本番リリース（stg → main）。

## 内容

- ダークモードでグラフのツールチップ縦線（日時指定線）が黒背景と同化して見えない問題を修正（テーマ対応のグレー破線に）
- スマホタップ後に「ランキング・急上昇」チップが白背景×白文字で読めなくなる問題を修正（ランキングページのチップと同色トークンに統一）

詳細は #355 を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)