### PR TITLE
[PROD] fix: ローソク足データがない期間タブで切り替えボタンをグレーアウト表示するように改善

### DIFF
--- a/app/Models/Repositories/Statistics/StatisticsOhlcRepositoryInterface.php
+++ b/app/Models/Repositories/Statistics/StatisticsOhlcRepositoryInterface.php
@@ -20,4 +20,13 @@ interface StatisticsOhlcRepositoryInterface
      * @return array{ date: string, open_member: int, high_member: int, low_member: int, close_member: int }[]
      */
     public function getOhlcDateAsc(int $open_chat_id): array;
+
+    /**
+     * メンバー数OHLCの件数を全期間・指定日以降（週/月ウィンドウ）でまとめて取得する。
+     *
+     * @param string $weekStartDate `Y-m-d` 週ウィンドウの開始日
+     * @param string $monthStartDate `Y-m-d` 月ウィンドウの開始日
+     * @return array{ all_count: int, week_count: int, month_count: int }
+     */
+    public function getOhlcCounts(int $open_chat_id, string $weekStartDate, string $monthStartDate): array;
 }

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
@@ -40,4 +40,43 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
 
         return $result;
     }
+
+    public function getOhlcCounts(int $open_chat_id, string $weekStartDate, string $monthStartDate): array
+    {
+        $query =
+            "SELECT
+                COUNT(*) AS all_count,
+                COUNT(CASE WHEN date >= :week_start_date THEN 1 END) AS week_count,
+                COUNT(CASE WHEN date >= :month_start_date THEN 1 END) AS month_count
+            FROM
+                statistics_ohlc
+            WHERE
+                open_chat_id = :open_chat_id";
+
+        $emptyResult = ['all_count' => 0, 'week_count' => 0, 'month_count' => 0];
+
+        try {
+            SQLiteStatisticsOhlc::connect(['mode' => '?mode=ro']);
+        } catch (\PDOException) {
+            // DBファイル未作成（OHLC統計の記録開始前の環境）は「データ無し」として扱う
+            return $emptyResult;
+        }
+
+        $result = SQLiteStatisticsOhlc::fetch($query, [
+            'open_chat_id' => $open_chat_id,
+            'week_start_date' => $weekStartDate,
+            'month_start_date' => $monthStartDate,
+        ]);
+        SQLiteStatisticsOhlc::$pdo = null;
+
+        if (!is_array($result)) {
+            return $emptyResult;
+        }
+
+        return [
+            'all_count' => (int)$result['all_count'],
+            'week_count' => (int)$result['week_count'],
+            'month_count' => (int)$result['month_count'],
+        ];
+    }
 }

--- a/app/Services/Statistics/Dto/StatisticsChartDto.php
+++ b/app/Services/Statistics/Dto/StatisticsChartDto.php
@@ -16,6 +16,13 @@ class StatisticsChartDto
 
     public string $endDate = '';
 
+    /**
+     * 期間タブ毎にローソク足(OHLC)データが存在するか
+     *
+     * @var array{ week: bool, month: bool, all: bool }
+     */
+    public array $ohlcAvailability = ['week' => false, 'month' => false, 'all' => false];
+
     function __construct(string $startDate, string $endDate)
     {
         $this->startDate = $startDate;

--- a/app/Services/Statistics/StatisticsChartArrayService.php
+++ b/app/Services/Statistics/StatisticsChartArrayService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Statistics;
 
+use App\Models\Repositories\Statistics\StatisticsOhlcRepositoryInterface;
 use App\Models\Repositories\Statistics\StatisticsPageRepositoryInterface;
 use App\Services\Statistics\Dto\StatisticsChartDto;
 
@@ -11,6 +12,7 @@ class StatisticsChartArrayService
 {
     function __construct(
         private StatisticsPageRepositoryInterface $statisticsPageRepository,
+        private StatisticsOhlcRepositoryInterface $statisticsOhlcRepository,
     ) {}
 
     /**
@@ -28,11 +30,47 @@ class StatisticsChartArrayService
 
         $dto = new StatisticsChartDto($memberStats[0]['date'], $memberStats[count($memberStats) - 1]['date']);
 
-        return $this->generateChartArray(
+        $this->generateChartArray(
             $dto,
             $this->generateDateArray($dto->startDate, $dto->endDate),
             $memberStats
         );
+
+        $this->setOhlcAvailability($dto, $open_chat_id);
+
+        return $dto;
+    }
+
+    /**
+     * 期間タブ毎のローソク足(OHLC)データ有無を設定する
+     *
+     * 各期間タブはグラフ末尾からの日数ウィンドウ（1週間=8件, 1ヶ月=31件）を表示するため、
+     * ウィンドウ内のOHLC件数で判定する
+     * - 1週間: ウィンドウ内の全日分が揃っている場合のみ有効
+     * - 1ヶ月: ウィンドウ内の半分以上の日にあれば有効
+     * - 全期間: 1件でもあれば有効
+     */
+    private function setOhlcAvailability(StatisticsChartDto $dto, int $open_chat_id): void
+    {
+        $len = count($dto->date);
+        $weekWindow = min(8, $len);
+        $monthWindow = min(31, $len);
+
+        $counts = $this->statisticsOhlcRepository->getOhlcCounts(
+            $open_chat_id,
+            $dto->date[$len - $weekWindow],
+            $dto->date[$len - $monthWindow],
+        );
+
+        if ($counts['all_count'] === 0) {
+            return;
+        }
+
+        $dto->ohlcAvailability = [
+            'week' => $counts['week_count'] >= $weekWindow,
+            'month' => $counts['month_count'] * 2 >= $monthWindow,
+            'all' => true,
+        ];
     }
 
     /**  

--- a/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
+++ b/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
@@ -7,6 +7,7 @@ import {
   handleChangeChartMode,
   handleChangeLimit,
   hasOhlcData,
+  hasOhlcDataForLimit,
   limitAtom,
   toggleDisplay24hAtom,
   toggleDisplayAllAtom,
@@ -19,8 +20,8 @@ function CandlestickToggle() {
   const limit = useAtomValue(limitAtom)
   if (!hasOhlcData()) return null
   const isCandlestick = chartMode === 'candlestick'
-  const isHourMode = limit === 25
-  const disabled = isHourMode && !isCandlestick
+  // 表示中の期間タブにOHLCデータが無い場合はグレーアウト（24時間タブも常に該当）
+  const disabled = !isCandlestick && !hasOhlcDataForLimit(limit)
 
   const handleToggle = () => {
     if (disabled) return

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -68,8 +68,8 @@ export function setChartStatesFromUrlParams() {
     }
   }
 
-  // ローソク足モードの復元（OHLCデータが存在する場合のみ、24時間モードでない場合）
-  if (params.chart === 'candlestick' && hasOhlcData() && graphStore.get(limitAtom) !== 25) {
+  // ローソク足モードの復元（表示中の期間タブにOHLCデータが存在する場合のみ）
+  if (params.chart === 'candlestick' && hasOhlcDataForLimit(graphStore.get(limitAtom))) {
     graphStore.set(chartModeAtom, 'candlestick')
     chart.setMode('candlestick')
   }
@@ -131,7 +131,10 @@ export function initDisplay() {
 export function handleChangeLimit(limit: ChartLimit | 25) {
   graphStore.set(limitAtom, limit)
 
-  if (graphStore.get(chartModeAtom) === 'candlestick' && limit === 25) {
+  // 移動先の期間タブにOHLCデータが無い場合は折れ線グラフに戻す
+  const fallbackToLine =
+    graphStore.get(chartModeAtom) === 'candlestick' && !hasOhlcDataForLimit(limit)
+  if (fallbackToLine) {
     graphStore.set(chartModeAtom, 'line')
     chart.setMode('line')
   }
@@ -141,6 +144,9 @@ export function handleChangeLimit(limit: ChartLimit | 25) {
     fetchChart(true)
   } else if (chart.getIsHour()) {
     chart.setIsHour(false)
+    fetchChart(true)
+  } else if (fallbackToLine) {
+    // モードが変わるため折れ線グラフ用のデータで再取得する
     fetchChart(true)
   } else {
     chart.update(limit)
@@ -168,14 +174,61 @@ export function handleChangeEnableZoom(value: boolean) {
 }
 
 export function hasOhlcData(): boolean {
-  return statsDto.date.length > 1
+  return statsDto.ohlcAvailability?.all ?? false
+}
+
+/** 指定の期間タブにローソク足(OHLC)データが存在するか（24時間タブは常にfalse） */
+export function hasOhlcDataForLimit(limit: ChartLimit | 25): boolean {
+  const availability = statsDto.ohlcAvailability
+  if (!availability) return false
+
+  switch (limit) {
+    case 8:
+      return availability.week
+    case 31:
+      return availability.month
+    case 0:
+      return availability.all
+    default:
+      return false
+  }
 }
 
 export function updateTabVisibility(dataLength: number) {
   graphStore.set(toggleDisplayMonthAtom, dataLength > 8)
   graphStore.set(toggleDisplayAllAtom, dataLength > 31)
+  fallbackHiddenLimit()
+}
 
-  // 非表示になったタブが選択中の場合、表示中のタブにフォールバック
+/**
+ * ローソク足モード: 期間タブ毎のウィンドウ内ローソク足本数に基づいてタブ表示を設定する
+ *
+ * OHLCデータは記録期間が限られるため（例: 過去のみに存在する部屋）、
+ * 件数ではなく各タブのウィンドウに実際に入る本数で判定する
+ */
+export function updateCandleTabVisibility(ohlcData: MemberOhlc[]) {
+  const dates = statsDto.date
+  const ohlcDateSet = new Set(ohlcData.map((r) => r.date))
+  const countInWindow = (limit: number) => {
+    let count = 0
+    for (let i = limit ? Math.max(0, dates.length - limit) : 0; i < dates.length; i++) {
+      if (ohlcDateSet.has(dates[i])) count++
+    }
+    return count
+  }
+
+  const weekCount = countInWindow(8)
+  const monthCount = countInWindow(31)
+  const allCount = countInWindow(0)
+
+  // より短いタブで全て表示しきれないローソク足がある場合のみ表示
+  graphStore.set(toggleDisplayMonthAtom, monthCount > weekCount)
+  graphStore.set(toggleDisplayAllAtom, allCount > monthCount)
+  fallbackHiddenLimit()
+}
+
+/** 非表示になったタブが選択中の場合、表示中のタブにフォールバックする */
+function fallbackHiddenLimit() {
   if (graphStore.get(limitAtom) === 0 && !graphStore.get(toggleDisplayAllAtom)) {
     graphStore.set(limitAtom, graphStore.get(toggleDisplayMonthAtom) ? 31 : 8)
   }

--- a/frontend/oc-app/src/graph/types/api.d.ts
+++ b/frontend/oc-app/src/graph/types/api.d.ts
@@ -11,6 +11,8 @@ type StatisticsChartDto = {
   member: (number | null)[]
   startDate: string
   endDate: string
+  /** 期間タブ毎にローソク足(OHLC)データが存在するか */
+  ohlcAvailability: { week: boolean; month: boolean; all: boolean }
 }
 
 interface MemberOhlc {

--- a/frontend/oc-app/src/graph/util/fetchRenderer.ts
+++ b/frontend/oc-app/src/graph/util/fetchRenderer.ts
@@ -7,6 +7,7 @@ import {
   loadingAtom,
   rankingRisingAtom,
   renderPositionBtnsAtom,
+  updateCandleTabVisibility,
   updateTabVisibility,
 } from '../state/chartState'
 import fetcher from './fetcher'
@@ -110,8 +111,8 @@ export async function fetchChart(animation: boolean) {
     )
     chart.memberOhlcApiData = memberOhlcData
 
-    // OHLCデータ数に基づいてタブ表示を更新
-    updateTabVisibility(memberOhlcData.length)
+    // 期間タブ毎のローソク足本数に基づいてタブ表示を更新
+    updateCandleTabVisibility(memberOhlcData)
     const currentLimit = graphStore.get(limitAtom)
     const limit: ChartLimit = currentLimit === 25 ? 31 : currentLimit
 


### PR DESCRIPTION
## 概要

stg → main の本番リリース。

含まれる変更: #359

## 内容

- 個別ルームページのグラフで、ローソク足を表示できない期間タブでは切り替えボタンをグレーアウト（24時間タブと同様の表示）
- ページ埋め込みの統計データに期間タブ毎のローソク足有無を追加（1週間=全日分必須 / 1ヶ月=半分以上 / 全期間=1件以上）
- 過去にしかローソク足データがない部屋で全期間タブが消えて「OHLCデータがありません」になる既存バグも修正

CI は #359 で通過済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)