### PR TITLE
[STG] chore: oc_page_cache 周りのクリーンアップ（未使用DI削除・app()→DI）

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -6,7 +6,6 @@ namespace App\Controllers\Pages;
 
 use App\Config\AppConfig;
 use App\Config\SecretsConfig;
-use App\Models\CommentRepositories\RecentCommentListRepositoryInterface;
 use App\Models\RecommendRepositories\RecommendRankingRepository;
 use App\Models\Repositories\OpenChatPageRepositoryInterface;
 use App\Models\SQLite\Repositories\OcPageCacheRepository;
@@ -14,15 +13,12 @@ use App\Services\OpenChatAdmin\AdminOpenChat;
 use App\Services\Recommend\Dto\RecommendListDto;
 use App\Services\Recommend\OfficialPageList;
 use App\Services\Recommend\RecommendGenarator;
-use App\Services\Recommend\SimilarSizeRoomService;
 use App\Services\StaticData\Dto\StaticTopPageDto;
 use App\Services\StaticData\StaticDataFile;
-use App\Services\Narrative\OcNarrativeService;
 use App\Services\Statistics\StatisticsChartArrayService;
 use App\Views\Meta\OcPageMeta;
 use App\Views\Schema\OcPageSchema;
 use App\Views\Schema\PageBreadcrumbsListSchema;
-use App\Views\StatisticsViewUtility;
 use App\Services\Statistics\Dto\StatisticsChartDto;
 use App\Views\Classes\CollapseKeywordEnumerationsInterface;
 use App\Views\Classes\Dto\RankingPositionChartArgDtoFactoryInterface;
@@ -36,18 +32,13 @@ class OpenChatPageController
     function index(
         OpenChatPageRepositoryInterface $ocRepo,
         OcPageMeta $meta,
-        StatisticsChartArrayService $statisticsChartArrayService,
-        StatisticsViewUtility $statisticsViewUtility,
         PageBreadcrumbsListSchema $breadcrumbsShema,
         OcPageSchema $ocPageSchema,
         StaticDataFile $staticDataGeneration,
         RecommendGenarator $recommendGenarator,
-        RecentCommentListRepositoryInterface $recentCommentListRepository,
         RankingPositionChartArgDtoFactoryInterface $rankingPositionChartArgDtoFactory,
         CollapseKeywordEnumerationsInterface $collapseKeywordEnumerations,
         FileStorageInterface $fileStorage,
-        OcNarrativeService $narrativeService,
-        SimilarSizeRoomService $similarSizeRoomService,
         OcPageCacheRepository $ocPageCacheRepository,
         int $open_chat_id,
         ?string $isAdminPage,

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\SQLite\Repositories;
 
 use App\Models\SQLite\SQLiteOcPageCache;
+use App\Services\Storage\FileStorageInterface;
 
 /**
  * ルーム個別ページの事前計算HTML断片（分析文・関連ルーム）の読み書き。
@@ -17,6 +18,11 @@ use App\Models\SQLite\SQLiteOcPageCache;
  */
 class OcPageCacheRepository
 {
+    public function __construct(
+        private FileStorageInterface $fileStorage,
+    ) {
+    }
+
     /**
      * @return array{narrative_html: string, recommend_html: string}|null
      */
@@ -48,7 +54,7 @@ class OcPageCacheRepository
         }
 
         // PDO rwc はファイルは作るがディレクトリは作らない。既存環境で dir が無い場合に備えて先に作る。
-        $dbPath = app(\App\Services\Storage\FileStorageInterface::class)->getStorageFilePath('sqliteOcPageCacheDb');
+        $dbPath = $this->fileStorage->getStorageFilePath('sqliteOcPageCacheDb');
         $dir = dirname($dbPath);
         if (!is_dir($dir)) {
             @mkdir($dir, 0775, true);


### PR DESCRIPTION
OpenChatPageController::index の未使用注入(StatisticsViewUtility/RecentCommentListRepository/OcNarrativeService/SimilarSizeRoomService と index未使用のStatisticsChartArrayService)を削除。OcPageCacheRepository の app() インラインをコンストラクタDIに。