### PR TITLE
[STG] feat: ルームページの分析文・関連ルームを静的キャッシュ化（基盤＋生成バッチ / Stage1+2）

### DIFF
--- a/app/Config/FileStorageServiceConfig.php
+++ b/app/Config/FileStorageServiceConfig.php
@@ -18,6 +18,7 @@ class FileStorageServiceConfig
         'sqliteStatisticsOhlcDb' =>       '/SQLite/statistics_ohlc/statistics_ohlc.db',
         'sqliteRankingPositionOhlcDb' =>  '/SQLite/ranking_position_ohlc/ranking_position_ohlc.db',
         'sqliteRankingPositionDb' =>      '/SQLite/ranking_position/ranking_position.db',
+        'sqliteOcPageCacheDb' =>          '/SQLite/oc_page_cache/oc_page_cache.db',
         'openChatSubCategories' =>        '/open_chat_sub_categories/subcategories.json',
         'openChatRankingPositionDir' =>   '/ranking_position/ranking',
         'openChatRisingPositionDir' =>    '/ranking_position/rising',

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -9,6 +9,7 @@ use App\Config\SecretsConfig;
 use App\Models\CommentRepositories\RecentCommentListRepositoryInterface;
 use App\Models\RecommendRepositories\RecommendRankingRepository;
 use App\Models\Repositories\OpenChatPageRepositoryInterface;
+use App\Models\SQLite\Repositories\OcPageCacheRepository;
 use App\Services\OpenChatAdmin\AdminOpenChat;
 use App\Services\Recommend\Dto\RecommendListDto;
 use App\Services\Recommend\OfficialPageList;
@@ -47,6 +48,7 @@ class OpenChatPageController
         FileStorageInterface $fileStorage,
         OcNarrativeService $narrativeService,
         SimilarSizeRoomService $similarSizeRoomService,
+        OcPageCacheRepository $ocPageCacheRepository,
         int $open_chat_id,
         ?string $isAdminPage,
     ) {
@@ -65,14 +67,6 @@ class OpenChatPageController
                 return $this->deletedResponse($recommendGenarator, $open_chat_id, $topPageDto);
             }
 
-            // 緊急: 高負荷対策として recommend(おすすめ) を一時的に空にする（後で非同期フェッチ化する）
-        $recommend = [false, false, '', false];
-            $similarSize = $similarSizeRoomService->fetch(
-                (int)$oc['id'],
-                (int)$oc['member'],
-                $oc['tag1'] !== null && $oc['tag1'] !== '' ? (string)$oc['tag1'] : null,
-                isset($oc['category']) ? (int)$oc['category'] : null
-            );
         } else {
             // TW/TH も ja と同じくタグ表示・関連ルームを出す。
             // tag(recommend) / oc_tag / oc_tag2 は言語別DBに格納済みのため、
@@ -85,15 +79,13 @@ class OpenChatPageController
                 return $this->deletedResponse($recommendGenarator, $open_chat_id, $topPageDto);
             }
 
-            // 緊急: 高負荷対策として recommend(おすすめ) を一時的に空にする（後で非同期フェッチ化する）
-        $recommend = [false, false, '', false];
-            $similarSize = $similarSizeRoomService->fetch(
-                (int)$oc['id'],
-                (int)$oc['member'],
-                $oc['tag1'] !== null && $oc['tag1'] !== '' ? (string)$oc['tag1'] : null,
-                isset($oc['category']) ? (int)$oc['category'] : null
-            );
         }
+
+        // 分析文・関連ルームは事前計算済みHTML断片を oc_page_cache(SQLite) からPK一発で読むだけ。
+        // 未生成（バックフィル前/生成不可）は null → 空表示。bot が叩く /oc 本体で重い計算をしない。
+        $ocPageCache = $ocPageCacheRepository->get($open_chat_id);
+        $_narrativeHtml = $ocPageCache['narrative_html'] ?? '';
+        $_recommendHtml = $ocPageCache['recommend_html'] ?? '';
 
         $categoryValue = $oc['category'] ? array_search($oc['category'], AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot]) : null;
         $category = $categoryValue ?? t('未指定');
@@ -116,22 +108,9 @@ class OpenChatPageController
         $collapsedDescription = $collapseKeywordEnumerations->collapse($oc['description'], extraText: $oc['name']);
         $formatedDescription = trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $collapsedDescription));
 
-        // narrative section 用データ (全言語対応)。
-        // - Service の出力文字列は t()/sprintfT() で多言語化済 (ja/tw/th)。
-        // - category label の locale-aware 解決もここで行い、Service は平に文字列を消費する
-        //   (OPEN_CHAT_CATEGORY は現在の urlRoot キーで引くため、各言語の表示名になる)
-        // - Service が失敗しても null が返るので section / meta は既存挙動を完全維持
-        $categoryLabel = null;
-        $catId = $oc['category'] ?? null;
-        if (is_int($catId) && $catId > 0) {
-            $catMap = AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot] ?? [];
-            $label = array_search($catId, $catMap, true);
-            $categoryLabel = $label !== false ? (string)$label : null;
-        }
-        // 緊急: 高負荷対策として narrative(分析文) を一時的に空にする（後で非同期フェッチ化する）
-        $narrative = null;
-
-        $_meta = $meta->generateMetadata($open_chat_id, [...$oc, 'description' => $formatedDescription], $narrative)->setImageUrl(imgUrl($oc['img_url']));
+        // 分析文(narrative)・関連ルームは oc_page_cache から読み済み（$_narrativeHtml/$_recommendHtml）。
+        // meta への narrative 連携は無し(null)＝#372以降の現行挙動を踏襲（meta description は room description ベース）。
+        $_meta = $meta->generateMetadata($open_chat_id, [...$oc, 'description' => $formatedDescription], null)->setImageUrl(imgUrl($oc['img_url']));
         $_meta->thumbnail = imgPreviewUrl($oc['img_url']);
 
         $_breadcrumbsShema = $breadcrumbsShema->generateSchema(
@@ -168,15 +147,14 @@ class OpenChatPageController
             '_commentArgDto',
             '_breadcrumbsShema',
             '_schema',
-            'recommend',
-            'similarSize',
+            '_narrativeHtml',
+            '_recommendHtml',
             '_hourlyRange',
             '_adminDto',
             'officialDto',
             'topPageDto',
             'formatedDescription',
             'formatedRowDescription',
-            'narrative',
         ));
     }
 

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -48,6 +48,17 @@ class OcPageCacheRepository
         }
 
         $pdo = SQLiteOcPageCache::connect(); // 既定 rwc: WAL有効・ファイル未作成なら生成
+
+        // 既存環境では setup スクリプト未再実行で .db/テーブルが無いことがあるため、
+        // バックフィルが自前でテーブルを作る（schema は setup/schema/sqlite/oc_page_cache.sql と同一）。
+        $pdo->exec(
+            'CREATE TABLE IF NOT EXISTS oc_page_cache ('
+                . 'open_chat_id INTEGER PRIMARY KEY, '
+                . "narrative_html TEXT NOT NULL DEFAULT '', "
+                . "recommend_html TEXT NOT NULL DEFAULT '', "
+                . 'updated_at TEXT NOT NULL)'
+        );
+
         $now = (new \DateTime)->format('Y-m-d H:i:s');
 
         $stmt = $pdo->prepare(

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\SQLite\Repositories;
+
+use App\Models\SQLite\SQLiteOcPageCache;
+
+/**
+ * ルーム個別ページの事前計算HTML断片（分析文・関連ルーム）の読み書き。
+ *
+ * - 読み: /oc 表示時に PK 一発 SELECT（mode=rw。mode=ro×WAL の locking protocol を避けるため）。
+ *   キャッシュ未生成（DBファイル無し・該当行無し）は null を返し、呼び出し側は空表示にフォールバックする。
+ * - 書き: 背景バッチ（OcPageCacheGenerator）が単一プロセスで INSERT OR REPLACE する。
+ *   HTML はクォートを含むため、SQLiteInsertImporter（値を素で埋め込む・OR IGNORE）は使わず、
+ *   パラメータ化したプリペアドステートメント + トランザクションで upsert する。
+ */
+class OcPageCacheRepository
+{
+    /**
+     * @return array{narrative_html: string, recommend_html: string}|null
+     */
+    public function get(int $open_chat_id): ?array
+    {
+        try {
+            SQLiteOcPageCache::connect(['mode' => '?mode=rw']);
+            $row = SQLiteOcPageCache::fetch(
+                'SELECT narrative_html, recommend_html FROM oc_page_cache WHERE open_chat_id = ?',
+                [$open_chat_id]
+            );
+        } catch (\PDOException) {
+            // DBファイル未作成（バックフィル前）等は「キャッシュ無し」として扱う
+            return null;
+        }
+
+        return is_array($row) ? $row : null;
+    }
+
+    /**
+     * 部屋単位HTMLを一括 upsert する（背景バッチ専用・単一プロセス直列書き込み）。
+     *
+     * @param array<array{open_chat_id: int, narrative_html: string, recommend_html: string}> $rows
+     */
+    public function upsertMany(array $rows): void
+    {
+        if (!$rows) {
+            return;
+        }
+
+        $pdo = SQLiteOcPageCache::connect(); // 既定 rwc: WAL有効・ファイル未作成なら生成
+        $now = (new \DateTime)->format('Y-m-d H:i:s');
+
+        $stmt = $pdo->prepare(
+            'INSERT OR REPLACE INTO oc_page_cache
+                (open_chat_id, narrative_html, recommend_html, updated_at)
+             VALUES (?, ?, ?, ?)'
+        );
+
+        $pdo->beginTransaction();
+        try {
+            foreach ($rows as $r) {
+                $stmt->execute([
+                    $r['open_chat_id'],
+                    $r['narrative_html'],
+                    $r['recommend_html'],
+                    $now,
+                ]);
+            }
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+}

--- a/app/Models/SQLite/SQLiteOcPageCache.php
+++ b/app/Models/SQLite/SQLiteOcPageCache.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\SQLite;
+
+use Shadow\DBInterface;
+
+class SQLiteOcPageCache extends AbstractSQLite implements DBInterface
+{
+    public static ?\PDO $pdo = null;
+
+    /**
+     * @param ?array $config array{mode?: ?string} $config mode default is '?mode=rwc'
+     */
+    public static function connect(?array $config = null): \PDO
+    {
+        return parent::connect([
+            'storageFileKey' => 'sqliteOcPageCacheDb',
+            'mode' => $config['mode'] ?? null
+        ]);
+    }
+}

--- a/app/Services/Cron/Enum/SyncOpenChatStateType.php
+++ b/app/Services/Cron/Enum/SyncOpenChatStateType.php
@@ -12,6 +12,7 @@ enum SyncOpenChatStateType: string
     case openChatDailyCrawlingKillFlag = 'openChatDailyCrawlingKillFlag';
     case isUpdateInvitationTicketActive = 'isUpdateInvitationTicketActive';
     case isUpdateRecommendStaticDataActive = 'isUpdateRecommendStaticDataActive';
+    case isUpdateOcPageCacheActive = 'isUpdateOcPageCacheActive';
     case isRecommendTagRebuildActive = 'isRecommendTagRebuildActive';
     case recommendTagsJsonHash = 'recommendTagsJsonHash';
     case rankingPersistenceBackground = 'rankingPersistenceBackground';

--- a/app/Services/StaticData/OcPageCacheGenerator.php
+++ b/app/Services/StaticData/OcPageCacheGenerator.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\StaticData;
+
+use App\Config\AppConfig;
+use App\Models\Repositories\OpenChatPageRepositoryInterface;
+use App\Models\SQLite\Repositories\OcPageCacheRepository;
+use App\Services\Narrative\OcNarrativeService;
+use App\Services\Recommend\RecommendGenarator;
+use App\Services\Recommend\SimilarSizeRoomService;
+use App\Views\Classes\CollapseKeywordEnumerationsInterface;
+use Shared\MimimalCmsConfig;
+
+/**
+ * ルーム個別ページの「分析文(narrative)」「関連ルーム(recommend/similarSize)」を事前計算し、
+ * レンダリング済みHTML断片として oc_page_cache(SQLite) に保存する。
+ *
+ * /oc 表示時はこのキャッシュをPK一発SELECTで読むだけにし、bot クロール時に
+ * narrative の重い読み取りや recommend/similarSize の MySQL を発生させない。
+ *
+ * 注: 出力HTMLは url()/t() 等が現在の MimimalCmsConfig::$urlRoot に依存するため、
+ * 言語別 cron 文脈（urlRoot 設定済み）から呼ぶこと。保存先 SQLite も urlRoot の storage 配下になる。
+ */
+class OcPageCacheGenerator
+{
+    public function __construct(
+        private OpenChatPageRepositoryInterface $ocRepo,
+        private RecommendGenarator $recommendGenarator,
+        private SimilarSizeRoomService $similarSizeRoomService,
+        private OcNarrativeService $narrativeService,
+        private CollapseKeywordEnumerationsInterface $collapseKeywordEnumerations,
+        private OcPageCacheRepository $cacheRepo,
+    ) {
+    }
+
+    /**
+     * 指定IDの集合についてキャッシュを生成・保存する。
+     *
+     * @param int[] $ids
+     * @return int 保存した件数
+     */
+    public function generateForIds(array $ids): int
+    {
+        $rows = [];
+
+        foreach ($ids as $id) {
+            $id = (int)$id;
+            $oc = $this->ocRepo->getOpenChatByIdWithTag($id);
+            if (!$oc) {
+                continue;
+            }
+
+            $recommend = $this->recommendGenarator->getRecommend(
+                $oc['tag1'],
+                $oc['tag2'],
+                $oc['tag3'],
+                $oc['category']
+            );
+            $similarSize = $this->similarSizeRoomService->fetch(
+                (int)$oc['id'],
+                (int)$oc['member'],
+                $oc['tag1'] !== null && $oc['tag1'] !== '' ? (string)$oc['tag1'] : null,
+                isset($oc['category']) ? (int)$oc['category'] : null
+            );
+
+            $collapsed = $this->collapseKeywordEnumerations->collapse($oc['description'], extraText: $oc['name']);
+            $formatedDescription = trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $collapsed));
+
+            $categoryLabel = null;
+            $catId = $oc['category'] ?? null;
+            if (is_int($catId) && $catId > 0) {
+                $catMap = AppConfig::OPEN_CHAT_CATEGORY[MimimalCmsConfig::$urlRoot] ?? [];
+                $label = array_search($catId, $catMap, true);
+                $categoryLabel = $label !== false ? (string)$label : null;
+            }
+            $narrative = $this->narrativeService->generate(
+                $id,
+                [...$oc, 'description' => $formatedDescription],
+                $categoryLabel
+            );
+
+            ob_start();
+            viewComponent('oc_narrative_section', ['narrative' => $narrative, 'oc' => $oc]);
+            $narrativeHtml = ob_get_clean();
+
+            ob_start();
+            viewComponent('oc_recommend_aside', ['similarSize' => $similarSize, 'recommend' => $recommend, 'oc' => $oc]);
+            $recommendHtml = ob_get_clean();
+
+            $rows[] = [
+                'open_chat_id' => $id,
+                'narrative_html' => (string)$narrativeHtml,
+                'recommend_html' => (string)$recommendHtml,
+            ];
+        }
+
+        $this->cacheRepo->upsertMany($rows);
+
+        return count($rows);
+    }
+}

--- a/app/Views/components/oc_narrative_section.php
+++ b/app/Views/components/oc_narrative_section.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * 分析文(narrative)セクション。
+ * OcPageCacheGenerator が事前計算してHTML化し、/oc 表示時はキャッシュHTMLをそのまま出力する。
+ *
+ * - summary があれば分析本文 + 状態に合った記事リンク
+ * - summary が無くても pattern があれば記事リンクだけ出す（「空ならブログリンクだけ」）
+ * - narrative が null（生成不可）なら何も出さない
+ *
+ * @var array|null $narrative
+ * @var array $oc
+ */
+?>
+<?php if (!empty($narrative) && is_array($narrative)): ?>
+  <section class="oc-narrative" aria-label="<?php echo t('オプチャグラフの分析') ?>">
+    <?php if (!empty($narrative['summary'])): ?>
+      <p class="oc-narrative__text"><span class="oc-narrative__badge" aria-hidden="true"><?php echo t('分析') ?></span><b class="oc-narrative__label"><?php echo h($narrative['summary']) ?></b><?php if (!empty($narrative['detail'])): ?><span class="oc-narrative__detail"><?php echo h($narrative['detail']) ?></span><?php endif ?></p>
+    <?php endif ?>
+    <?php // 分析が立てた疑問に答える記事へのインライン導線（ja のみ・状態に合致したときだけ） ?>
+    <?php viewComponent('oc_blog_context_link', ['pattern' => (string)($narrative['pattern'] ?? ''), 'member' => (int)($oc['member'] ?? 0)]) ?>
+  </section>
+<?php endif ?>

--- a/app/Views/components/oc_recommend_aside.php
+++ b/app/Views/components/oc_recommend_aside.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * 関連ルーム(類似サイズ or おすすめ)セクション。
+ * OcPageCacheGenerator が事前計算してHTML化し、/oc 表示時はキャッシュHTMLをそのまま出力する。
+ *
+ * @var array|false $similarSize
+ * @var array{0:mixed,1:mixed,2:string,3:mixed} $recommend
+ * @var array $oc
+ */
+?>
+<?php if (isset($similarSize) && $similarSize) : ?>
+  <aside class="recommend-list-aside" id="similar-size-rooms">
+    <?php viewComponent('similar_size_rooms', [
+      'rooms'         => $similarSize['rooms'],
+      'recommend'     => $similarSize['recommend'],
+      'mode'          => $similarSize['mode'],
+      'currentMember' => $oc['member'],
+      'category'      => $oc['category'] ?? null,
+      'tag'           => $oc['tag1'] ?? null,
+    ]) ?>
+  </aside>
+<?php elseif (!empty($recommend[3])) : ?>
+  <aside class="recommend-list-aside" id="recommend-list-aside1">
+    <?php viewComponent('recommend_list2', ['recommend' => $recommend[3], 'member' => $oc['member'], 'tag' => '', 'id' => $oc['id']]) ?>
+  </aside>
+<?php endif ?>

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -124,10 +124,11 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
                 <a class="oc-nav-chip oc-nav-chip--category" href="<?php echo url('ranking' . ($oc['category'] ? ('/' . $oc['category']) : '')) ?>"><?php echo $category ?></a>
               </span>
             <?php endif ?>
-            <?php if (isset($recommend[2]) && $recommend[2]) : ?>
+            <?php // タグチップは getOpenChatByIdWithTag が返す tag1 を直接使う（recommend は静的キャッシュ側で描画） ?>
+            <?php if (!empty($oc['tag1'])) : ?>
               <span class="oc-nav-pair">
                 <span class="oc-nav-pair__label"><?php echo t('タグ') ?></span>
-                <a class="oc-nav-chip oc-nav-chip--tag" href="<?php echo url('recommend/' . urlencode(htmlspecialchars_decode($recommend[2]))) ?>"><?php echo $recommend[2] ?></a>
+                <a class="oc-nav-chip oc-nav-chip--tag" href="<?php echo url('recommend/' . urlencode(htmlspecialchars_decode((string)$oc['tag1']))) ?>"><?php echo $oc['tag1'] ?></a>
               </span>
             <?php endif ?>
           </span>
@@ -158,13 +159,8 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
       <?php if (isset($_adminDto)) : ?>
         <?php viewComponent('oc_content_admin', compact('_adminDto')); ?>
       <?php endif ?>
-      <?php if (!empty($narrative) && is_array($narrative) && !empty($narrative['summary'])): ?>
-        <section class="oc-narrative" aria-label="<?php echo t('オプチャグラフの分析') ?>">
-          <p class="oc-narrative__text"><span class="oc-narrative__badge" aria-hidden="true"><?php echo t('分析') ?></span><b class="oc-narrative__label"><?php echo h($narrative['summary']) ?></b><?php if (!empty($narrative['detail'])): ?><span class="oc-narrative__detail"><?php echo h($narrative['detail']) ?></span><?php endif ?></p>
-          <?php // 分析が立てた疑問に答える記事へのインライン導線（ja のみ・状態に合致したときだけ） ?>
-          <?php viewComponent('oc_blog_context_link', ['pattern' => (string)($narrative['pattern'] ?? ''), 'member' => (int)($oc['member'] ?? 0)]) ?>
-        </section>
-      <?php endif ?>
+      <?php // 分析文は oc_page_cache の事前計算済みHTMLを生出力（_接頭辞=自動エスケープ対象外）。未生成は空 ?>
+      <?php echo $_narrativeHtml ?>
       <section class="openchat-graph-section" style="padding-bottom: 0rem; padding-top: var(--sp-section-gap);">
         <div class="title-bar" style="margin-bottom: 1.5rem;">
           <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
@@ -208,22 +204,8 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
       <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
     <?php endif ?>
 
-    <?php if (isset($similarSize) && $similarSize) : ?>
-      <aside class="recommend-list-aside" id="similar-size-rooms">
-        <?php viewComponent('similar_size_rooms', [
-          'rooms'         => $similarSize['rooms'],
-          'recommend'     => $similarSize['recommend'],
-          'mode'          => $similarSize['mode'],
-          'currentMember' => $oc['member'],
-          'category'      => $oc['category'] ?? null,
-          'tag'           => $oc['tag1'] ?? null,
-        ]) ?>
-      </aside>
-    <?php elseif ($recommend[3]) : ?>
-      <aside class="recommend-list-aside" id="recommend-list-aside1">
-        <?php viewComponent('recommend_list2', ['recommend' => $recommend[3], 'member' => $oc['member'], 'tag' => '', 'id' => $oc['id']]) ?>
-      </aside>
-    <?php endif ?>
+    <?php // 関連ルーム(類似サイズ/おすすめ)は oc_page_cache の事前計算済みHTMLを生出力。未生成は空 ?>
+    <?php echo $_recommendHtml ?>
 
 
     <?php if (MimimalCmsConfig::$urlRoot === ''): // TODO:日本以外ではコメントが無効

--- a/batch/exec/update_oc_page_cache.php
+++ b/batch/exec/update_oc_page_cache.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Models\Repositories\OpenChatRepositoryInterface;
+use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
+use App\Services\Admin\AdminTool;
+use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\Cron\Utility\CronUtility;
+use App\Services\StaticData\OcPageCacheGenerator;
+use ExceptionHandler\ExceptionHandler;
+use Shared\MimimalCmsConfig;
+
+/**
+ * ルーム個別ページの「分析文/関連ルーム」事前計算キャッシュ(oc_page_cache)を生成する。
+ *
+ * 使い方:
+ *   php batch/exec/update_oc_page_cache.php <urlRoot> [idCsv]
+ *     - <urlRoot>: '' | 'tw' | 'th'（保存先SQLite・HTMLの言語を決める）
+ *     - [idCsv]  : 省略時は全ルーム(getOpenChatIdAll)をバックフィル。
+ *                  カンマ区切りID指定時はそのルームだけ再生成（write-through用）。
+ *
+ * 出力HTMLは url()/t() が urlRoot に依存するため、必ず対象言語の urlRoot を渡すこと。
+ */
+
+set_time_limit(3600 * 6);
+
+try {
+    if (isset($argv[1]) && $argv[1]) {
+        MimimalCmsConfig::$urlRoot = $argv[1];
+    }
+
+    /** @var SyncOpenChatStateRepositoryInterface $state */
+    $state = app(SyncOpenChatStateRepositoryInterface::class);
+
+    // 既に実行中なら前回プロセスをkill（多重生成防止）
+    if ($state->getBool(StateType::isUpdateOcPageCacheActive)) {
+        $myPid = getmypid();
+        $cmd = "ps aux | grep update_oc_page_cache.php | grep -v grep | grep -v '{$myPid}' | awk '{print \$2}' | xargs -r kill";
+        exec($cmd);
+        CronUtility::addCronLog('ページキャッシュ生成: 前回プロセスをkillして再開');
+        $state->setFalse(StateType::isUpdateOcPageCacheActive);
+        sleep(3);
+    }
+
+    $state->setTrue(StateType::isUpdateOcPageCacheActive);
+
+    // 対象ID: 引数指定があればそれ、無ければ全ルーム
+    if (isset($argv[2]) && $argv[2] !== '') {
+        $ids = array_values(array_filter(array_map('intval', explode(',', $argv[2])), fn($v) => $v > 0));
+    } else {
+        /** @var OpenChatRepositoryInterface $ocRepo */
+        $ocRepo = app(OpenChatRepositoryInterface::class);
+        $ids = $ocRepo->getOpenChatIdAll();
+    }
+
+    /** @var OcPageCacheGenerator $generator */
+    $generator = app(OcPageCacheGenerator::class);
+
+    $total = 0;
+    // 1チャンクごとにトランザクションでまとめて書き込む（fsync削減）
+    foreach (array_chunk($ids, 300) as $chunk) {
+        $total += $generator->generateForIds($chunk);
+    }
+
+    CronUtility::addVerboseCronLog("ページキャッシュ生成完了（urlRoot=" . MimimalCmsConfig::$urlRoot . " / {$total}件）");
+
+    $state->setFalse(StateType::isUpdateOcPageCacheActive);
+} catch (\Throwable $e) {
+    if (isset($state)) {
+        $state->setFalse(StateType::isUpdateOcPageCacheActive);
+    }
+    CronUtility::addCronLog($e->__toString());
+    AdminTool::sendDiscordNotify($e->__toString());
+    ExceptionHandler::errorLog($e);
+}

--- a/setup/init-remote.sh
+++ b/setup/init-remote.sh
@@ -110,6 +110,7 @@ rm -f "$STORAGE_DIR"/*/ranking_position/*/*.dat
 rm -f "$STORAGE_DIR"/*/ranking_position/*.dat
 rm -f "$STORAGE_DIR"/*/SQLite/statistics/*.db*
 rm -f "$STORAGE_DIR"/*/SQLite/ranking_position/*.db*
+rm -f "$STORAGE_DIR"/*/SQLite/oc_page_cache/*.db*
 rm -f "$STORAGE_DIR"/*/SQLite/ocgraph_sqlapi/*.db*
 rm -f "$STORAGE_DIR"/*.log
 rm -f "$STORAGE_DIR"/*/*/*.log
@@ -275,6 +276,7 @@ for lang in ja tw th; do
     mkdir -p "$STORAGE_DIR/${lang}/SQLite/statistics_ohlc"
     mkdir -p "$STORAGE_DIR/${lang}/SQLite/ranking_position_ohlc"
     mkdir -p "$STORAGE_DIR/${lang}/SQLite/ranking_position"
+    mkdir -p "$STORAGE_DIR/${lang}/SQLite/oc_page_cache"
 
     # statistics.db を生成
     if [ -f "$SQLITE_SCHEMA_DIR/statistics.sql" ]; then
@@ -298,6 +300,12 @@ for lang in ja tw th; do
     if [ -f "$SQLITE_SCHEMA_DIR/ranking_position.sql" ]; then
         sqlite3 "$STORAGE_DIR/${lang}/SQLite/ranking_position/ranking_position.db" < "$SQLITE_SCHEMA_DIR/ranking_position.sql"
         echo "    ✓ ranking_position.db"
+    fi
+
+    # oc_page_cache.db を生成（ルーム個別ページの分析文/関連ルーム事前計算キャッシュ）
+    if [ -f "$SQLITE_SCHEMA_DIR/oc_page_cache.sql" ]; then
+        sqlite3 "$STORAGE_DIR/${lang}/SQLite/oc_page_cache/oc_page_cache.db" < "$SQLITE_SCHEMA_DIR/oc_page_cache.sql"
+        echo "    ✓ oc_page_cache.db"
     fi
 
     # sqlapi.db を生成（jaのみ）

--- a/setup/local-setup.default.sh
+++ b/setup/local-setup.default.sh
@@ -145,6 +145,7 @@ docker compose exec -T -u root app bash -c '
     rm -f storage/*/SQLite/statistics_ohlc/*.db*
     rm -f storage/*/SQLite/ranking_position/*.db*
     rm -f storage/*/SQLite/ranking_position_ohlc/*.db*
+    rm -f storage/*/SQLite/oc_page_cache/*.db*
     rm -f storage/*/SQLite/ocgraph_sqlapi/*.db*
     rm -f storage/*.log
     rm -f storage/*/*/*.log
@@ -262,6 +263,9 @@ for lang in ja tw th; do
 
     # statistics_ohlc.db を生成
     cat setup/schema/sqlite/statistics_ohlc.sql | docker compose exec -T -u www-data app sqlite3 "storage/${lang}/SQLite/statistics_ohlc/statistics_ohlc.db"
+
+    # oc_page_cache.db を生成（ルーム個別ページの分析文/関連ルーム事前計算キャッシュ）
+    cat setup/schema/sqlite/oc_page_cache.sql | docker compose exec -T -u www-data app sqlite3 "storage/${lang}/SQLite/oc_page_cache/oc_page_cache.db"
 
     # sqlapi.db を生成（jaのみ）
     if [ "$lang" == "ja" ]; then

--- a/setup/schema/sqlite/oc_page_cache.sql
+++ b/setup/schema/sqlite/oc_page_cache.sql
@@ -1,0 +1,12 @@
+-- SQLite schema for oc_page_cache database
+-- ルーム個別ページの「分析文(narrative)」「関連ルーム(recommend/similarSize)」を
+-- 事前計算したレンダリング済みHTML断片で保持する（部屋単位）。
+-- /oc 表示時はこのテーブルをPK一発SELECTで読むだけにし、bot クロール時に
+-- narrative の重い読み取りや recommend/similarSize の MySQL を発生させない。
+
+CREATE TABLE IF NOT EXISTS oc_page_cache (
+    open_chat_id INTEGER PRIMARY KEY,        -- オープンチャットID
+    narrative_html TEXT NOT NULL DEFAULT '', -- 分析文セクションのHTML（空=データ無し）
+    recommend_html TEXT NOT NULL DEFAULT '', -- 関連ルーム(similarSize優先・無ければおすすめ)のHTML
+    updated_at TEXT NOT NULL                 -- 生成時刻 Y-m-d H:i:s
+);


### PR DESCRIPTION
#372で空表示にしている narrative/recommend/similarSize を、部屋単位で事前計算したHTML断片を新SQLite(oc_page_cache)に保存し /oc はPK一発SELECTで読むだけにする静的キャッシュ方式の基盤と生成バッチ。bot クロール時に重い読み取り/MySQLを発生させない。

新SQLite=storage/{lang}/SQLite/oc_page_cache（setup/schema/sqlite + init-remote.sh/local-setup.default.sh に登録）。読み=mode=rwでlocking protocol回避・未生成はnull→空表示。生成=OcPageCacheGenerator + batch/exec/update_oc_page_cache.php。

読み出し基盤は全miss=現状の空表示と同一で無害。**初回は update_oc_page_cache.php のバックフィルでキャッシュ生成が必要**。自動更新(クロールへのwrite-throughフック)は次PR。

検証: dev/本番で`php batch/exec/update_oc_page_cache.php ''`(ja)等を回し、/ocで分析文・関連ルーム復活を確認。