### PR TITLE
[PROD] feat: oc_page_cache バックフィルの管理画面トリガーを本番反映（/admin/genocpagecache）

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -604,6 +604,12 @@ Route::path('admin/adminer@get@post', [AdminPageController::class, 'adminer'])
         return MimimalCmsConfig::$urlRoot === '';
     });
 
+// ルーム個別ページ静的キャッシュ(oc_page_cache)のバックフィル実行（admin・背景実行）
+Route::path('admin/genocpagecache/{lang}', [AdminPageController::class, 'genocpagecache'])
+    ->match(function () {
+        return MimimalCmsConfig::$urlRoot === '';
+    });
+
 Route::path(
     'admin-api@post',
     [AdminEndPointController::class, 'index']

--- a/app/Controllers/Pages/AdminPageController.php
+++ b/app/Controllers/Pages/AdminPageController.php
@@ -242,6 +242,32 @@ class AdminPageController
     }
 
     /**
+     * ルーム個別ページの分析文/関連ルームの静的キャッシュ(oc_page_cache)を生成する。
+     * 指定言語の全ルームをバックフィルする（背景実行・長時間）。
+     * 例: /admin/genocpagecache/ja  (tw / th も可)
+     */
+    function genocpagecache(string $lang)
+    {
+        $urlRoot = match ($lang) {
+            'ja' => '',
+            'tw' => '/tw',
+            'th' => '/th',
+            default => null,
+        };
+
+        if (is_null($urlRoot)) {
+            return view('admin/admin_message_page', ['title' => 'exec', 'message' => 'パラメータ(lang)が不正です。ja / tw / th を指定してください。']);
+        }
+
+        $path = AppConfig::ROOT_PATH . 'batch/exec/update_oc_page_cache.php';
+        $arg = escapeshellarg($urlRoot);
+
+        exec(AppConfig::$phpBinary . " {$path} {$arg} >/dev/null 2>&1 &");
+
+        return view('admin/admin_message_page', ['title' => 'exec', 'message' => $path . " ({$lang}) を背景実行しました（全ルームのバックフィル・完了まで時間がかかります）。"]);
+    }
+
+    /**
      * 日次ランキング更新
      */
     function updatedailyranking(UpdateDailyRankingService $updateRankingService,)


### PR DESCRIPTION
本番で静的キャッシュのバックフィルを起動できるよう /admin/genocpagecache/{lang} を本番へ。これでキャッシュ生成→分析文・関連ルーム復活が可能になる。