### PR TITLE
[STG] fix: ローソク足グラフの表示崩れを修正、データがない期間のランキング表示ボタンをグレーアウト化

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -96,7 +96,10 @@ class OpenChatPageController
         $categoryValue = $oc['category'] ? array_search($oc['category'], AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot]) : null;
         $category = $categoryValue ?? t('未指定');
 
-        $_statsDto = $statisticsChartArrayService->buildStatisticsChartArray($open_chat_id);
+        $_statsDto = $statisticsChartArrayService->buildStatisticsChartArray(
+            $open_chat_id,
+            isset($oc['category']) ? (int)$oc['category'] : null
+        );
         if (!$_statsDto) {
             $_statsDto = new StatisticsChartDto((new \DateTime('-1day'))->format('Y-m-d'), (new \DateTime('now'))->format('Y-m-d'));
         }

--- a/app/Models/RankingPositionDB/Repositories/RankingPositionHourRepository.php
+++ b/app/Models/RankingPositionDB/Repositories/RankingPositionHourRepository.php
@@ -404,6 +404,39 @@ class RankingPositionHourRepository implements RankingPositionHourRepositoryInte
         ];
     }
 
+    public function getHourPositionCounts(
+        int $open_chat_id,
+        int $inCategory,
+        int $intervalHour,
+        \DateTime $endTime
+    ): array {
+        $firstTime = (new \DateTime($endTime->format('Y-m-d H:i:s')))
+            ->modify("- {$intervalHour}hour")
+            ->format('Y-m-d H:i:s');
+
+        $query =
+            "SELECT
+                (SELECT COUNT(*) FROM member WHERE open_chat_id = :open_chat_id AND time >= :first_time) AS member,
+                (SELECT COUNT(*) FROM ranking WHERE open_chat_id = :open_chat_id AND category = :in_category AND time >= :first_time) AS ranking_in,
+                (SELECT COUNT(*) FROM ranking WHERE open_chat_id = :open_chat_id AND category = 0 AND time >= :first_time) AS ranking_all,
+                (SELECT COUNT(*) FROM rising WHERE open_chat_id = :open_chat_id AND category = :in_category AND time >= :first_time) AS rising_in,
+                (SELECT COUNT(*) FROM rising WHERE open_chat_id = :open_chat_id AND category = 0 AND time >= :first_time) AS rising_all";
+
+        $result = RankingPositionDB::fetch($query, [
+            'open_chat_id' => $open_chat_id,
+            'in_category' => $inCategory,
+            'first_time' => $firstTime,
+        ]);
+
+        return [
+            'member' => (int)($result['member'] ?? 0),
+            'ranking_in' => (int)($result['ranking_in'] ?? 0),
+            'ranking_all' => (int)($result['ranking_all'] ?? 0),
+            'rising_in' => (int)($result['rising_in'] ?? 0),
+            'rising_all' => (int)($result['rising_all'] ?? 0),
+        ];
+    }
+
     public function getLastHour(int $offset = 0): string|false
     {
         $categories = AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot];

--- a/app/Models/Repositories/RankingPosition/RankingPositionHourRepositoryInterface.php
+++ b/app/Models/Repositories/RankingPosition/RankingPositionHourRepositoryInterface.php
@@ -68,4 +68,18 @@ interface RankingPositionHourRepositoryInterface
      * @return string|false Y-m-d H:i:s
      */
     public function getLastHour(int $offset = 0): string|false;
+
+    /**
+     * 最新24時間ウィンドウ内の毎時データ件数（メンバー数・ランキング種別×カテゴリ毎の掲載数）を取得する。
+     *
+     * @param int $inCategory カテゴリ内判定に使うカテゴリID（カテゴリ無しの部屋は -1 等の不一致値を渡す）
+     * @param \DateTime $endTime ウィンドウの終端（最新クロール時刻）
+     * @return array{ member: int, ranking_in: int, ranking_all: int, rising_in: int, rising_all: int }
+     */
+    public function getHourPositionCounts(
+        int $open_chat_id,
+        int $inCategory,
+        int $intervalHour,
+        \DateTime $endTime
+    ): array;
 }

--- a/app/Models/Repositories/RankingPosition/RankingPositionRepositoryInterface.php
+++ b/app/Models/Repositories/RankingPosition/RankingPositionRepositoryInterface.php
@@ -29,4 +29,20 @@ interface RankingPositionRepositoryInterface
      * @return string|false Y-m-d
      */
     public function getLastDate(): string|false;
+
+    /**
+     * ランキング種別(ranking/rising)×カテゴリ(in/all)毎の掲載日数を
+     * 全期間・指定日以降（週/月ウィンドウ）でまとめて取得する。
+     *
+     * @param int $inCategory カテゴリ内判定に使うカテゴリID（カテゴリ無しの部屋は -1 等の不一致値を渡す）
+     * @param string $weekStartDate `Y-m-d` 週ウィンドウの開始日
+     * @param string $monthStartDate `Y-m-d` 月ウィンドウの開始日
+     * @return array<'ranking_in'|'ranking_all'|'rising_in'|'rising_all', array{ week: int, month: int, all: int }>
+     */
+    public function getPositionCountsByPeriod(
+        int $open_chat_id,
+        int $inCategory,
+        string $weekStartDate,
+        string $monthStartDate
+    ): array;
 }

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
@@ -56,6 +56,54 @@ class SqliteRankingPositionRepository implements RankingPositionRepositoryInterf
         );
     }
 
+    public function getPositionCountsByPeriod(
+        int $open_chat_id,
+        int $inCategory,
+        string $weekStartDate,
+        string $monthStartDate
+    ): array {
+        $result = [];
+
+        SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
+
+        foreach (['ranking', 'rising'] as $tableName) {
+            $row = SQLiteRankingPosition::fetch(
+                "SELECT
+                    COUNT(CASE WHEN category = :in_category THEN 1 END) AS in_all,
+                    COUNT(CASE WHEN category = :in_category AND date >= :month_start_date THEN 1 END) AS in_month,
+                    COUNT(CASE WHEN category = :in_category AND date >= :week_start_date THEN 1 END) AS in_week,
+                    COUNT(CASE WHEN category = 0 THEN 1 END) AS all_all,
+                    COUNT(CASE WHEN category = 0 AND date >= :month_start_date THEN 1 END) AS all_month,
+                    COUNT(CASE WHEN category = 0 AND date >= :week_start_date THEN 1 END) AS all_week
+                FROM
+                    {$tableName}
+                WHERE
+                    open_chat_id = :open_chat_id",
+                [
+                    'open_chat_id' => $open_chat_id,
+                    'in_category' => $inCategory,
+                    'week_start_date' => $weekStartDate,
+                    'month_start_date' => $monthStartDate,
+                ]
+            );
+
+            $result["{$tableName}_in"] = [
+                'week' => (int)($row['in_week'] ?? 0),
+                'month' => (int)($row['in_month'] ?? 0),
+                'all' => (int)($row['in_all'] ?? 0),
+            ];
+            $result["{$tableName}_all"] = [
+                'week' => (int)($row['all_week'] ?? 0),
+                'month' => (int)($row['all_month'] ?? 0),
+                'all' => (int)($row['all_all'] ?? 0),
+            ];
+        }
+
+        SQLiteRankingPosition::$pdo = null;
+
+        return $result;
+    }
+
     public function getLastDate(): string|false
     {
         $categories = AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot];

--- a/app/Services/Statistics/Dto/StatisticsChartDto.php
+++ b/app/Services/Statistics/Dto/StatisticsChartDto.php
@@ -23,6 +23,28 @@ class StatisticsChartDto
      */
     public array $ohlcAvailability = ['week' => false, 'month' => false, 'all' => false];
 
+    /** 最新24時間タブに表示できる毎時メンバー数データが存在するか */
+    public bool $hourAvailability = false;
+
+    /**
+     * 期間タブ×ランキング種別(ranking/rising)×カテゴリ(in/all)毎に順位データが存在するか
+     *
+     * @var array<'hour'|'week'|'month'|'all', array{ ranking_in: bool, ranking_all: bool, rising_in: bool, rising_all: bool }>
+     */
+    public array $positionAvailability = [
+        'hour' => self::POSITION_NONE,
+        'week' => self::POSITION_NONE,
+        'month' => self::POSITION_NONE,
+        'all' => self::POSITION_NONE,
+    ];
+
+    private const POSITION_NONE = [
+        'ranking_in' => false,
+        'ranking_all' => false,
+        'rising_in' => false,
+        'rising_all' => false,
+    ];
+
     function __construct(string $startDate, string $endDate)
     {
         $this->startDate = $startDate;

--- a/app/Services/Statistics/StatisticsChartArrayService.php
+++ b/app/Services/Statistics/StatisticsChartArrayService.php
@@ -4,23 +4,33 @@ declare(strict_types=1);
 
 namespace App\Services\Statistics;
 
+use App\Models\Repositories\RankingPosition\RankingPositionHourRepositoryInterface;
+use App\Models\Repositories\RankingPosition\RankingPositionRepositoryInterface;
 use App\Models\Repositories\Statistics\StatisticsOhlcRepositoryInterface;
 use App\Models\Repositories\Statistics\StatisticsPageRepositoryInterface;
 use App\Services\Statistics\Dto\StatisticsChartDto;
+use App\Services\Storage\FileStorageInterface;
 
 class StatisticsChartArrayService
 {
+    /** 最新24時間タブのウィンドウ幅（RankingPositionHourChartArrayServiceと同じ） */
+    private const HOUR_INTERVAL = 24;
+
     function __construct(
         private StatisticsPageRepositoryInterface $statisticsPageRepository,
         private StatisticsOhlcRepositoryInterface $statisticsOhlcRepository,
+        private RankingPositionRepositoryInterface $rankingPositionRepository,
+        private RankingPositionHourRepositoryInterface $rankingPositionHourRepository,
+        private FileStorageInterface $fileStorage,
     ) {}
 
     /**
      * 日毎のメンバー数の統計を取得する
      *
+     * @param int|null $category 部屋のカテゴリID（未掲載・その他はnull/0）
      * @return array{ date: string, member: int }[] date: Y-m-d
      */
-    function buildStatisticsChartArray(int $open_chat_id): StatisticsChartDto|false
+    function buildStatisticsChartArray(int $open_chat_id, int|null $category = null): StatisticsChartDto|false
     {
         $memberStats = $this->statisticsPageRepository->getDailyMemberStatsDateAsc($open_chat_id);
 
@@ -37,8 +47,66 @@ class StatisticsChartArrayService
         );
 
         $this->setOhlcAvailability($dto, $open_chat_id);
+        $this->setPositionAvailability($dto, $open_chat_id, $category);
 
         return $dto;
+    }
+
+    /**
+     * 期間タブ×種別×カテゴリ毎のランキング順位データ有無と、
+     * 最新24時間タブの毎時メンバー数データ有無を設定する
+     *
+     * フロントエンドはこれを基に「最新24時間」タブと
+     * 「ランキングの順位を表示」の各ボタンを期間毎に出し分ける
+     */
+    private function setPositionAvailability(StatisticsChartDto $dto, int $open_chat_id, int|null $category): void
+    {
+        // カテゴリ未設定(その他/未掲載)の部屋はカテゴリ内ランキングを持たない
+        $inCategory = ($category !== null && $category > 0) ? $category : -1;
+
+        $len = count($dto->date);
+
+        try {
+            $counts = $this->rankingPositionRepository->getPositionCountsByPeriod(
+                $open_chat_id,
+                $inCategory,
+                $dto->date[$len - min(8, $len)],
+                $dto->date[$len - min(31, $len)],
+            );
+        } catch (\PDOException) {
+            // DBファイル未作成の環境は「データ無し」として扱う
+            return;
+        }
+
+        foreach (['week', 'month', 'all'] as $period) {
+            $dto->positionAvailability[$period] = [
+                'ranking_in' => $counts['ranking_in'][$period] > 0,
+                'ranking_all' => $counts['ranking_all'][$period] > 0,
+                'rising_in' => $counts['rising_in'][$period] > 0,
+                'rising_all' => $counts['rising_all'][$period] > 0,
+            ];
+        }
+
+        try {
+            $updatedAt = $this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime');
+            $hourCounts = $this->rankingPositionHourRepository->getHourPositionCounts(
+                $open_chat_id,
+                $inCategory,
+                self::HOUR_INTERVAL,
+                new \DateTime($updatedAt),
+            );
+        } catch (\Throwable) {
+            // 毎時クロール未実行・DB未作成の環境は「データ無し」として扱う
+            return;
+        }
+
+        $dto->hourAvailability = $hourCounts['member'] > 0;
+        $dto->positionAvailability['hour'] = [
+            'ranking_in' => $hourCounts['ranking_in'] > 0,
+            'ranking_all' => $hourCounts['ranking_all'] > 0,
+            'rising_in' => $hourCounts['rising_in'] > 0,
+            'rising_all' => $hourCounts['rising_all'] > 0,
+        ];
     }
 
     /**

--- a/frontend/oc-app/src/graph/classes/ChartJS/Factories/buildOptions.ts
+++ b/frontend/oc-app/src/graph/classes/ChartJS/Factories/buildOptions.ts
@@ -194,14 +194,14 @@ export default function buildOptions(
   }
 
   // ローソク足モード: CandlestickControllerがautoSkipを極端に効かせるため無効化
-  // 月・全期間はcallbackでラベルを間引く
+  // 1週間・1ヶ月は全ラベル表示（折れ線と同じ）。全期間のみcallbackで間引く
   if (ocChart.getMode() === 'candlestick') {
     options.scales!.x!.ticks!.autoSkip = false
 
     const dataLen = ocChart.ohlcData.length
 
-    if (!isWeekly) {
-      const maxLabels = limit === 31 ? 15 : 20
+    if (limit === 0) {
+      const maxLabels = 20
       const step = Math.max(1, Math.ceil(dataLen / maxLabels))
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       options.scales!.x!.ticks!.callback = function (this: any, _val: any, index: number) {

--- a/frontend/oc-app/src/graph/classes/ChartJS/Factories/buildPlugin.ts
+++ b/frontend/oc-app/src/graph/classes/ChartJS/Factories/buildPlugin.ts
@@ -57,6 +57,9 @@ export default function buildPlugin(ocChart: OpenChatChart): any {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 return chart.data.datasets.map((ds: any, i: number) => ({
                   text: ds.label,
+                  // fontColor を渡さないと fillStyle が未設定のまま描画され
+                  // ダークテーマで文字が背景と同化する（Chart.js は item.fontColor を参照）
+                  fontColor: getColors().text.primary,
                   fillStyle: colors[i] ?? getColors().text.tertiary,
                   strokeStyle: colors[i] ?? getColors().text.tertiary,
                   lineWidth: 0,

--- a/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
+++ b/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
@@ -12,6 +12,7 @@ import {
   toggleDisplay24hAtom,
   toggleDisplayAllAtom,
   toggleDisplayMonthAtom,
+  toggleDisplayWeekAtom,
 } from '../state/chartState'
 import { t } from '../util/translation'
 
@@ -51,6 +52,7 @@ export default function ChartLimitBtns() {
   const limit = useAtomValue(limitAtom)
   const chartMode = useAtomValue(chartModeAtom)
   const display24h = useAtomValue(toggleDisplay24hAtom)
+  const displayWeek = useAtomValue(toggleDisplayWeekAtom)
   const displayMonth = useAtomValue(toggleDisplayMonthAtom)
   const displayAll = useAtomValue(toggleDisplayAllAtom)
 
@@ -68,7 +70,7 @@ export default function ChartLimitBtns() {
           {display24h && chartMode !== 'candlestick' && (
             <Tab value={25} label={t('最新24時間')} />
           )}
-          <Tab value={8} label={t('1週間')} />
+          {displayWeek && <Tab value={8} label={t('1週間')} />}
           {displayMonth && <Tab value={31} label={t('1ヶ月')} />}
           {displayAll && <Tab value={0} label={t('全期間')} />}
         </Tabs>

--- a/frontend/oc-app/src/graph/components/ToggleButtons.tsx
+++ b/frontend/oc-app/src/graph/components/ToggleButtons.tsx
@@ -20,12 +20,13 @@ import {
   limitAtom,
   handleChangeEnableZoom,
   zoomEnableAtom,
+  getPositionAvailabilityForLimit,
 } from '../state/chartState'
 import SettingButton from './SettingButton'
 import { t } from '../util/translation'
 import { useIsDark } from '../../themeMui'
 
-const chips1: [string, ToggleChart][] = [
+const chips1: [string, Exclude<ToggleChart, 'none'>][] = [
   [t('急上昇'), 'rising'],
   [t('ランキング'), 'ranking'],
 ]
@@ -34,19 +35,31 @@ function CategoryToggle() {
   const rankingRising = useAtomValue(rankingRisingAtom)
   const category = useAtomValue(categoryAtom)
   const toggleShowCategory = useAtomValue(toggleShowCategoryAtom)
+  const limit = useAtomValue(limitAtom)
+
+  // 期間タブ毎: 選択中の種別でデータが無いカテゴリのボタンはグレーアウト
+  // （種別未選択時はどちらかの種別にデータがあれば有効扱い）
+  const avail = getPositionAvailabilityForLimit(limit)
+  const enableIn =
+    rankingRising === 'none' ? avail.ranking_in || avail.rising_in : avail[`${rankingRising}_in`]
+  const enableAll =
+    rankingRising === 'none'
+      ? avail.ranking_all || avail.rising_all
+      : avail[`${rankingRising}_all`]
 
   const handleChangeToggle = (_e: React.SyntheticEvent, alignment: urlParamsValue<'category'> | null) => {
     rankingRising !== 'none' && handleChangeCategory(alignment)
   }
 
   const isDark = useIsDark()
+  const isDisabled = rankingRising === 'none'
 
   return (
     <Stack
       direction="row"
       spacing={1}
       alignItems="center"
-      sx={{ opacity: rankingRising === 'none' ? 0.2 : undefined }}
+      sx={{ opacity: isDisabled ? 0.2 : undefined }}
     >
       <ToggleButtonGroup
         value={category}
@@ -63,7 +76,8 @@ function CategoryToggle() {
                   '&.Mui-selected': {
                     color: '#ffffff',
                     backgroundColor: '#565b60',
-                    borderColor: '#d3d6d8',
+                    /* グレーアウト時は明るい枠が悪目立ちするので通常枠と同じ色に */
+                    borderColor: isDisabled ? '#71767b' : '#d3d6d8',
                     '&:hover': {
                       backgroundColor: '#71767b',
                     },
@@ -71,16 +85,20 @@ function CategoryToggle() {
                   '&:hover': {
                     backgroundColor: 'rgba(231, 233, 234, 0.15)',
                   },
+                  '&.Mui-disabled': {
+                    color: 'rgba(239, 241, 242, 0.35)',
+                    borderColor: '#3f4347',
+                  },
                 },
               }
             : undefined
         }
       >
-        <ToggleButton value="all">
+        <ToggleButton value="all" disabled={!enableAll}>
           <Typography variant="caption">{t('すべて')}</Typography>
         </ToggleButton>
         {toggleShowCategory && (
-          <ToggleButton value="in">
+          <ToggleButton value="in" disabled={!enableIn}>
             <Typography variant="caption">{t('カテゴリー内')}</Typography>
           </ToggleButton>
         )}
@@ -113,6 +131,13 @@ export default function ToggleButtons() {
   const rankingRising = useAtomValue(rankingRisingAtom)
   const limit = useAtomValue(limitAtom)
   const toggleShowCategory = useAtomValue(toggleShowCategoryAtom)
+
+  // 期間タブ毎: データが0件の種別チップはグレーアウト（完全に消すと空白がバグに見えるため）
+  const avail = getPositionAvailabilityForLimit(limit)
+  const enableChip: Record<Exclude<ToggleChart, 'none'>, boolean> = {
+    rising: avail.rising_in || avail.rising_all,
+    ranking: avail.ranking_in || avail.ranking_all,
+  }
 
   return (
     <Box>
@@ -150,8 +175,17 @@ export default function ToggleButtons() {
                   key={chip[1]}
                   className={`openchat-item-header-chip graph ${rankingRising === chip[1] ? 'selected' : ''}`}
                   label={chip[0]}
-                  onClick={() => handleChangeRankingRising(rankingRising === chip[1] ? 'none' : chip[1])}
+                  onClick={
+                    enableChip[chip[1]]
+                      ? () => handleChangeRankingRising(rankingRising === chip[1] ? 'none' : chip[1])
+                      : undefined
+                  }
                   size={isMiniMobile ? 'small' : 'medium'}
+                  sx={
+                    enableChip[chip[1]]
+                      ? undefined
+                      : { opacity: 0.4, cursor: 'default', pointerEvents: 'none' }
+                  }
                 />
               )
           )}

--- a/frontend/oc-app/src/graph/components/ToggleButtons.tsx
+++ b/frontend/oc-app/src/graph/components/ToggleButtons.tsx
@@ -138,6 +138,8 @@ export default function ToggleButtons() {
     rising: avail.rising_in || avail.rising_all,
     ranking: avail.ranking_in || avail.ranking_all,
   }
+  // 表示中の期間にデータが全く無い場合は見出しも薄く
+  const enableAny = enableChip.rising || enableChip.ranking
 
   return (
     <Box>
@@ -147,7 +149,13 @@ export default function ToggleButtons() {
         alignItems="center"
         justifyContent={isPc ? 'space-around' : 'space-between'}
       >
-        <Typography variant="h3" fontSize="13px" fontWeight="bold" color="var(--c-text-1)">
+        <Typography
+          variant="h3"
+          fontSize="13px"
+          fontWeight="bold"
+          color="var(--c-text-1)"
+          sx={{ opacity: enableAny ? undefined : 0.4 }}
+        >
           {t('ランキングの順位を表示')}
         </Typography>
         {limit === 0 && !isPc && <SwitchLabels />}

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -112,24 +112,96 @@ export function initDisplay() {
   // データ数に基づいてタブ表示を設定
   updateTabVisibility(statsDto.date.length)
 
-  // ランキング未掲載の場合
-  if (chatArgDto.categoryKey === null) {
-    graphStore.set(renderPositionBtnsAtom, false)
+  // 最新24時間タブ: 毎時メンバー数データが無い場合は非表示（DTOのデータ有無で判定）
+  if (!statsDto.hourAvailability) {
     chart.setIsHour(false)
     graphStore.set(toggleDisplay24hAtom, false)
+    graphStore.get(limitAtom) === 25 && graphStore.set(limitAtom, 8)
+  }
 
+  // ランキング順位データが全期間・全組み合わせで0件の場合は「ランキングの順位を表示」を丸ごと非表示
+  if (!hasAnyPositionData()) {
+    graphStore.set(renderPositionBtnsAtom, false)
     graphStore.set(categoryAtom, 'in')
     graphStore.set(rankingRisingAtom, 'none')
-    graphStore.get(limitAtom) === 25 && graphStore.set(limitAtom, 8)
 
-    return false
+    // 24時間タブ表示中のみAPI取得が必要
+    return chart.getIsHour()
   }
+
+  graphStore.set(renderPositionBtnsAtom, true)
+  sanitizePositionSelection()
 
   return true
 }
 
+const emptyPositionAvailability: PositionAvailability = {
+  ranking_in: false,
+  ranking_all: false,
+  rising_in: false,
+  rising_all: false,
+}
+
+/** 指定の期間タブの順位データ有無を取得する */
+export function getPositionAvailabilityForLimit(limit: ChartLimit | 25): PositionAvailability {
+  const availability = statsDto.positionAvailability
+  if (!availability) return emptyPositionAvailability
+
+  switch (limit) {
+    case 25:
+      return availability.hour ?? emptyPositionAvailability
+    case 8:
+      return availability.week ?? emptyPositionAvailability
+    case 31:
+      return availability.month ?? emptyPositionAvailability
+    case 0:
+      return availability.all ?? emptyPositionAvailability
+  }
+}
+
+/** いずれかの期間・組み合わせで順位データが存在するか */
+export function hasAnyPositionData(): boolean {
+  const availability = statsDto.positionAvailability
+  if (!availability) return false
+
+  return Object.values(availability).some(
+    (p) => p && (p.ranking_in || p.ranking_all || p.rising_in || p.rising_all)
+  )
+}
+
+/**
+ * 現在の期間タブで選択中の順位表示(種別×カテゴリ)にデータが無い場合、
+ * データのある組み合わせへフォールバックする
+ *
+ * @returns 選択を変更した場合 true
+ */
+function sanitizePositionSelection(): boolean {
+  const sort = graphStore.get(rankingRisingAtom)
+  if (sort === 'none') return false
+
+  const avail = getPositionAvailabilityForLimit(graphStore.get(limitAtom))
+
+  // 種別自体にデータが無い場合は順位表示を解除する
+  if (!avail[`${sort}_in`] && !avail[`${sort}_all`]) {
+    graphStore.set(rankingRisingAtom, 'none')
+    return true
+  }
+
+  // 選択中のカテゴリにデータが無い場合はもう一方へ切り替える
+  const categoryKey = graphStore.get(categoryAtom) === 'all' ? 'all' : 'in'
+  if (!avail[`${sort}_${categoryKey}`]) {
+    graphStore.set(categoryAtom, categoryKey === 'all' ? 'in' : 'all')
+    return true
+  }
+
+  return false
+}
+
 export function handleChangeLimit(limit: ChartLimit | 25) {
   graphStore.set(limitAtom, limit)
+
+  // 移動先の期間タブでデータが無い順位表示(種別×カテゴリ)を解除する
+  const selectionChanged = sanitizePositionSelection()
 
   // 移動先の期間タブにOHLCデータが無い場合は折れ線グラフに戻す
   const fallbackToLine =
@@ -145,8 +217,8 @@ export function handleChangeLimit(limit: ChartLimit | 25) {
   } else if (chart.getIsHour()) {
     chart.setIsHour(false)
     fetchChart(true)
-  } else if (fallbackToLine) {
-    // モードが変わるため折れ線グラフ用のデータで再取得する
+  } else if (fallbackToLine || selectionChanged) {
+    // モードまたは順位表示の選択が変わるため、表示中のデータのままでは再描画できない
     fetchChart(true)
   } else {
     chart.update(limit)
@@ -164,6 +236,16 @@ export function handleChangeCategory(alignment: urlParamsValue<'category'> | nul
 
 export function handleChangeRankingRising(alignment: ToggleChart) {
   graphStore.set(rankingRisingAtom, alignment)
+
+  // 選択した種別で現在のカテゴリにデータが無い場合、データのあるカテゴリへ切り替える
+  if (alignment !== 'none') {
+    const avail = getPositionAvailabilityForLimit(graphStore.get(limitAtom))
+    const categoryKey = graphStore.get(categoryAtom) === 'all' ? 'all' : 'in'
+    if (!avail[`${alignment}_${categoryKey}`]) {
+      graphStore.set(categoryAtom, categoryKey === 'all' ? 'in' : 'all')
+    }
+  }
+
   fetchChart(false)
   setUrlParamsFromChartStates()
 }

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -17,6 +17,7 @@ export const chartModeAtom = atom<ChartMode>('line')
 export const renderTabAtom = atom(false)
 export const renderPositionBtnsAtom = atom(false)
 export const toggleDisplay24hAtom = atom(true)
+export const toggleDisplayWeekAtom = atom(true)
 export const toggleDisplayMonthAtom = atom(true)
 export const toggleDisplayAllAtom = atom(true)
 
@@ -277,6 +278,7 @@ export function hasOhlcDataForLimit(limit: ChartLimit | 25): boolean {
 }
 
 export function updateTabVisibility(dataLength: number) {
+  graphStore.set(toggleDisplayWeekAtom, true)
   graphStore.set(toggleDisplayMonthAtom, dataLength > 8)
   graphStore.set(toggleDisplayAllAtom, dataLength > 31)
   fallbackHiddenLimit()
@@ -285,8 +287,10 @@ export function updateTabVisibility(dataLength: number) {
 /**
  * ローソク足モード: 期間タブ毎のウィンドウ内ローソク足本数に基づいてタブ表示を設定する
  *
- * OHLCデータは記録期間が限られるため（例: 過去のみに存在する部屋）、
- * 件数ではなく各タブのウィンドウに実際に入る本数で判定する
+ * - ローソク足を利用できない期間（折れ線モードで切替ボタンがグレーアウトになる期間）の
+ *   タブは非表示にする
+ * - OHLCデータは記録期間が限られるため（例: 過去のみに存在する部屋）、
+ *   より短いタブで全て表示しきれる冗長な長いタブも非表示にする
  */
 export function updateCandleTabVisibility(ohlcData: MemberOhlc[]) {
   const dates = statsDto.date
@@ -303,20 +307,29 @@ export function updateCandleTabVisibility(ohlcData: MemberOhlc[]) {
   const monthCount = countInWindow(31)
   const allCount = countInWindow(0)
 
-  // より短いタブで全て表示しきれないローソク足がある場合のみ表示
-  graphStore.set(toggleDisplayMonthAtom, monthCount > weekCount)
-  graphStore.set(toggleDisplayAllAtom, allCount > monthCount)
+  const showWeek = hasOhlcDataForLimit(8)
+  const showMonth = hasOhlcDataForLimit(31) && monthCount > (showWeek ? weekCount : 0)
+  const showAll = allCount > (showMonth ? monthCount : showWeek ? weekCount : 0)
+
+  graphStore.set(toggleDisplayWeekAtom, showWeek)
+  graphStore.set(toggleDisplayMonthAtom, showMonth)
+  graphStore.set(toggleDisplayAllAtom, showAll)
   fallbackHiddenLimit()
 }
 
 /** 非表示になったタブが選択中の場合、表示中のタブにフォールバックする */
 function fallbackHiddenLimit() {
-  if (graphStore.get(limitAtom) === 0 && !graphStore.get(toggleDisplayAllAtom)) {
-    graphStore.set(limitAtom, graphStore.get(toggleDisplayMonthAtom) ? 31 : 8)
+  const display: Record<ChartLimit, boolean> = {
+    8: graphStore.get(toggleDisplayWeekAtom),
+    31: graphStore.get(toggleDisplayMonthAtom),
+    0: graphStore.get(toggleDisplayAllAtom),
   }
-  if (graphStore.get(limitAtom) === 31 && !graphStore.get(toggleDisplayMonthAtom)) {
-    graphStore.set(limitAtom, 8)
-  }
+
+  const limit = graphStore.get(limitAtom)
+  if (limit === 25 || display[limit]) return
+
+  const fallback = ([31, 8, 0] as ChartLimit[]).find((l) => l !== limit && display[l])
+  fallback !== undefined && graphStore.set(limitAtom, fallback)
 }
 
 export function handleChangeChartMode(mode: ChartMode) {

--- a/frontend/oc-app/src/graph/types/api.d.ts
+++ b/frontend/oc-app/src/graph/types/api.d.ts
@@ -6,6 +6,14 @@ type RankingPositionChartArgDto = {
   urlRoot: string
 }
 
+/** ランキング種別(ranking/rising)×カテゴリ(in/all)毎に順位データが存在するか */
+type PositionAvailability = {
+  ranking_in: boolean
+  ranking_all: boolean
+  rising_in: boolean
+  rising_all: boolean
+}
+
 type StatisticsChartDto = {
   date: string[]
   member: (number | null)[]
@@ -13,6 +21,15 @@ type StatisticsChartDto = {
   endDate: string
   /** 期間タブ毎にローソク足(OHLC)データが存在するか */
   ohlcAvailability: { week: boolean; month: boolean; all: boolean }
+  /** 最新24時間タブに表示できる毎時メンバー数データが存在するか */
+  hourAvailability: boolean
+  /** 期間タブ毎の順位データ有無 */
+  positionAvailability: {
+    hour: PositionAvailability
+    week: PositionAvailability
+    month: PositionAvailability
+    all: PositionAvailability
+  }
 }
 
 interface MemberOhlc {

--- a/frontend/oc-app/src/graph/util/fetchRenderer.ts
+++ b/frontend/oc-app/src/graph/util/fetchRenderer.ts
@@ -6,7 +6,6 @@ import {
   limitAtom,
   loadingAtom,
   rankingRisingAtom,
-  renderPositionBtnsAtom,
   updateCandleTabVisibility,
   updateTabVisibility,
 } from '../state/chartState'
@@ -102,8 +101,6 @@ export function renderChartWithoutRanking() {
 
 export async function fetchChart(animation: boolean) {
   if (graphStore.get(chartModeAtom) === 'candlestick') {
-    graphStore.set(renderPositionBtnsAtom, true)
-
     // メンバーOHLCをAPI経由で取得
     graphStore.set(loadingAtom, true)
     const memberOhlcData = await fetcher<MemberOhlc[]>(
@@ -160,8 +157,6 @@ export async function fetchChart(animation: boolean) {
 
   // メンバーグラフのみの場合
   if (ranking === 'none') {
-    graphStore.set(renderPositionBtnsAtom, true)
-
     if (chart.getIsHour()) {
       graphStore.set(loadingAtom, true)
       await fetcher<RankingPositionChart>(
@@ -181,7 +176,6 @@ export async function fetchChart(animation: boolean) {
   await fetcher<RankingPositionChart>(
     `${chatArgDto.baseUrl}/oc/${chatArgDto.id}/${path}?${getApiQuery(param, chart.getIsHour())}`
   ).then((data) => {
-    graphStore.set(renderPositionBtnsAtom, true)
     renderChart(param, animation, limit)(data)
   })
 }


### PR DESCRIPTION
## 問題の概要

個別ルームページのグラフに複数の表示問題があった。

### 1. ローソク足の日付ラベルが歯抜けになる

折れ線グラフでは1ヶ月タブのX軸日付（31個）が全て表示されるのに、ローソク足に切り替えると15個に間引かれていた。ローソク足モードの手動間引き処理が、本来必要な全期間タブだけでなく1ヶ月タブにも効いていたのが原因。

### 2. ダークテーマでローソク足の凡例文字が見えない

ローソク足用のカスタム凡例生成が文字色（fontColor）を返しておらず、ダークテーマで「メンバー数」のラベルが背景と同化して見えなかった。

### 3. ランキング掲載データがない期間でも順位表示ボタンが押せてしまう

「最新24時間」タブと「ランキングの順位を表示」のボタン群は、ランキング掲載歴の有無でしか出し分けておらず、過去に掲載歴はあるが直近はデータがない部屋では、ボタンを押しても空のグラフが表示されるだけだった。

### 4. ローソク足を利用できない期間のタブが残る

OHLCデータが揃っていない期間（例: 1週間分が無い部屋の1週間タブ）が、ローソク足モードでもタブとして残り、選択すると折れ線に戻されて混乱を招いていた。

## 対処内容

- 1ヶ月タブのローソク足は日付ラベルを全表示（間引きは全期間タブのみ）
- ローソク足の凡例文字色をテーマに応じて明示的に設定
- ページ埋め込みの統計データ(stats-dto)に「期間タブ×種別(急上昇/ランキング)×カテゴリ(すべて/カテゴリー内)」毎のデータ有無を追加し、表示中の期間にデータがないボタンを個別にグレーアウト（完全に消すと空白がバグに見えるため薄く表示）
  - 期間内に順位データが全く無い場合は「ランキングの順位を表示」の見出しも薄く表示
  - 最新24時間タブ: 直近24時間の毎時データがない場合は非表示
  - 期間タブ切替時、選択中の組み合わせのデータがない場合は自動で解除
- ローソク足モードでは利用できない期間のタブ自体を非表示（折れ線に戻すと全タブ復帰）
- あわせてダークテーマでグレーアウト中のカテゴリトグルの枠線が明るすぎる問題を修正

## 動作確認

- ローカル環境（実データ）でダーク/ライト両テーマ・全期間タブ・掲載歴パターン別（通常部屋/過去のみ掲載/未掲載/OHLC途中開始）に表示と選択フォールバックを確認
- `vendor/bin/phpunit app/Services/Statistics/test/` パス（リポジトリテストの既存12件のエラーはstg時点で再現する環境起因のもので本PRとは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)