### PR TITLE
[PROD] stg → main: データをSQLで取得できるデータAPIを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ test-logs/
 # 例外: .gitkeepは含める
 !*.gitkeep
 local-secrets.php.bak
+app/Config/ApiUser.php

--- a/API_README.md
+++ b/API_README.md
@@ -1,0 +1,370 @@
+# オプチャグラフ データAPI
+
+オプチャグラフ（[openchat-review.me](https://openchat-review.me/)）が集めた LINEオープンチャットのデータ（SQLite）を、SQL で取得できる読み取り専用APIです。
+
+`…/database/{username}/query?stmt=<SQL>` に SELECT文を渡すと、結果が JSON で返ります。
+
+`{username}` / `{password}` は、申請時に受け取る Basic認証のユーザー名・パスワードです（[取得方法](#認証情報の取得)）。
+
+---
+
+## データを取得する
+
+`stmt` パラメータに SQL を渡すと、実行結果が JSON で返ります。
+
+例：過去24時間で伸びている部屋トップ20
+
+```bash
+curl -u '{username}:{password}' \
+  -G "https://openchat-review.me/database/{username}/query" \
+  --data-urlencode "stmt=SELECT m.display_name, g.member_increase_count
+                         FROM growth_ranking_past_24_hours g
+                         JOIN openchat_master m ON m.openchat_id = g.openchat_id
+                         ORDER BY g.ranking_position
+                         LIMIT 20"
+```
+
+レスポンス：
+
+```json
+{
+  "status": "success",
+  "data": [
+    { "display_name": "雑談部屋", "member_increase_count": 518 }
+  ],
+  "lastUpdate": "2026-06-10 23:30:00"
+}
+```
+
+- 実行結果の行は、`data` 配列に入ります（レスポンス全体の説明は [レスポンスの形式](#レスポンスの形式)）。
+- 認証は Basic認証です（`-u {username}:{password}`）。URLパスの `{username}` にも、同じユーザー名を入れます。
+- SQL は `stmt` パラメータに渡します。URLエンコードが必要です（`curl` では `-G --data-urlencode` で自動的にエンコードされます）。
+- 他のクエリも、`stmt` の SQL を [サンプル](#サンプルsql) のように差し替えて実行します。
+
+---
+
+## 認証情報の取得
+
+Basic認証のユーザー名とパスワードが必要です。
+
+X（旧Twitter）の [@openchat_graph](https://x.com/openchat_graph) のDMでご相談ください。利用目的を伺ったうえでお渡しします。
+
+以下では、受け取った値を `{username}` / `{password}` と表記します。
+
+---
+
+## 制約事項
+
+- 使えるのは `SELECT` のみです。`UPDATE` / `DELETE` / `INSERT` は拒否されます。
+- 1回で取得できるのは**最大20件**です。
+  - `LIMIT` 未指定なら自動で `LIMIT 20` が付きます。
+  - `LIMIT` に20を超える値を指定するとエラーです。
+  - 20件より多く取りたいときは、`OFFSET` でページングします（[GASサンプル](#google-apps-scriptgasから使う) 参照）。
+- SQL は URLエンコードが必要です。
+- SQL の長さは最大10000文字です。
+- テーブルは `openchat_id`（コメント系のみ `open_chat_id`）と `category_id` でつながります（[スキーマ](#スキーマテーブル定義) 参照）。
+
+---
+
+## レスポンスの形式
+
+| フィールド | 型 | 内容 |
+| --- | --- | --- |
+| `status` | string | `"success"` または `"error"` |
+| `data` | array | 結果の配列。`SELECT` した列名をキーに持つオブジェクトが並ぶ。0件なら `[]` |
+| `lastUpdate` | string | データ取り込みが最後に完了した日時（`YYYY-MM-DD HH:MM:SS`・JST）。毎時更新 |
+| `message` | string | エラー内容（エラー時のみ。成功時は無し） |
+
+`data` の各値の型は、列の型に従います。INTEGER・REAL は数値、TEXT は文字列、NULL は `null` です。日付・日時も文字列で、`statistics_date` は `YYYY-MM-DD`、`last_updated_at` は `YYYY-MM-DD HH:MM:SS` です。
+
+---
+
+## エラー時のレスポンス
+
+エラー時は HTTPステータスがエラーコードになり、ボディの `status` が `"error"`、`message` にエラー内容が入ります。成功判定は HTTPステータス（`200`）か `status` で行えます。
+
+```json
+{
+  "status": "error",
+  "message": "LIMIT cannot exceed 20"
+}
+```
+
+| 状況 | ステータス | `message` |
+| --- | --- | --- |
+| ユーザー名（URLパス）が未登録 | 403 | `User not found` |
+| パスワードが違う／未指定 | 401 | `Basic authentication is required to access the database API.`（`WWW-Authenticate: Basic` ヘッダ付き） |
+| `stmt` が未指定 | 400 | `The "stmt" parameter is required and must be a string.` |
+| `SELECT` 以外を実行 | 400 | `UPDATE / DELETE / INSERT statements are not allowed` |
+| `LIMIT` が20超 | 400 | `LIMIT cannot exceed 20` |
+| SQL が10000文字超 | 400 | `Query too long` |
+| SQL の文法ミスなど実行エラー | 400 | `SQLSTATE[...] ...`（DBのエラーメッセージ） |
+
+---
+
+## サンプルSQL
+
+`stmt=` の中身を差し替えて使います。
+
+ルーム一覧のサンプルは、`openchat_existing` を `JOIN` して現存ルームに絞り込んでいます（理由は [現存ルームの抽出](#現存ルームの抽出)）。
+
+### メンバー数が多い部屋 トップ20
+
+```sql
+SELECT m.openchat_id, m.display_name, m.current_member_count
+FROM openchat_master m
+JOIN openchat_existing e ON e.openchat_id = m.openchat_id
+ORDER BY m.current_member_count DESC
+LIMIT 20
+```
+
+返り値: `openchat_id`（数値）, `display_name`（文字列）, `current_member_count`（数値）
+
+### 過去24時間で伸びている部屋ランキング（部屋名つき）
+
+```sql
+SELECT g.ranking_position, m.display_name,
+       g.member_increase_count, g.growth_rate_percent
+FROM growth_ranking_past_24_hours g
+JOIN openchat_master m ON m.openchat_id = g.openchat_id
+ORDER BY g.ranking_position
+LIMIT 20
+```
+
+返り値: `ranking_position`（数値）, `display_name`（文字列）, `member_increase_count`（数値）, `growth_rate_percent`（数値・小数）
+
+### 特定カテゴリ（例：「雑談」）の部屋をメンバー数順に
+
+```sql
+SELECT m.display_name, m.current_member_count, c.category_name
+FROM openchat_master m
+JOIN categories c ON c.category_id = m.category_id
+JOIN openchat_existing e ON e.openchat_id = m.openchat_id
+WHERE c.category_name = '雑談'
+ORDER BY m.current_member_count DESC
+LIMIT 20
+```
+
+返り値: `display_name`（文字列）, `current_member_count`（数値）, `category_name`（文字列）
+
+### ある部屋（openchat_id=12345）のメンバー数の推移（直近20日）
+
+```sql
+SELECT statistics_date, member_count
+FROM daily_member_statistics
+WHERE openchat_id = 12345
+ORDER BY statistics_date DESC
+LIMIT 20
+```
+
+返り値: `statistics_date`（文字列 `YYYY-MM-DD`）, `member_count`（数値）
+
+### スペシャル（認証バッジ＝スペシャル）の部屋だけ取得
+
+`verification_badge` は `NULL`（なし）/ `公式認証` / `スペシャル` の3種類です。
+
+```sql
+SELECT m.openchat_id, m.display_name, m.current_member_count
+FROM openchat_master m
+JOIN openchat_existing e ON e.openchat_id = m.openchat_id
+WHERE m.verification_badge = 'スペシャル'
+ORDER BY m.current_member_count DESC
+LIMIT 20
+```
+
+返り値: `openchat_id`（数値）, `display_name`（文字列）, `current_member_count`（数値）
+
+公式認証も含めるなら `m.verification_badge IS NOT NULL` とします。
+
+---
+
+## 現存ルームの抽出
+
+このDBは過去に存在したルームも削除せず保持し続けるため、`openchat_master` には現在は存在しないルームも含まれます。
+
+現存ルームだけを対象にするには、`openchat_existing`（現在オプチャグラフに存在するIDだけを毎時洗い替えで保持するテーブル）と `openchat_id` で `JOIN` します。上のサンプルのルーム一覧は、すべてこの方法で絞り込んでいます。
+
+---
+
+## Google Apps Script（GAS）から使う
+
+Basic認証付きでデータを取得する関数の例です。`USER` / `PASS` を書き換えてください。取得後のデータの扱いは任意です。
+
+```javascript
+const USER = '{username}';
+const PASS = '{password}';
+
+// SQLを実行し、結果の行（配列）を返す
+function query(sql) {
+  const res = UrlFetchApp.fetch(
+    'https://openchat-review.me/database/' + USER + '/query?stmt=' + encodeURIComponent(sql),
+    {
+      headers: { Authorization: 'Basic ' + Utilities.base64Encode(USER + ':' + PASS) },
+      muteHttpExceptions: true,
+    }
+  );
+  const json = JSON.parse(res.getContentText());
+  if (json.status !== 'success') throw new Error(json.message);
+  return json.data;
+}
+
+// ページングの例（1回の上限は20件）
+function example() {
+  let all = [], offset = 0, rows;
+  do {
+    rows = query('SELECT openchat_id, display_name FROM openchat_master'
+      + ' ORDER BY openchat_id LIMIT 20 OFFSET ' + offset);
+    all = all.concat(rows);
+    offset += 20;
+  } while (rows.length === 20);
+  Logger.log(all.length);
+}
+```
+
+---
+
+## スキーマ（テーブル定義）
+
+各テーブルの定義です。カラムのコメントに、取得できる内容を記載しています。
+
+```sql
+-- カテゴリマスタテーブル（25レコード）
+CREATE TABLE categories (
+    category_id INTEGER PRIMARY KEY,        -- カテゴリID
+    category_name TEXT NOT NULL             -- カテゴリ名
+);
+
+-- オープンチャットのメンバー数統計（毎日1件、オープンチャットIDと日付でユニーク）約6000万レコード以上
+CREATE TABLE daily_member_statistics (
+    record_id INTEGER PRIMARY KEY,          -- レコードID
+    openchat_id INTEGER NOT NULL,           -- オプチャグラフでオープンチャットを識別するための主キー（openchat_masterと紐づく）
+    member_count INTEGER NOT NULL,          -- メンバー数
+    statistics_date TEXT NOT NULL           -- 統計日
+);
+
+-- 成長ランキング（過去24時間・毎時更新）
+CREATE TABLE growth_ranking_past_24_hours (
+    ranking_position INTEGER PRIMARY KEY,   -- 順位（1位、2位...）
+    openchat_id INTEGER NOT NULL,           -- 主キー（openchat_masterと紐づく）
+    member_increase_count INTEGER NOT NULL, -- メンバー増加数
+    growth_rate_percent REAL NOT NULL       -- 成長率（%）
+);
+
+-- 成長ランキング（過去1時間・毎時更新）
+CREATE TABLE growth_ranking_past_hour (
+    ranking_position INTEGER PRIMARY KEY,   -- 順位（1位、2位...）
+    openchat_id INTEGER NOT NULL,           -- 主キー（openchat_masterと紐づく）
+    member_increase_count INTEGER NOT NULL, -- メンバー増加数
+    growth_rate_percent REAL NOT NULL       -- 成長率（%）
+);
+
+-- 成長ランキング（過去1週間・毎時更新）
+CREATE TABLE growth_ranking_past_week (
+    ranking_position INTEGER PRIMARY KEY,   -- 順位（1位、2位...）
+    openchat_id INTEGER NOT NULL,           -- 主キー（openchat_masterと紐づく）
+    member_increase_count INTEGER NOT NULL, -- メンバー増加数
+    growth_rate_percent REAL NOT NULL       -- 成長率（%）
+);
+
+-- LINE公式サイトの「ランキング」履歴（カテゴリ別・全体、1日1件、中央値保存）
+CREATE TABLE line_official_activity_ranking_history (
+    record_id INTEGER PRIMARY KEY,                -- レコードID
+    openchat_id INTEGER NOT NULL,                 -- 主キー（openchat_masterと紐づく）
+    category_id INTEGER NOT NULL,                 -- カテゴリID（0=すべて、1以上=各カテゴリ）（categoriesと紐づく）
+    activity_ranking_position INTEGER NOT NULL,   -- その日のLINE公式「ランキング」順位（中央値、何件中何位かはline_official_ranking_total_countで確認）
+    recorded_at TEXT NOT NULL,                    -- 記録日時（line_official_ranking_total_countと紐づく）
+    record_date TEXT NOT NULL                     -- 記録日（ユニークキー用のカラム。取得不要）
+);
+
+-- LINE公式サイトの「急上昇」履歴（カテゴリ別・全体、1日1件、最大値保存）
+CREATE TABLE line_official_activity_trending_history (
+    record_id INTEGER PRIMARY KEY,                -- レコードID
+    openchat_id INTEGER NOT NULL,                 -- 主キー（openchat_masterと紐づく）
+    category_id INTEGER NOT NULL,                 -- カテゴリID（0=すべて、1以上=各カテゴリ）（categoriesと紐づく）
+    activity_trending_position INTEGER NOT NULL,  -- その日のLINE公式「急上昇」順位（最大値、何件中何位かはline_official_ranking_total_countで確認）
+    recorded_at TEXT NOT NULL,                    -- 記録日時
+    record_date TEXT NOT NULL                     -- 記録日
+);
+
+-- LINE公式サイトの全ランキング総件数履歴（「ランキング」・「急上昇」、カテゴリ別・全体、毎時間記録）
+CREATE TABLE line_official_ranking_total_count (
+    record_id INTEGER PRIMARY KEY,                  -- レコードID
+    activity_trending_total_count INTEGER NOT NULL, -- その時間のLINE公式「急上昇」総件数（何件中何位かを知るために使用）
+    activity_ranking_total_count INTEGER NOT NULL,  -- その時間のLINE公式「ランキング」総件数（何件中何位かを知るために使用）
+    recorded_at TEXT NOT NULL,                      -- 記録日時（毎時間更新）
+    category_id INTEGER NOT NULL                    -- カテゴリID（0=すべて、1以上=各カテゴリ）（categoriesと紐づく）
+);
+
+-- オープンチャットマスターテーブル（部屋の基本情報）
+CREATE TABLE openchat_master (
+    openchat_id INTEGER PRIMARY KEY,        -- オプチャグラフでオープンチャットを識別するための主キー
+    line_internal_id TEXT,                  -- LINE内部ID（emid）
+    display_name TEXT NOT NULL,             -- オープンチャット名
+    invitation_url TEXT,                    -- オープンチャット招待用URL（参加リンク）
+    description TEXT,                        -- 説明
+    profile_image_url TEXT,                 -- オープンチャットのメイン画像
+    current_member_count INTEGER NOT NULL DEFAULT 0,  -- 現在のメンバー数
+    verification_badge TEXT,                -- 認証バッジ（NULL:なし, 公式認証, スペシャル）
+    category_id INTEGER,                    -- カテゴリID（categoriesと紐づく）
+    join_method TEXT NOT NULL,              -- 参加方法（全体公開, 参加承認制, 参加コード入力制）
+    established_at TEXT,                     -- オープンチャットの開設日時
+    first_seen_at TEXT NOT NULL,            -- 初回取得日時
+    last_updated_at TEXT NOT NULL           -- 名前・画像・説明・バッジ・参加方法・カテゴリのいずれかが最後に更新された日時
+);
+
+-- 現在オプチャグラフに存在するオープンチャットのID一覧（毎時、全件洗い替え）
+CREATE TABLE openchat_existing (
+    openchat_id INTEGER PRIMARY KEY         -- 現存するオープンチャットID（openchat_master.openchat_idと紐づく）
+);
+
+-- コメントテーブル
+CREATE TABLE comment (
+    comment_id INTEGER PRIMARY KEY,         -- コメントID
+    open_chat_id INTEGER NOT NULL,          -- オープンチャットID（openchat_master.openchat_idと紐づく）
+    id INTEGER NOT NULL,                    -- 旧ID（互換性のため保持）
+    user_id TEXT NOT NULL,                  -- ユーザーID
+    name TEXT NOT NULL,                     -- ユーザー名
+    text TEXT NOT NULL,                     -- コメント本文
+    time TEXT NOT NULL,                     -- 投稿日時
+    flag INTEGER NOT NULL DEFAULT 0         -- フラグ（0: 通常、その他: 削除・非表示など）
+);
+
+-- いいねテーブル
+CREATE TABLE comment_like (
+    id INTEGER PRIMARY KEY,                 -- いいねID
+    comment_id INTEGER NOT NULL,            -- コメントID（comment.comment_idと紐づく）
+    user_id TEXT NOT NULL,                  -- ユーザーID
+    type TEXT NOT NULL,                     -- いいねタイプ
+    time TEXT NOT NULL                      -- いいね日時
+);
+```
+
+`ban_room` / `ban_user` / `comment_log` などの管理用テーブルもありますが、通常の分析では使いません。
+
+---
+---
+
+## （オーナー向けメモ）APIユーザーの追加方法
+
+APIにログインできるユーザーは `app/Config/ApiUser.php` の `ApiUser::$apiUser` 配列で定義します。`username` / `password` を追加してください。
+
+ここに含まれる `username` のみが Basic認証でログインできます。含まれない `username` でアクセスすると 403 になります。
+
+```php
+namespace App\Config;
+
+class ApiUser
+{
+    /** @var array<int, array{username:string, password:string}> */
+    static array $apiUser = [
+        [
+            'username' => 'user1',
+            'password' => 'password',
+        ],
+        [
+            'username' => 'user2',
+            'password' => 'password',
+        ],
+    ];
+}
+```

--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -46,6 +46,7 @@ use App\ServiceProvider\ApiRankingPositionPageRepositoryServiceProvider;
 use App\Models\CommentRepositories\RecentCommentListRepositoryInterface;
 use App\Services\Storage\FileStorageInterface;
 use Shadow\Kernel\Reception;
+use Shadow\Kernel\Validator;
 use Shared\Exceptions\UnauthorizedException;
 use Shared\MimimalCmsConfig;
 
@@ -787,39 +788,80 @@ Route::path(
             return false;
     });
 
+// データベースAPI（読み取り専用）
+// /database/{username}/... の {username} で挙動が分かれる:
+//   1. {username} が adminApiKey なら従来どおり
+//   2. {username} が ApiUser::$apiUser に存在するなら Basic認証を要求
+//   3. それ以外の {username} は 404（return false）
+$databaseApiAuth = function (string $username) {
+    if (MimimalCmsConfig::$urlRoot !== '') {
+        return false;
+    }
+
+    // 1. 管理用キー
+    if ($username === SecretsConfig::$adminApiKey) {
+        allowCORS();
+        return true;
+    }
+
+    // 2. 登録済みユーザーなら Basic認証
+    // ApiUser クラス自体が存在しない場合は、登録ユーザーなし＝ログイン失敗として扱う
+    $apiUsers = class_exists(ApiUser::class) ? ApiUser::$apiUser : [];
+    foreach ($apiUsers as $apiUser) {
+        if ($apiUser['username'] === $username) {
+            allowCORS();
+
+            $auth = getBasicAuthCredentials();
+            if ($auth['user'] !== $apiUser['username'] || $auth['pass'] !== $apiUser['password']) {
+                header('WWW-Authenticate: Basic realm="Database SQL API"');
+                response([
+                    'status' => 'error',
+                    'message' => 'Basic authentication is required to access the database API.',
+                ], 401)->send();
+                exit;
+            }
+
+            return true;
+        }
+    }
+
+    // 3. 未登録ユーザーは 403
+    response([
+        'status' => 'error',
+        'message' => 'User not found',
+    ], 403)->send();
+    exit;
+};
+
 Route::path(
-    'database/{user}/query@get@options',
+    'database/{username}/query@get@options',
     [DatabaseApiController::class, 'index']
 )
-    ->match(function (string $user) {
-        if (MimimalCmsConfig::$urlRoot === '' && $user === SecretsConfig::$adminApiKey)
+    ->match(function (string $username, $stmt) use ($databaseApiAuth) {
+        if (!$databaseApiAuth($username)) {
             return false;
+        }
 
-        allowCORS();
-    })
-    ->matchStr('stmt');
-
-Route::path(
-    'database/{user}/schema@get@options',
-    [DatabaseApiController::class, 'schema']
-)
-    ->match(function (string $user) {
-        if (MimimalCmsConfig::$urlRoot === '' && $user === SecretsConfig::$adminApiKey)
-            return false;
-
-        allowCORS();
+        if (!Validator::str($stmt)) {
+            response([
+                'status' => 'error',
+                'message' => 'The "stmt" parameter is required and must be a string.',
+            ], 400)->send();
+            exit;
+        }
     });
 
 Route::path(
-    'database/{user}/ban@get@options',
+    'database/{username}/schema@get@options',
+    [DatabaseApiController::class, 'schema']
+)
+    ->match($databaseApiAuth);
+
+Route::path(
+    'database/{username}/ban@get@options',
     [DatabaseApiController::class, 'ban']
 )
-    ->match(function (string $user) {
-        if (MimimalCmsConfig::$urlRoot === '' && $user === SecretsConfig::$adminApiKey)
-            return false;
-
-        allowCORS();
-    })
+    ->match($databaseApiAuth)
     ->matchStr('date');
 
 cache();

--- a/app/Controllers/Api/DatabaseApiController.php
+++ b/app/Controllers/Api/DatabaseApiController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Controllers\Api;
 
-use App\Models\RankingPositionDB\RankingPositionDB;
 use App\Models\SQLite\SQLiteOcgraphSqlapi;
 use App\Models\Repositories\Api\ApiDeletedOpenChatListRepository;
 use Shared\Exceptions\ValidationException;
@@ -13,18 +12,13 @@ class DatabaseApiController
 {
     // Migrated to SQLite - no longer need DB_NAME constant
     // private const DB_NAME = 'ocgraph_sqlapi';
-    private const MAX_LIMIT = 10000;
-    private const DEFAULT_LIMIT = 1000;
+    private const MAX_LIMIT = 20;
+    private const DEFAULT_LIMIT = 20;
 
     function index(string $stmt)
     {
         header('Content-Type: application/json');
         ob_start('ob_gzhandler');
-
-        // データベースの最終更新時間を取得
-        $lastUpdateQuery = "SELECT MAX(time) as last_update FROM rising";
-        $lastUpdateStmt = RankingPositionDB::connect()->query($lastUpdateQuery);
-        $lastUpdate = $lastUpdateStmt->fetchColumn();
 
         try {
             $pdo = $this->getPdo();
@@ -33,9 +27,10 @@ class DatabaseApiController
             echo json_encode([
                 'status' => 'success',
                 'data' => $result->fetchAll(\PDO::FETCH_ASSOC),
-                'lastUpdate' => $lastUpdate,
+                'lastUpdate' => $this->getLastImportedAt($pdo),
             ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
         } catch (\Exception $e) {
+            http_response_code(400);
             echo json_encode([
                 'status' => 'error',
                 'message' => $e->getMessage(),
@@ -76,16 +71,11 @@ class DatabaseApiController
             // 改行で分割して配列として返す
             $schemaLines = explode("\n", $schemaContent);
 
-            // データベースの最終更新時間を取得
-            $lastUpdateQuery = "SELECT MAX(time) as last_update FROM rising";
-            $lastUpdateStmt = RankingPositionDB::connect()->query($lastUpdateQuery);
-            $lastUpdate = $lastUpdateStmt->fetchColumn();
-
             // レスポンス
             $response = [
                 'database_type' => 'SQLite 3',
                 'schema' => $schemaLines,
-                'lastUpdate' => $lastUpdate
+                'lastUpdate' => $this->getLastImportedAt($this->getPdo())
             ];
 
             echo json_encode($response, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
@@ -100,6 +90,23 @@ class DatabaseApiController
     {
         // Use SQLite connection
         return SQLiteOcgraphSqlapi::connect(['mode' => '?mode=ro']); // Read-only mode
+    }
+
+    /**
+     * インポート処理（OcreviewApiDataImporter）が最後に完了した時刻を返す。
+     * import_meta テーブルが無い・未記録の場合は null。
+     */
+    private function getLastImportedAt(\PDO $pdo): ?string
+    {
+        try {
+            $value = $pdo
+                ->query("SELECT meta_value FROM import_meta WHERE meta_key = 'last_imported_at'")
+                ->fetchColumn();
+
+            return $value === false ? null : $value;
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     private function filterQuery(string $query): string

--- a/app/Services/Cron/OcreviewApiDataImporter.php
+++ b/app/Services/Cron/OcreviewApiDataImporter.php
@@ -70,6 +70,9 @@ class OcreviewApiDataImporter
         // オープンチャットマスターデータのインポート（差分同期）
         $this->importOpenChatMaster();
 
+        // 現存オープンチャットIDのインポート（全件洗い替え）
+        $this->importOpenChatExisting();
+
         // 成長ランキングのインポート（全件リフレッシュ）
         $this->importGrowthRankings();
 
@@ -88,6 +91,27 @@ class OcreviewApiDataImporter
         // コメント関連データのインポート（差分同期）
         $commentImporter = new OcreviewApiCommentDataImporter($this->sourceCommentPdo, $this->targetPdo);
         $commentImporter->execute();
+
+        // 全インポート完了時刻を記録（API の lastUpdate として返す）
+        $this->recordImportFinishedAt();
+    }
+
+    /**
+     * インポート処理の完了時刻を import_meta テーブルに記録する。
+     *
+     * ここに記録された時刻が、データAPIのレスポンスの lastUpdate として返される。
+     */
+    private function recordImportFinishedAt(): void
+    {
+        // 新規テーブルのため、存在しなければ作成（本番の既存DBにも自動反映）
+        $this->targetPdo->exec(
+            "CREATE TABLE IF NOT EXISTS import_meta (meta_key TEXT PRIMARY KEY, meta_value TEXT NOT NULL)"
+        );
+
+        $stmt = $this->targetPdo->prepare(
+            "INSERT OR REPLACE INTO import_meta (meta_key, meta_value) VALUES ('last_imported_at', ?)"
+        );
+        $stmt->execute([date('Y-m-d H:i:s')]);
     }
 
     /**
@@ -327,6 +351,59 @@ class OcreviewApiDataImporter
         // 初回または100件ごとにDiscord通知を送信
         if ($this->discordNotificationCount % self::DISCORD_NOTIFY_INTERVAL === 0) {
             AdminTool::sendDiscordNotify($message);
+        }
+    }
+
+    /**
+     * 現在オプチャグラフに存在するオープンチャットIDのインポート（全件洗い替え）
+     *
+     * メインDB（MySQL: open_chat）に存在するIDが「現在オプチャグラフに存在するルーム」です。
+     * openchat_master は過去に存在したルームも保持し続けるため、現存ルームだけを抽出するには
+     * このテーブルと JOIN します。差分ではなく毎回全件洗い替え（全削除→全挿入）します。
+     */
+    private function importOpenChatExisting(): void
+    {
+        // 新規テーブルのため、存在しなければ作成（本番の既存DBにも自動反映）
+        $this->targetPdo->exec(
+            "CREATE TABLE IF NOT EXISTS openchat_existing (openchat_id INTEGER PRIMARY KEY)"
+        );
+
+        $totalCount = (int)$this->sourcePdo->query("SELECT COUNT(*) FROM open_chat")->fetchColumn();
+
+        if ($totalCount === 0) {
+            return;
+        }
+
+        $query = "SELECT id AS openchat_id FROM open_chat ORDER BY id LIMIT ? OFFSET ?";
+        $stmt = $this->sourcePdo->prepare($query);
+
+        // 全削除→全挿入を1トランザクションにまとめる。
+        // WALモードのため、コミットされるまで読み取り側は洗い替え前の状態を見続け、
+        // テーブルが一瞬空になる窓は発生しない。失敗時はロールバックして旧データを保持する。
+        $this->targetPdo->beginTransaction();
+        try {
+            // 全件洗い替え（SQLiteはTRUNCATEをサポートしていないため DELETE を使用）
+            $this->targetPdo->exec("DELETE FROM openchat_existing");
+
+            $this->processInChunks(
+                $stmt,
+                [],
+                $totalCount,
+                self::CHUNK_SIZE,
+                function (array $data) {
+                    if (!empty($data)) {
+                        $this->sqlImporter->import($this->targetPdo, 'openchat_existing', $data, self::CHUNK_SIZE);
+                    }
+                },
+                'openchat_existing: %d / %d 件処理完了'
+            );
+
+            $this->targetPdo->commit();
+        } catch (\Throwable $e) {
+            if ($this->targetPdo->inTransaction()) {
+                $this->targetPdo->rollBack();
+            }
+            throw $e;
         }
     }
 

--- a/setup/schema/sqlite/sqlapi.sql
+++ b/setup/schema/sqlite/sqlapi.sql
@@ -1,6 +1,9 @@
 -- SQLite schema for ocgraph_sqlapi database
 -- Migrated from MySQL with full comment preservation
 -- Generated: 2026-01-10
+--
+-- このDBをAPI経由で叩く方法・サンプルSQL・GASコードは、リポジトリ直下の
+-- API_README.md にまとめてある（コピペしやすいMarkdown形式）。
 
 -- ==============================================================================
 -- カテゴリマスタテーブル（25レコード）
@@ -118,6 +121,25 @@ CREATE TABLE IF NOT EXISTS openchat_master (
 );
 CREATE INDEX IF NOT EXISTS idx_openchat_master_category ON openchat_master(category_id);
 CREATE INDEX IF NOT EXISTS idx_openchat_master_updated ON openchat_master(last_updated_at);
+
+-- ==============================================================================
+-- 現在オプチャグラフに存在するオープンチャットのID一覧（毎時、全件洗い替え）
+-- メインDB（MySQL）の現存オープンチャットIDをそのまま反映する。
+-- openchat_master は過去に存在したルームも保持し続けるため、現存ルームだけを抽出したい場合は
+-- このテーブルと openchat_id で JOIN する。
+-- ==============================================================================
+CREATE TABLE IF NOT EXISTS openchat_existing (
+    openchat_id INTEGER PRIMARY KEY         -- 現在オプチャグラフに存在するオープンチャットID（openchat_master.openchat_idと紐づく）
+);
+
+-- ==============================================================================
+-- インポート処理のメタ情報（キーバリュー）
+-- last_imported_at: OcreviewApiDataImporter が最後にインポートを完了した日時（API の lastUpdate）
+-- ==============================================================================
+CREATE TABLE IF NOT EXISTS import_meta (
+    meta_key TEXT PRIMARY KEY,              -- メタ情報のキー（例: last_imported_at）
+    meta_value TEXT NOT NULL                -- 値
+);
 
 -- ==============================================================================
 -- 削除されたオープンチャット履歴


### PR DESCRIPTION
stg の内容を main へ反映します。

- オープンチャットのデータをSQLで取得できる読み取り専用API（Basic認証）と利用ガイド `API_README.md`
- `openchat_existing`（現存ルーム判定）/ `import_meta`（lastUpdate）テーブル追加
- 詳細は #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)