### PR TITLE
[STG] fix: 部屋の増減指標がサーバー時計とのズレで誤る問題を修正（更新時刻を基準に統一）

### DIFF
--- a/app/Models/Repositories/OcNarrativeRepository.php
+++ b/app/Models/Repositories/OcNarrativeRepository.php
@@ -27,9 +27,9 @@ class OcNarrativeRepository implements OcNarrativeRepositoryInterface
     ) {
     }
 
-    public function getMemberMetrics(int $openChatId): array
+    public function getMemberMetrics(int $openChatId, ?string $baseDate = null): array
     {
-        return $this->statisticsRepository->getMemberMetricsForNarrative($openChatId);
+        return $this->statisticsRepository->getMemberMetricsForNarrative($openChatId, $baseDate);
     }
 
     public function getPositionMovement(int $openChatId, int $category, int $days = 30): array

--- a/app/Models/Repositories/OcNarrativeRepositoryInterface.php
+++ b/app/Models/Repositories/OcNarrativeRepositoryInterface.php
@@ -14,6 +14,8 @@ interface OcNarrativeRepositoryInterface
     /**
      * narrative 用のメンバー数メトリクス（OHLC 集約）。
      *
+     * @param ?string $baseDate 「現在の基準日」('Y-m-d')。指定時はこの日基準で m1/m7/m30/m90 等を
+     *                          算出する。null 時は SQLite 実行時刻 (date('now')、UTC) 基準。
      * @return array{
      *     curr: ?int,
      *     curr_date: ?string,
@@ -31,7 +33,7 @@ interface OcNarrativeRepositoryInterface
      *     all_time_peak_date: ?string
      * }
      */
-    public function getMemberMetrics(int $openChatId): array;
+    public function getMemberMetrics(int $openChatId, ?string $baseDate = null): array;
 
     /**
      * 直近 N 日のカテゴリ内 (Ranking type) 順位推移サマリ。

--- a/app/Models/Repositories/Statistics/StatisticsRepositoryInterface.php
+++ b/app/Models/Repositories/Statistics/StatisticsRepositoryInterface.php
@@ -68,6 +68,9 @@ interface StatisticsRepositoryInterface
      * all_time_peak / all_time_peak_date は 200 日 window 外も含む全期間の最大値。
      * 長期的な縮小 (現在がピークを大きく下回る) の検知に使う。
      *
+     * @param ?string $baseDate 「現在の基準日」('Y-m-d')。指定時は m1/m7/m30/m90・200日窓を
+     *                          この日基準で算出する。null 時は SQLite 実行時刻 (date('now')、UTC) 基準。
+     *
      * @return array{
      *     curr: ?int, curr_date: ?string,
      *     m1: ?int, m7: ?int, m30: ?int, m90: ?int,
@@ -78,5 +81,5 @@ interface StatisticsRepositoryInterface
      *     all_time_peak: ?int, all_time_peak_date: ?string
      * }
      */
-    public function getMemberMetricsForNarrative(int $open_chat_id): array;
+    public function getMemberMetricsForNarrative(int $open_chat_id, ?string $baseDate = null): array;
 }

--- a/app/Models/Repositories/test/OcNarrativeRepositoryTest.php
+++ b/app/Models/Repositories/test/OcNarrativeRepositoryTest.php
@@ -39,7 +39,7 @@ class OcNarrativeRepositoryTest extends TestCase
         $stats = $this->createMock(StatisticsRepositoryInterface::class);
         $stats->expects($this->once())
             ->method('getMemberMetricsForNarrative')
-            ->with(42)
+            ->with(42, null)
             ->willReturn($expected);
 
         $rankingOhlc = $this->createMock(RankingPositionOhlcRepositoryInterface::class);

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
@@ -139,8 +139,13 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
         return SQLiteStatistics::fetchColumn($query);
     }
 
-    public function getMemberMetricsForNarrative(int $open_chat_id): array
+    public function getMemberMetricsForNarrative(int $open_chat_id, ?string $baseDate = null): array
     {
+        // 「現在の基準日」。指定時は毎時クロール基準時刻 ('Y-m-d') を、null 時は SQLite 実行時刻
+        // (date('now')、UTC) を使う。後者は深夜帯の UTC 日付差で最新日とズレ、m7 等が誤った日に
+        // 丸まり diff7=0 になりうるため、呼び出し側から cron 基準日を渡せるようにした (後方互換)。
+        $base = $baseDate !== null ? ':base_date' : "'now'";
+
         // 直近 200 日を母集団に、期間値・ピーク・単日最大伸びを 1 クエリで集約。
         // 単日最大伸びは daily member の前日差分 (LAG) で算出 (OHLC の close-open ではなく)。
         $query =
@@ -149,15 +154,15 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
                        member - LAG(member) OVER (ORDER BY date ASC) AS day_diff
                   FROM statistics
                  WHERE open_chat_id = :open_chat_id
-                   AND date >= date('now', '-200 days')
+                   AND date >= date({$base}, '-200 days')
             )
             SELECT
                 (SELECT member FROM o ORDER BY date DESC LIMIT 1) AS curr,
                 (SELECT date   FROM o ORDER BY date DESC LIMIT 1) AS curr_date,
-                (SELECT member FROM o WHERE date <= date('now','-1 days')  ORDER BY date DESC LIMIT 1) AS m1,
-                (SELECT member FROM o WHERE date <= date('now','-7 days')  ORDER BY date DESC LIMIT 1) AS m7,
-                (SELECT member FROM o WHERE date <= date('now','-30 days') ORDER BY date DESC LIMIT 1) AS m30,
-                (SELECT member FROM o WHERE date <= date('now','-90 days') ORDER BY date DESC LIMIT 1) AS m90,
+                (SELECT member FROM o WHERE date <= date({$base},'-1 days')  ORDER BY date DESC LIMIT 1) AS m1,
+                (SELECT member FROM o WHERE date <= date({$base},'-7 days')  ORDER BY date DESC LIMIT 1) AS m7,
+                (SELECT member FROM o WHERE date <= date({$base},'-30 days') ORDER BY date DESC LIMIT 1) AS m30,
+                (SELECT member FROM o WHERE date <= date({$base},'-90 days') ORDER BY date DESC LIMIT 1) AS m90,
                 (SELECT COUNT(*)    FROM o) AS sample_n,
                 (SELECT MAX(member) FROM o) AS peak_high,
                 (SELECT date FROM o ORDER BY member DESC, date DESC LIMIT 1) AS peak_date,
@@ -168,8 +173,13 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
                 (SELECT MAX(member) FROM statistics WHERE open_chat_id = :open_chat_id) AS all_time_peak,
                 (SELECT date FROM statistics WHERE open_chat_id = :open_chat_id ORDER BY member DESC, date DESC LIMIT 1) AS all_time_peak_date";
 
+        $params = ['open_chat_id' => $open_chat_id];
+        if ($baseDate !== null) {
+            $params['base_date'] = $baseDate;
+        }
+
         SQLiteStatistics::connect(['mode' => '?mode=ro']);
-        $row = SQLiteStatistics::fetch($query, compact('open_chat_id'));
+        $row = SQLiteStatistics::fetch($query, $params);
         SQLiteStatistics::$pdo = null;
 
         $empty = [

--- a/app/Services/Narrative/OcNarrativeService.php
+++ b/app/Services/Narrative/OcNarrativeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Narrative;
 
 use App\Models\Repositories\OcNarrativeRepositoryInterface;
+use App\Services\Storage\FileStorageInterface;
 use Shared\MimimalCmsConfig;
 
 /**
@@ -79,7 +80,26 @@ class OcNarrativeService
 
     public function __construct(
         private OcNarrativeRepositoryInterface $repository,
+        private FileStorageInterface $fileStorage,
     ) {
+    }
+
+    /**
+     * メトリクスの「現在の基準日」を毎時クロール基準時刻 ('Y-m-d') から解決する。
+     * cron 時刻ファイルが空 / 不正 / 取得不能なら null を返し、Repository 側は従来の
+     * date('now') (SQLite 実行時刻) フォールバックで動く。
+     */
+    private function resolveBaseDate(): ?string
+    {
+        try {
+            $cron = trim($this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
+            if ($cron === '') {
+                return null;
+            }
+            return (new \DateTime($cron))->format('Y-m-d');
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 
     /**
@@ -91,7 +111,7 @@ class OcNarrativeService
     public function generate(int $openchatId, array $oc, ?string $categoryLabel = null): ?array
     {
         try {
-            $metrics = $this->repository->getMemberMetrics($openchatId);
+            $metrics = $this->repository->getMemberMetrics($openchatId, $this->resolveBaseDate());
 
             // 最低条件: 現在値が取れること
             if (($metrics['curr'] ?? null) === null || (int)($metrics['sample_n'] ?? 0) <= 0) {

--- a/app/Services/Narrative/test/OcNarrativeServiceTest.php
+++ b/app/Services/Narrative/test/OcNarrativeServiceTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 use App\Models\Repositories\OcNarrativeRepositoryInterface;
 use App\Services\Narrative\OcNarrativeService;
+use App\Services\Storage\FileStorageInterface;
 use PHPUnit\Framework\TestCase;
 
 class OcNarrativeServiceTest extends TestCase
@@ -82,7 +83,19 @@ class OcNarrativeServiceTest extends TestCase
         $repo->method('getPositionMovement')->willReturn($position ?? $this->emptyPositionMovement());
         $repo->method('getAveragePosition')->willReturn(['avg_position' => null, 'sample_n' => 0]);
         $repo->method('getGrowthRankingPositions')->willReturn(['hour' => null, 'day' => null, 'week' => null]);
-        return new OcNarrativeService($repo);
+        return new OcNarrativeService($repo, $this->fileStorageMock());
+    }
+
+    /**
+     * cron 基準日解決用の FileStorage mock。空文字を返し baseDate=null
+     * (従来の date('now') フォールバック) で動かす。メトリクスは mock 固定なので
+     * baseDate の値はテスト結果に影響しない。
+     */
+    private function fileStorageMock(): FileStorageInterface
+    {
+        $fs = $this->createMock(FileStorageInterface::class);
+        $fs->method('getContents')->willReturn('');
+        return $fs;
     }
 
     // ============================================
@@ -374,7 +387,7 @@ class OcNarrativeServiceTest extends TestCase
     {
         $repo = $this->createMock(OcNarrativeRepositoryInterface::class);
         $repo->method('getMemberMetrics')->willThrowException(new \RuntimeException('DB unavailable'));
-        $service = new OcNarrativeService($repo);
+        $service = new OcNarrativeService($repo, $this->fileStorageMock());
         $this->assertNull($service->generate(1, $this->buildOc()));
     }
 
@@ -386,7 +399,7 @@ class OcNarrativeServiceTest extends TestCase
         $repo->method('getPositionMovement')->willThrowException(new \RuntimeException('ranking DB error'));
         $repo->method('getAveragePosition')->willReturn(['avg_position' => null, 'sample_n' => 0]);
         $repo->method('getGrowthRankingPositions')->willReturn(['hour' => null, 'day' => null, 'week' => null]);
-        $service = new OcNarrativeService($repo);
+        $service = new OcNarrativeService($repo, $this->fileStorageMock());
 
         // 順位取得が落ちてもメンバー数推移ベースの narrative は返る
         $result = $service->generate(1, $this->buildOc());
@@ -596,7 +609,7 @@ class OcNarrativeServiceTest extends TestCase
         ]);
         $repo->method('getAveragePosition')->willReturn(['avg_position' => null, 'sample_n' => 0]);
         $repo->method('getGrowthRankingPositions')->willReturn(['hour' => null, 'day' => null, 'week' => null]);
-        $service = new OcNarrativeService($repo);
+        $service = new OcNarrativeService($repo, $this->fileStorageMock());
 
         $result = $service->generate(1, $this->buildOc(['category' => 5]));
         $this->assertNotNull($result);
@@ -615,7 +628,7 @@ class OcNarrativeServiceTest extends TestCase
             }
             return ['avg_position' => null, 'sample_n' => 0];
         });
-        $service = new OcNarrativeService($repo);
+        $service = new OcNarrativeService($repo, $this->fileStorageMock());
         $result = $service->generate(1, $this->buildOc(['category' => 5]));
 
         $this->assertNotNull($result);
@@ -634,7 +647,7 @@ class OcNarrativeServiceTest extends TestCase
             }
             return ['avg_position' => null, 'sample_n' => 0];
         });
-        $service = new OcNarrativeService($repo);
+        $service = new OcNarrativeService($repo, $this->fileStorageMock());
         $result = $service->generate(1, $this->buildOc(['category' => 5]));
 
         $this->assertNotNull($result);
@@ -658,7 +671,7 @@ class OcNarrativeServiceTest extends TestCase
             }
             return ['avg_position' => null, 'sample_n' => 0];
         });
-        $service = new OcNarrativeService($repo);
+        $service = new OcNarrativeService($repo, $this->fileStorageMock());
         $result = $service->generate(1, $this->buildOc(['category' => 5]));
 
         $this->assertNotNull($result);


### PR DESCRIPTION
部屋の「直近7日／30日の増減」などの統計指標が、サーバーの時計とデータ更新時刻のズレで実態と違う値になることがある問題を修正します。

## 何が起きていたか
直近7/30/90日の集計を、データベースの実行時刻（UTC）を起点に「今日から7日前」と引いていました。このため次の状況で基準日が1日前後ずれ、増減が「0」や過大な値になることがありました。

- 日付がまたぐ深夜帯（サーバーのUTCと日本時間で日付が違う時間帯）
- その時間のクロール（毎時更新）がまだ走っていない／直後のタイミング

例: ある部屋で本来「7日で+2,381人」のところ、基準日がずれて「7日前の人数＝現在の人数」と誤判定し増減0になっていた。

## 対処
集計の起点を、毎時クロールの基準時刻（hourly_updated_at）に統一しました。データの更新サイクルと同じ基準で数えるため、サーバー時計や閲覧タイミングに左右されなくなります。

- 基準日を渡さない既存の呼び出しは従来どおり動作（後方互換）
- 影響範囲: 部屋ページのナラティブ（文章生成）が使う統計メトリクス
- 該当: `app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php` の `getMemberMetricsForNarrative`、利用側 `app/Services/Narrative/OcNarrativeService.php`

## テスト
- phpunit（ナラティブ関連）40件 緑
- PHPStan エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
