### PR TITLE
[PROD] perf: タグページの「テーマの勢い」集計を毎時1回の事前計算に変更しアクセス時の負荷を削減

### DIFF
--- a/app/Controllers/Pages/RecommendOpenChatPageController.php
+++ b/app/Controllers/Pages/RecommendOpenChatPageController.php
@@ -166,11 +166,13 @@ class RecommendOpenChatPageController
             $tag
         );
 
-        // テーマの勢い: rank/rising は ranking_position.db(ロケール別)、
-        // member(合計人数)は statistics.db(ロケール別)から集計。ja/tw/th 全ロケール対応。
-        // 集計窓の起点は現在時刻ではなく最終 cron 時刻($hourlyUpdatedAt)を渡す。クロール遅延や
+        // テーマの勢い: 毎時バッチが .dat 生成時に事前計算して DTO に同梱している
+        // (RecommendStaticDataGenerator::setThemeMomentum)。アクセスごとの SQLite 集計はしない。
+        // null は未計算（旧 .dat / per-tag 即時生成）の場合のみで、そのときだけライブ集計に
+        // フォールバックする（[] は計算済みデータ不足なので再計算しない）。
+        // 集計窓の起点は現在時刻ではなく最終 cron 時刻($hourlyUpdatedAt)。クロール遅延や
         // ローカルの古いデータでも窓が実データに乗るようにするため(時刻取得はこの利用元の責務)。
-        $growth = $this->recommendGrowthRepository->themeMomentum(
+        $growth = $recommend->themeMomentum ?? $this->recommendGrowthRepository->themeMomentum(
             array_column($recommend->getList(false, null), 'id'),
             $hourlyUpdatedAt
         );

--- a/app/Services/Recommend/Dto/RecommendListDto.php
+++ b/app/Services/Recommend/Dto/RecommendListDto.php
@@ -16,6 +16,14 @@ class RecommendListDto
     public ?array $shuffledMergedElements = null;
     public array $sortAndUniqueTags = [];
 
+    /**
+     * テーマの勢い(RecommendGrowthRepository::themeMomentum の結果)。毎時バッチの .dat 生成時に
+     * 事前計算して同梱し、/recommend ページのアクセスごとの SQLite 集計を無くす。
+     * null = 未計算（旧 .dat / per-tag 即時生成）→ ページ側がライブ計算にフォールバック。
+     * []   = 計算済みでデータ不足（フォールバック不要）。
+     */
+    public ?array $themeMomentum = null;
+
     /** @var array{ id:int,name:string,img_url:string,member:int,table_name:string,emblem:int } $list */
     function __construct(
         public RecommendListType $type,

--- a/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
+++ b/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
@@ -6,6 +6,7 @@ namespace App\Services\Recommend\StaticData;
 
 use App\Config\AppConfig;
 use App\Models\RecommendRepositories\BulkRankingDataRepositoryInterface;
+use App\Models\Repositories\Recommend\RecommendGrowthRepositoryInterface;
 use App\Models\RecommendRepositories\CategoryRankingRepository;
 use App\Models\RecommendRepositories\OfficialRoomRankingRepository;
 use App\Models\RecommendRepositories\RecommendRankingRepository;
@@ -32,6 +33,7 @@ class RecommendStaticDataGenerator
         private FileStorageInterface $fileStorage,
         private BulkRankingDataRepositoryInterface $bulkRankingDataRepository,
         private BulkRecommendRankingBuilderInterface $bulkRecommendRankingBuilder,
+        private RecommendGrowthRepositoryInterface $recommendGrowthRepository,
     ) {}
 
     // ============================================================
@@ -140,11 +142,34 @@ class RecommendStaticDataGenerator
     {
         foreach ($this->getAllTagNames() as $tag) {
             $fileName = hash('crc32', $tag);
+            $dto = $this->bulkRecommendRankingBuilder->buildTagRanking($tag, $tag);
+            $this->setThemeMomentum($dto);
             $this->fileStorage->saveSerializedFile(
                 $this->fileStorage->getStorageFilePath('recommendStaticDataDir') . "/{$fileName}.dat",
-                $this->bulkRecommendRankingBuilder->buildTagRanking($tag, $tag)
+                $dto
             );
         }
+    }
+
+    /**
+     * テーマの勢い(themeMomentum)を事前計算して DTO に同梱する。
+     *
+     * /recommend/{tag} がアクセスごとに ranking_position.db / statistics.db を集計していたのを、
+     * 毎時の .dat 生成時の1回に寄せる。対象はタグ .dat のみ（勢いを表示するのはタグページだけ）。
+     * 集計窓の起点・対象IDはページ側のライブ計算と同一
+     * (RecommendOpenChatPageController::index と揃えること)。
+     */
+    private function setThemeMomentum(RecommendListDto $dto): void
+    {
+        if (!$dto->getCount()) {
+            $dto->themeMomentum = [];
+            return;
+        }
+
+        $dto->themeMomentum = $this->recommendGrowthRepository->themeMomentum(
+            array_column($dto->getList(false, null), 'id'),
+            new \DateTime($dto->hourlyUpdatedAt)
+        );
     }
 
     private function updateCategoryStaticDataBulk(): void


### PR DESCRIPTION
stg の変更を本番リリースします（#393 のみ）。

## 含まれる変更

### #393 タグページの「テーマの勢い」を毎時1回の事前計算に

- /recommend/{tag} がアクセスのたびに行っていた SQLite 集計（全体ランキング順位の推移＋コホート合計人数、2クエリ×7日窓）を、毎時バッチのタグ .dat 生成時の1回に変更
- ページ側は同梱値を使用し、旧 .dat ・タグ新設時の即時生成のときだけ従来のライブ集計にフォールバック（表示内容は不変）
- bot クロールを含むタグページのアクセスごとの集計負荷がゼロに

## デプロイ後の確認

- 次の毎時静的データ生成から有効（それまでの最大1時間は従来どおりライブ集計）
- 毎時バッチにタグ数ぶんの軽い集計が追加されるため、所要時間を一度確認推奨

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj

---
_Generated by [Claude Code](https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj)_