### PR TITLE
[PROD] データAPIの認証をPOST＋パスワードのSHA256送信方式に変更

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -847,12 +847,52 @@ $databaseApiAuth = function (string $username) {
     exit;
 };
 
+// /database/{username}/query・/schema 用の認証（いずれも POST）:
+//   - Basic認証ではなく、POSTボディの password で認証する
+//   - password は ApiUser の登録パスワードを SHA256 した16進文字列を送る
+//   - {username} が adminApiKey の場合は従来どおり password 不要
+$databaseApiPostAuth = function (string $username, $password = null) {
+    if (MimimalCmsConfig::$urlRoot !== '') {
+        return false;
+    }
+
+    allowCORS(); // OPTIONS プリフライトはここで終了
+
+    // 1. 管理用キー（password 不要）
+    if ($username === SecretsConfig::$adminApiKey) {
+        return true;
+    }
+
+    // 2. 登録済みユーザーは POSTされた password（SHA256）で照合
+    $apiUsers = class_exists(ApiUser::class) ? ApiUser::$apiUser : [];
+    foreach ($apiUsers as $apiUser) {
+        if ($apiUser['username'] === $username) {
+            $expected = hash('sha256', $apiUser['password']);
+            if (!is_string($password) || !hash_equals($expected, strtolower($password))) {
+                response([
+                    'status' => 'error',
+                    'message' => 'Authentication failed.',
+                ], 401)->send();
+                exit;
+            }
+            return true;
+        }
+    }
+
+    // 3. 未登録ユーザーは 403
+    response([
+        'status' => 'error',
+        'message' => 'User not found',
+    ], 403)->send();
+    exit;
+};
+
 Route::path(
-    'database/{username}/query@get@options',
+    'database/{username}/query@post@options',
     [DatabaseApiController::class, 'index']
 )
-    ->match(function (string $username, $stmt) use ($databaseApiAuth) {
-        if (!$databaseApiAuth($username)) {
+    ->match(function (string $username, $password = null, $stmt = null) use ($databaseApiPostAuth) {
+        if (!$databaseApiPostAuth($username, $password)) {
             return false;
         }
 
@@ -866,10 +906,10 @@ Route::path(
     });
 
 Route::path(
-    'database/{username}/schema@get@options',
+    'database/{username}/schema@post@options',
     [DatabaseApiController::class, 'schema']
 )
-    ->match($databaseApiAuth);
+    ->match($databaseApiPostAuth);
 
 Route::path(
     'database/{username}/ban@get@options',


### PR DESCRIPTION
データAPI（/database/{username}/query・/schema）の認証を変更。

- メソッドを GET → **POST** に
- 認証を Basic から、POSTボディの `password`（登録パスワードの **SHA256・16進**）照合に変更
- `stmt` も POST ボディで受け取る
- {username} が adminApiKey の場合は従来どおり password 不要
- /ban は対象外（変更なし）

README は別途 main/stg に直接反映済み。stg は #387 でマージ済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)