### PR TITLE
[PROD] skip-post: fix: アクセス集中によるDB接続上限エラーを自動リトライで救済（500エラー多発を緩和）

### DIFF
--- a/app/Models/Repositories/DB.php
+++ b/app/Models/Repositories/DB.php
@@ -12,11 +12,59 @@ class DB extends \Shadow\DB implements DBInterface
 {
     public static ?\PDO $pdo = null;
 
+    /**
+     * 接続数上限エラー時のリトライ回数（初回 + リトライ）
+     */
+    private const CONNECT_MAX_ATTEMPTS = 3;
+
     public static function connect(?array $config = null): \PDO
     {
-        return parent::connect($config ?? [
-            'dbName' => AppConfig::$dbName[MimimalCmsConfig::$urlRoot]
-        ]);
+        $config ??= ['dbName' => AppConfig::$dbName[MimimalCmsConfig::$urlRoot]];
+
+        for ($attempt = 0; $attempt < self::CONNECT_MAX_ATTEMPTS; $attempt++) {
+            try {
+                return parent::connect($config);
+            } catch (\PDOException $e) {
+                // 接続数上限（max_user_connections / too many connections）の瞬間的なスパイクは
+                // 少し待ってリトライすれば空きが出て捌ける場合がある。
+                // 失敗時は static::$pdo は null のまま（new \PDO が例外を投げたため）なので再試行できる。
+                if ($attempt < self::CONNECT_MAX_ATTEMPTS - 1 && static::isTooManyConnections($e)) {
+                    // FPMワーカーを長時間占有しないよう待機は短く、軽いジッタで分散させる
+                    usleep(random_int(100000, 250000) * ($attempt + 1)); // 約0.1〜0.5秒
+                    continue;
+                }
+
+                throw $e;
+            }
+        }
+
+        throw new \LogicException('Unreachable');
+    }
+
+    /**
+     * 接続数上限エラーかどうかを判定する
+     *
+     * connect()（PDO::__construct）で発生するため errorInfo が未設定のことが多い。
+     * その場合に備えてメッセージでも判定する。
+     */
+    private static function isTooManyConnections(\PDOException $e): bool
+    {
+        // 1226: ER_USER_LIMIT_REACHED (max_user_connections)
+        // 1040: ER_CON_COUNT_ERROR (Too many connections)
+        $driverCode = $e->errorInfo[1] ?? null;
+        if ($driverCode !== null) {
+            $driverCode = (int) $driverCode;
+            if ($driverCode === 1226 || $driverCode === 1040) {
+                return true;
+            }
+        }
+
+        $message = $e->getMessage();
+        return str_contains($message, 'max_user_connections')
+            || str_contains($message, 'max_connections')
+            || str_contains($message, 'Too many connections')
+            || str_contains($message, '[1226]')
+            || str_contains($message, '[1040]');
     }
 
     public static function execute(string $query, ?array $params = null): \PDOStatement


### PR DESCRIPTION
## 問題（緊急・本番発生中）

アクセス集中時に **MySQLの接続数上限 `max_user_connections=100` に瞬間的に到達**し、ページ表示用のDB接続生成（`PDO::__construct`）が失敗。ルームページ等が **500エラーを多発**していた（例外ログ #10832〜 多数）。

```
PDOException: SQLSTATE[HY000] [1226] User 'ocgraph_user' has exceeded the 'max_user_connections' resource (current value: 100)
  shadow/DB.php(35): PDO->__construct(...)
  app/Models/Repositories/DB.php(17): Shadow\DB::connect(...)
```

## 対処（暫定）

`App\Models\Repositories\DB::connect()` に**接続生成の自動リトライ**を追加（最大3回 / 約0.1〜0.5秒・ジッタ付き）。各リクエストは接続枠を短時間しか保持しないため、わずかに待って再試行すれば空きが出て成功するケースが多い。

- MySQL系の**全リポジトリ（35ファイル）がこの `connect()` を経由**（遅延静的束縛で確認済み）。`Shadow\DB` を直接使う迂回パスは0件
- リトライ対象は接続数上限のみ（`1226` max_user_connections / `1040` too many connections）。connect時は `errorInfo` が空のことがあるためメッセージでも判定
- `php -l` 構文チェック済み

## 補足

これは瞬間スパイク吸収の暫定対処。根本対処（接続上限引き上げ / 悪質ボットのレート制限）は別途追跡。