### PR TITLE
[STG] fix: アクセス集中時にルームページが落ちるSQLiteロックエラーを修正（読み取り接続の設定を是正）

### DIFF
--- a/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
+++ b/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
@@ -131,7 +131,7 @@ class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
         $since = (clone $anchorDate)->modify("-{$days} days")->format('Y-m-d');
         $category = self::RANK_CATEGORY_OVERALL;
 
-        SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPosition::connect(['mode' => '?mode=rw']);
         $rows = SQLiteRankingPosition::fetchAll(
             "SELECT date, MIN(position) AS value
              FROM ranking
@@ -193,7 +193,7 @@ class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
         // DateTime 由来の Y-m-d 固定書式なのでインライン化(注入リスクなし)。
         $since = (clone $anchorDate)->modify("-{$days} days")->format('Y-m-d');
 
-        SQLiteStatistics::connect(['mode' => '?mode=ro']);
+        SQLiteStatistics::connect(['mode' => '?mode=rw']);
 
         $rows = SQLiteStatistics::fetchAll(
             "WITH bounds AS (

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -42,9 +42,12 @@ abstract class AbstractSQLite extends DB implements DBInterface
         // Set busy timeout for all modes (including read-only) to handle concurrent access
         static::$pdo->exec('PRAGMA busy_timeout=10000');
 
-        // Apply write-related PRAGMA settings only for read-write mode
-        // Read-only mode (mode=ro) cannot execute journal_mode and synchronous
-        if (!str_contains($mode, 'mode=ro')) {
+        // Apply write-related PRAGMA settings only when the DB may be created (rwc / default).
+        // Reader connections use mode=rw (read-write, must-exist): they must NOT run journal_mode
+        // /synchronous (those attempt a write and add contention), but mode=rw still lets the
+        // reader open the WAL -shm wal-index. Using mode=ro on a WAL DB fails to access -shm and
+        // causes "locking protocol" (SQLITE_PROTOCOL) under concurrency, so readers must use rw.
+        if (str_contains($mode, 'rwc')) {
             // Enable WAL mode for concurrent read/write performance
             static::$pdo->exec('PRAGMA journal_mode=WAL');
 

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
@@ -39,7 +39,7 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
             ORDER BY
                 date ASC";
 
-        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=rw']);
         $result = SQLiteRankingPositionOhlc::fetchAll($query, ['open_chat_id' => $open_chat_id, 'category' => $category, 'type' => $typeValue]);
         SQLiteRankingPositionOhlc::$pdo = null;
 
@@ -69,7 +69,7 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
 
         $since = '-' . max(1, $days) . ' days';
 
-        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=rw']);
         $row = SQLiteRankingPositionOhlc::fetch($query, [
             'open_chat_id' => $open_chat_id,
             'category' => $category,
@@ -114,7 +114,7 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
                 AND type = :type
                 AND date >= date('now', :since)";
 
-        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=rw']);
         $row = SQLiteRankingPositionOhlc::fetch($query, [
             'open_chat_id' => $open_chat_id,
             'category' => $category,

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
@@ -39,7 +39,7 @@ class SqliteRankingPositionPageRepository implements RankingPositionPageReposito
 
         $dto = new RankingPositionPageRepoDto;
 
-        SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPosition::connect(['mode' => '?mode=rw']);
 
         $result = SQLiteRankingPosition::fetchAll($query, compact('open_chat_id', 'category'));
 

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
@@ -64,7 +64,7 @@ class SqliteRankingPositionRepository implements RankingPositionRepositoryInterf
     ): array {
         $result = [];
 
-        SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPosition::connect(['mode' => '?mode=rw']);
 
         foreach (['ranking', 'rising'] as $tableName) {
             $row = SQLiteRankingPosition::fetch(

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
@@ -34,7 +34,7 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
             ORDER BY
                 date ASC";
 
-        SQLiteStatisticsOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteStatisticsOhlc::connect(['mode' => '?mode=rw']);
         $result = SQLiteStatisticsOhlc::fetchAll($query, compact('open_chat_id'));
         SQLiteStatisticsOhlc::$pdo = null;
 
@@ -56,7 +56,7 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
         $emptyResult = ['all_count' => 0, 'week_count' => 0, 'month_count' => 0];
 
         try {
-            SQLiteStatisticsOhlc::connect(['mode' => '?mode=ro']);
+            SQLiteStatisticsOhlc::connect(['mode' => '?mode=rw']);
         } catch (\PDOException) {
             // DBファイル未作成（OHLC統計の記録開始前の環境）は「データ無し」として扱う
             return $emptyResult;

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
@@ -22,7 +22,7 @@ class SqliteStatisticsPageRepository implements StatisticsPageRepositoryInterfac
             ORDER BY
                 date ASC";
 
-        SQLiteStatistics::connect(['mode' => '?mode=ro']);
+        SQLiteStatistics::connect(['mode' => '?mode=rw']);
         $result = SQLiteStatistics::fetchAll($query, compact('open_chat_id'));
         SQLiteStatistics::$pdo = null;
 

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
@@ -178,7 +178,7 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
             $params['base_date'] = $baseDate;
         }
 
-        SQLiteStatistics::connect(['mode' => '?mode=ro']);
+        SQLiteStatistics::connect(['mode' => '?mode=rw']);
         $row = SQLiteStatistics::fetch($query, $params);
         SQLiteStatistics::$pdo = null;
 


### PR DESCRIPTION
## 問題（本番発生中・Phase 1 / 根本対策の第一段）

アクセス集中時に `SQLSTATE[HY000]: General error: 15 locking protocol`(SQLITE_PROTOCOL) が多発し、ルームページが500を返している。スタックは `getOhlcCounts` 等のSQLite**読み取り**。

### 真因
統計・ランキング系SQLiteはWALモードで運用されているが、読み取り接続を **`mode=ro`** で開いていた。WAL DBは読み取りでも `-shm`(wal-index 共有メモリ)へのアクセスが必要だが、`mode=ro` ではそれが禁止され、cronのWAL checkpointと競合して `SQLITE_PROTOCOL` が出る。`busy_timeout` は BUSY/LOCKED 用でこのエラーには効かず、アプリ層リトライ(5×0.1s)も持続負荷で枯渇していた。

## 対処
- 読み取り接続を **`mode=ro` → `mode=rw`**（read-write・**ファイル不在なら従来通り例外**）。`rw` は `-shm` にアクセスできるためロックプロトコルエラーが解消。「接続失敗=データ無し」扱いのtry/catch挙動も維持。
- `AbstractSQLite::connect` の WAL/synchronous 設定を「作成時(rwc/既定)のみ」適用に変更。読み取り(rw)では実行しない。

対象: `statistics` / `statistics_ohlc` / `ranking_position` / `ranking_position_ohlc` の AbstractSQLite系リーダー（7ファイル）。

## スコープ外（別途）
`ocgraph_sqlapi`系（`SQLiteOcgraphSqlapi`：API用DB、読み取り専用の可能性）は書込可否を確認してから対応するため今回は `mode=ro` のまま据え置き。

## 検証
CI（Mock環境クローリング+URLテスト）が /oc ページの読み取りパスを実走。マージ後 stg→本番で例外ログの `locking protocol` 減少を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)