### PR TITLE
[PROD] feat: ルームページの分析文・関連ルームキャッシュを毎時処理で自動更新（変動ルームのみ）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Initialize SQLite databases
         run: |
-          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do for name in statistics_ohlc ranking_position_ohlc; do db="storage/$lang/SQLite/$name/$name.db"; if [ ! -f "$db" ]; then sqlite3 "$db" < "setup/schema/sqlite/$name.sql" && echo "Created: $db"; fi; done; done'
+          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do for name in statistics_ohlc ranking_position_ohlc oc_page_cache; do db="storage/$lang/SQLite/$name/$name.db"; if [ ! -f "$db" ]; then sqlite3 "$db" < "setup/schema/sqlite/$name.sql" && echo "Created: $db"; fi; done; done'
 
       # setup/schema/mysql/*.sql を source of truth に、全DBグループ(ocreview/ranking/comment/userlog)へ
       # 不足テーブル・カラム・索引を「加算のみ」で冪等反映する (MySQL/MariaDB 両対応)。

--- a/app/Services/Cron/OcreviewApiDataImporter.php
+++ b/app/Services/Cron/OcreviewApiDataImporter.php
@@ -395,7 +395,8 @@ class OcreviewApiDataImporter
                         $this->sqlImporter->import($this->targetPdo, 'openchat_existing', $data, self::CHUNK_SIZE);
                     }
                 },
-                'openchat_existing: %d / %d 件処理完了'
+                // 毎時全件洗い替え（常に20万件超）のため進捗のDiscord通知はしない
+                null
             );
 
             $this->targetPdo->commit();

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -168,6 +168,14 @@ class SyncOpenChat
             ],
         );
 
+        // 日次クロール対象（変動・新規・週次更新の部屋）のページキャッシュを再生成する。
+        // ランキング外の部屋は毎時フックでは拾えないため、日次クロールと同じ対象を追従させる
+        // （週次更新部屋も含むため、全部屋のキャッシュが最長でも約1週間周期で更新される）。
+        $ocPageCachePath = AppConfig::ROOT_PATH . 'batch/exec/update_oc_page_cache.php';
+        $urlRootArg = escapeshellarg(MimimalCmsConfig::$urlRoot);
+        exec(PHP_BINARY . " {$ocPageCachePath} {$urlRootArg} daily >/dev/null 2>&1 &");
+        CronUtility::addVerboseCronLog('ページキャッシュ日次更新をバックグラウンドで開始');
+
         CronUtility::addCronLog('【日次処理】完了');
     }
 

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -118,6 +118,14 @@ class SyncOpenChat
             [fn() => $this->rankingBanUpdater->updateRankingBanTable(), 'ランキングBAN情報更新'],
         );
 
+        // ルーム個別ページの分析文/関連ルームキャッシュ(oc_page_cache)を毎時更新する。
+        // 直近1時間でメンバー数が変動したルームだけを対象にバックグラウンドで再生成
+        // （実行中のバックフィルがあればバッチ側でスキップされる）。
+        $ocPageCachePath = AppConfig::ROOT_PATH . 'batch/exec/update_oc_page_cache.php';
+        $urlRootArg = escapeshellarg(MimimalCmsConfig::$urlRoot);
+        exec(PHP_BINARY . " {$ocPageCachePath} {$urlRootArg} hourly >/dev/null 2>&1 &");
+        CronUtility::addVerboseCronLog('ページキャッシュ毎時更新をバックグラウンドで開始');
+
         // アーカイブ用DBインポート処理をバックグラウンドで実行（日本のみ）
         if (!MimimalCmsConfig::$urlRoot) {
             $path = AppConfig::ROOT_PATH . 'batch/exec/ocreview_api_data_import_background.php';

--- a/batch/exec/update_oc_page_cache.php
+++ b/batch/exec/update_oc_page_cache.php
@@ -3,10 +3,12 @@
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use App\Models\Repositories\OpenChatRepositoryInterface;
+use App\Models\Repositories\RankingPosition\RankingPositionHourRepositoryInterface;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Admin\AdminTool;
 use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
 use App\Services\Cron\Utility\CronUtility;
+use App\Services\OpenChat\Utility\OpenChatServicesUtility;
 use App\Services\StaticData\OcPageCacheGenerator;
 use ExceptionHandler\ExceptionHandler;
 use Shared\MimimalCmsConfig;
@@ -15,10 +17,12 @@ use Shared\MimimalCmsConfig;
  * ルーム個別ページの「分析文/関連ルーム」事前計算キャッシュ(oc_page_cache)を生成する。
  *
  * 使い方:
- *   php batch/exec/update_oc_page_cache.php <urlRoot> [idCsv]
- *     - <urlRoot>: '' | 'tw' | 'th'（保存先SQLite・HTMLの言語を決める）
- *     - [idCsv]  : 省略時は全ルーム(getOpenChatIdAll)をバックフィル。
- *                  カンマ区切りID指定時はそのルームだけ再生成（write-through用）。
+ *   php batch/exec/update_oc_page_cache.php <urlRoot> [hourly|idCsv]
+ *     - <urlRoot>: '' | '/tw' | '/th'（保存先SQLite・HTMLの言語を決める）
+ *     - hourly   : 毎時モード。直近1時間でメンバー数が変動した（またはランキングに
+ *                  新規掲載された）ルームだけ再生成する（SyncOpenChat毎時処理から起動）。
+ *     - idCsv    : カンマ区切りID指定時はそのルームだけ再生成（write-through用）。
+ *     - 省略時   : 全ルーム(getOpenChatIdAll)をバックフィル。
  *
  * 出力HTMLは url()/t() が urlRoot に依存するため、必ず対象言語の urlRoot を渡すこと。
  */
@@ -30,11 +34,22 @@ try {
         MimimalCmsConfig::$urlRoot = $argv[1];
     }
 
+    $mode = $argv[2] ?? '';
+
     /** @var SyncOpenChatStateRepositoryInterface $state */
     $state = app(SyncOpenChatStateRepositoryInterface::class);
 
-    // 既に実行中なら前回プロセスをkill（多重生成防止）
     if ($state->getBool(StateType::isUpdateOcPageCacheActive)) {
+        if ($mode === 'hourly') {
+            // 毎時モードは実行中（フルバックフィル等）をkillせず今回をスキップする。
+            // フラグも下ろしておく＝プロセス異常終了でフラグだけ残った場合に次回から自走再開できる
+            // （実行中プロセスが本当に居れば完走時/エラー時に自分でフラグを下ろすため矛盾しない）。
+            CronUtility::addCronLog('ページキャッシュ毎時更新: 実行中のためスキップ');
+            $state->setFalse(StateType::isUpdateOcPageCacheActive);
+            exit;
+        }
+
+        // バックフィル時は前回プロセスをkill（多重生成防止）
         $myPid = getmypid();
         $cmd = "ps aux | grep update_oc_page_cache.php | grep -v grep | grep -v '{$myPid}' | awk '{print \$2}' | xargs -r kill";
         exec($cmd);
@@ -45,9 +60,27 @@ try {
 
     $state->setTrue(StateType::isUpdateOcPageCacheActive);
 
-    // 対象ID: 引数指定があればそれ、無ければ全ルーム
-    if (isset($argv[2]) && $argv[2] !== '') {
-        $ids = array_values(array_filter(array_map('intval', explode(',', $argv[2])), fn($v) => $v > 0));
+    // 対象ID: hourly=直近1時間の変動ルーム / idCsv=指定ルーム / 省略=全ルーム
+    if ($mode === 'hourly') {
+        /** @var RankingPositionHourRepositoryInterface $hourRepo */
+        $hourRepo = app(RankingPositionHourRepositoryInterface::class);
+
+        $curTime = OpenChatServicesUtility::getModifiedCronTime('now');
+        $prevTime = (clone $curTime)->modify('-1 hour');
+
+        // 今時間と前時間のスナップショットをPHP側で突き合わせ、メンバー数が変動した
+        // ルームと前時間に存在しない（ランキング新規掲載）ルームだけを対象にする。
+        $prevMemberMap = array_column($hourRepo->getHourlyMemberColumn($prevTime), 'member', 'open_chat_id');
+
+        $ids = [];
+        foreach ($hourRepo->getHourlyMemberColumn($curTime) as $row) {
+            $id = (int)$row['open_chat_id'];
+            if (!isset($prevMemberMap[$id]) || (int)$prevMemberMap[$id] !== (int)$row['member']) {
+                $ids[] = $id;
+            }
+        }
+    } elseif ($mode !== '') {
+        $ids = array_values(array_filter(array_map('intval', explode(',', $mode)), fn($v) => $v > 0));
     } else {
         /** @var OpenChatRepositoryInterface $ocRepo */
         $ocRepo = app(OpenChatRepositoryInterface::class);

--- a/batch/exec/update_oc_page_cache.php
+++ b/batch/exec/update_oc_page_cache.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+use App\Models\Repositories\MemberChangeFilterCacheRepositoryInterface;
 use App\Models\Repositories\OpenChatRepositoryInterface;
 use App\Models\Repositories\RankingPosition\RankingPositionHourRepositoryInterface;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
@@ -17,10 +18,13 @@ use Shared\MimimalCmsConfig;
  * ルーム個別ページの「分析文/関連ルーム」事前計算キャッシュ(oc_page_cache)を生成する。
  *
  * 使い方:
- *   php batch/exec/update_oc_page_cache.php <urlRoot> [hourly|idCsv]
+ *   php batch/exec/update_oc_page_cache.php <urlRoot> [hourly|daily|idCsv]
  *     - <urlRoot>: '' | '/tw' | '/th'（保存先SQLite・HTMLの言語を決める）
  *     - hourly   : 毎時モード。直近1時間でメンバー数が変動した（またはランキングに
  *                  新規掲載された）ルームだけ再生成する（SyncOpenChat毎時処理から起動）。
+ *     - daily    : 日次モード。日次クロールと同じ対象（変動・新規・週次更新の部屋）を
+ *                  再生成する（SyncOpenChat日次処理から起動）。ランキング外の部屋は
+ *                  毎時モードでは拾えないため、これで最長でも週次周期で全部屋が更新される。
  *     - idCsv    : カンマ区切りID指定時はそのルームだけ再生成（write-through用）。
  *     - 省略時   : 全ルーム(getOpenChatIdAll)をバックフィル。
  *
@@ -40,11 +44,11 @@ try {
     $state = app(SyncOpenChatStateRepositoryInterface::class);
 
     if ($state->getBool(StateType::isUpdateOcPageCacheActive)) {
-        if ($mode === 'hourly') {
-            // 毎時モードは実行中（フルバックフィル等）をkillせず今回をスキップする。
+        if ($mode === 'hourly' || $mode === 'daily') {
+            // 毎時/日次モードは実行中（フルバックフィル等）をkillせず今回をスキップする。
             // フラグも下ろしておく＝プロセス異常終了でフラグだけ残った場合に次回から自走再開できる
             // （実行中プロセスが本当に居れば完走時/エラー時に自分でフラグを下ろすため矛盾しない）。
-            CronUtility::addCronLog('ページキャッシュ毎時更新: 実行中のためスキップ');
+            CronUtility::addCronLog("ページキャッシュ更新({$mode}): 実行中のためスキップ");
             $state->setFalse(StateType::isUpdateOcPageCacheActive);
             exit;
         }
@@ -60,8 +64,15 @@ try {
 
     $state->setTrue(StateType::isUpdateOcPageCacheActive);
 
-    // 対象ID: hourly=直近1時間の変動ルーム / idCsv=指定ルーム / 省略=全ルーム
-    if ($mode === 'hourly') {
+    // 対象ID: hourly=直近1時間の変動ルーム / daily=日次クロール対象 / idCsv=指定ルーム / 省略=全ルーム
+    if ($mode === 'daily') {
+        // 日次クロールが使ったフィルター（変動・新規・週次更新）と同じ対象を再生成する。
+        // 同一日付キーなら日次処理が保存した .dat キャッシュから読むだけで、
+        // 重い statistics クエリは再実行されない（ja は翌日23時まで同一日付になる）。
+        /** @var MemberChangeFilterCacheRepositoryInterface $filterRepo */
+        $filterRepo = app(MemberChangeFilterCacheRepositoryInterface::class);
+        $ids = $filterRepo->getForDaily(OpenChatServicesUtility::getCronModifiedStatsMemberDate());
+    } elseif ($mode === 'hourly') {
         /** @var RankingPositionHourRepositoryInterface $hourRepo */
         $hourRepo = app(RankingPositionHourRepositoryInterface::class);
 


### PR DESCRIPTION
- SyncOpenChat の毎時処理から update_oc_page_cache.php を hourly モードで
  バックグラウンド起動し、直近1時間でメンバー数が変動した（または
  ランキングに新規掲載された）ルームだけキャッシュを再生成する
- hourly モードは実行中のバックフィルを kill せずスキップする
- deploy.yml の SQLite 初期化に oc_page_cache.db を追加
  （stg側でリポジトリの自前 CREATE TABLE が削除されたため、本番反映前に必要）
- openchat_existing 同期（毎時20万件超の全件洗い替え）の進捗 Discord 通知を停止

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj