### PR TITLE
[STG] feat: ルームページの統計グラフを初回から非同期取得にしてDB負荷を軽減

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -132,6 +132,14 @@ Route::path('oc/{open_chat_id}/jump', [JumpOpenChatPageController::class, 'index
         checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
     });
 
+// 統計チャートデータ。graph(React)が初回ロードで非同期取得する（/oc 本体から統計SQLite読み取りを外す）
+Route::path('oc/{open_chat_id}/stats', [OpenChatPageController::class, 'stats'])
+    ->matchNum('open_chat_id', min: 1)
+    ->matchNum('category', min: 0)
+    ->match(function (FileStorageInterface $fileStorage) {
+        checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
+    });
+
 // TODO: test-api
 Route::path('ocapi/{user}/{open_chat_id}', [OpenChatPageController::class, 'index'])
     ->matchNum('open_chat_id', min: 1)

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -98,15 +98,9 @@ class OpenChatPageController
         $categoryValue = $oc['category'] ? array_search($oc['category'], AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot]) : null;
         $category = $categoryValue ?? t('未指定');
 
-        $_statsDto = $statisticsChartArrayService->buildStatisticsChartArray(
-            $open_chat_id,
-            isset($oc['category']) ? (int)$oc['category'] : null
-        );
-        if (!$_statsDto) {
-            $_statsDto = new StatisticsChartDto((new \DateTime('-1day'))->format('Y-m-d'), (new \DateTime('now'))->format('Y-m-d'));
-        }
-
-        $oc += $statisticsViewUtility->getOcPageArrayElementMemberDiff($_statsDto, $oc['member']);
+        // 統計チャートデータは graph(React)が /oc/{id}/stats から初回も非同期取得する
+        // （bot が叩く /oc 本体から統計の重い SQLite 読み取りを外す）。
+        // ヘッダーの「1週間」差分は getOpenChatByIdWithTag の statistics_ranking_week JOIN(rw_*) で取得済み。
 
         $_css = [
             'components/room_list',
@@ -148,7 +142,7 @@ class OpenChatPageController
             $_meta->title,
             $_meta->description,
             new \DateTime($oc['created_at']),
-            new \DateTime($_statsDto->endDate),
+            new \DateTime($oc['updated_at']),
             $oc,
         );
 
@@ -171,7 +165,6 @@ class OpenChatPageController
             'oc',
             'category',
             '_chartArgDto',
-            '_statsDto',
             '_commentArgDto',
             '_breadcrumbsShema',
             '_schema',
@@ -185,6 +178,30 @@ class OpenChatPageController
             'formatedRowDescription',
             'narrative',
         ));
+    }
+
+    /**
+     * 統計チャートデータ（メンバー数推移・期間タブ可用性）を返す。
+     * graph(React) が初回ロード時にこれを fetch する。これにより bot が叩く /oc 本体の
+     * サーバーレンダリングから統計の重い SQLite 読み取り（member/OHLC/順位）を外す。
+     */
+    function stats(
+        StatisticsChartArrayService $statisticsChartArrayService,
+        int $open_chat_id,
+        int $category,
+    ) {
+        $dto = $statisticsChartArrayService->buildStatisticsChartArray(
+            $open_chat_id,
+            $category > 0 ? $category : null
+        );
+        if (!$dto) {
+            $dto = new StatisticsChartDto(
+                (new \DateTime('-1day'))->format('Y-m-d'),
+                (new \DateTime('now'))->format('Y-m-d')
+            );
+        }
+
+        return response($dto);
     }
 
     private function getAdminDto(int $open_chat_id)

--- a/app/Models/Repositories/OpenChatPageRepository.php
+++ b/app/Models/Repositories/OpenChatPageRepository.php
@@ -66,6 +66,8 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
                 rh.percent_increase AS rh_percent_increase,
                 rh24.diff_member AS rh24_diff_member,
                 rh24.percent_increase AS rh24_percent_increase,
+                rw.diff_member AS rw_diff_member,
+                rw.percent_increase AS rw_percent_increase,
                 tg.tag AS tag1,
                 tg2.tag AS tag2,
                 tg3.tag AS tag3
@@ -73,6 +75,7 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
                 open_chat AS oc
                 LEFT JOIN statistics_ranking_hour AS rh ON oc.id = rh.open_chat_id
                 LEFT JOIN statistics_ranking_hour24 AS rh24 ON oc.id = rh24.open_chat_id
+                LEFT JOIN statistics_ranking_week AS rw ON oc.id = rw.open_chat_id
                 LEFT JOIN recommend AS tg ON oc.id = tg.id
                 LEFT JOIN oc_tag AS tg2 ON oc.id = tg2.id
                 LEFT JOIN oc_tag2 AS tg3 ON oc.id = tg3.id

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -84,24 +84,24 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
               </div>
             <?php endif ?>
 
-            <?php if (isset($oc['diff_member2']) && $oc['diff_member2'] >= AppConfig::RECOMMEND_MIN_MEMBER_DIFF_H24) : ?>
+            <?php if (isset($oc['rw_diff_member']) && $oc['rw_diff_member'] >= AppConfig::RECOMMEND_MIN_MEMBER_DIFF_H24) : ?>
               <div class="number-box " style="margin-right: 6px;">
                 <svg class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium show-north css-162gv95" focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="NorthIcon">
                   <path d="m5 9 1.41 1.41L11 5.83V22h2V5.83l4.59 4.59L19 9l-7-7-7 7z"></path>
                 </svg>
                 <span class="openchat-itme-stats-title"><?php echo t('1週間') ?></span>
                 <div>
-                  <span class="openchat-item-stats"><?php echo sprintfT('%s人', signedNumF($oc['diff_member2'])) ?></span><span class="openchat-item-stats percent">(<?php echo signedNum(signedCeil($oc['percent_increase2'] * 10) / 10) ?>%)</span>
+                  <span class="openchat-item-stats"><?php echo sprintfT('%s人', signedNumF($oc['rw_diff_member'])) ?></span><span class="openchat-item-stats percent">(<?php echo signedNum(signedCeil($oc['rw_percent_increase'] * 10) / 10) ?>%)</span>
                 </div>
               </div>
-            <?php elseif (isset($oc['diff_member2'])) : ?>
+            <?php elseif (isset($oc['rw_diff_member'])) : ?>
               <div class="number-box" style="margin-right: 6px;">
                 <span class="openchat-itme-stats-title"><?php echo t('1週間') ?></span>
-                <?php if (($oc['diff_member2'] ?? 0) !== 0) : ?>
+                <?php if (($oc['rw_diff_member'] ?? 0) !== 0) : ?>
                   <div>
-                    <span class="openchat-item-stats"><?php echo sprintfT('%s人', signedNumF($oc['diff_member2'])) ?></span><span class="openchat-item-stats percent">(<?php echo signedNum(signedCeil($oc['percent_increase2'] * 10) / 10) ?>%)</span>
+                    <span class="openchat-item-stats"><?php echo sprintfT('%s人', signedNumF($oc['rw_diff_member'])) ?></span><span class="openchat-item-stats percent">(<?php echo signedNum(signedCeil($oc['rw_percent_increase'] * 10) / 10) ?>%)</span>
                   </div>
-                <?php elseif ($oc['diff_member2'] === 0) : ?>
+                <?php elseif ($oc['rw_diff_member'] === 0) : ?>
                   <span class="zero-stats">±0</span>
                 <?php endif ?>
               </div>
@@ -198,9 +198,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
         <script type="application/json" id="chart-arg">
           <?php echo json_encode($_chartArgDto, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>
         </script>
-        <script type="application/json" id="stats-dto">
-          <?php echo json_encode($_statsDto, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>
-        </script>
+        <?php // 統計データ(#stats-dto)はサーバー注入をやめ、graph(React)が /oc/{id}/stats から初回も非同期取得する ?>
         <script async type="module" crossorigin src="/<?php echo getFilePath('js/oc-app', 'graph-*.js') ?>"></script>
       </section>
     </article>

--- a/frontend/oc-app/src/graph/App.tsx
+++ b/frontend/oc-app/src/graph/App.tsx
@@ -14,13 +14,17 @@ import {
   setChartStatesFromUrlParams,
   setUrlParamsFromChartStates,
 } from './state/chartState'
-import { fetchChart, renderChartWithoutRanking } from './util/fetchRenderer'
+import { fetchChart, loadStatsDto, renderChartWithoutRanking } from './util/fetchRenderer'
 import { Box, CircularProgress } from '@mui/material'
 import { OcThemeProvider } from '../themeMui'
 import { onThemeChange } from './util/theme'
 import { t } from './util/translation'
 
 const init = async () => {
+  // 統計データを初回ロードで非同期取得（サーバー注入の #stats-dto は廃止）
+  graphStore.set(loadingAtom, true)
+  await loadStatsDto()
+
   setChartStatesFromUrlParams()
 
   if (initDisplay()) {

--- a/frontend/oc-app/src/graph/util/fetchRenderer.ts
+++ b/frontend/oc-app/src/graph/util/fetchRenderer.ts
@@ -15,9 +15,15 @@ import { t } from './translation'
 export const chatArgDto: RankingPositionChartArgDto = JSON.parse(
   (document.getElementById('chart-arg') as HTMLScriptElement).textContent!
 )
-export const statsDto: StatisticsChartDto = JSON.parse(
-  (document.getElementById('stats-dto') as HTMLScriptElement).textContent!
-)
+// statsDto はサーバー注入(#stats-dto)をやめ、初回ロードで /oc/{id}/stats から非同期取得する
+// （bot が叩く /oc 本体から統計の重い SQLite 読み取りを外すため）
+export let statsDto: StatisticsChartDto
+
+export async function loadStatsDto() {
+  statsDto = await fetcher<StatisticsChartDto>(
+    `${chatArgDto.baseUrl}/oc/${chatArgDto.id}/stats?category=${chatArgDto.categoryKey ?? 0}`
+  )
+}
 
 export const langCode = chatArgDto.urlRoot.replace(/^\/+/, '') as '' | 'tw' | 'th'
 


### PR DESCRIPTION
統計チャート生成(メンバー数推移・期間タブ可用性=SQLite/MySQLの重い読み取り)を、graph(React)が初回ロードで `GET /oc/{id}/stats` から非同期取得する方式に変更。期間切替で既に使っていたfetchパターンを初回にも適用。JS実行しないbotクロール時はこれらの読み取りが発生しなくなる。

ヘッダーの「1週間」増減は statistics_ranking_week のJOIN(rw_*)で取得し、計算処理(getOcPageArrayElementMemberDiff)を削除。

dev実機でグラフ表示・期間切替・候補足・ヘッダー1週間を検証してから stg→main。🤖 Generated with [Claude Code](https://claude.com/claude-code)