### PR TITLE
[PROD] skip-post: コントローラ内部設計の整理（DI統一・フォールバック層の移動、挙動変更なし）

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -10,7 +10,6 @@ use App\Models\RecommendRepositories\RecommendRankingRepository;
 use App\Models\Repositories\OpenChatPageRepositoryInterface;
 use App\Models\SQLite\Repositories\OcPageCacheRepository;
 use App\Services\OpenChatAdmin\AdminOpenChat;
-use App\Services\Recommend\Dto\RecommendListDto;
 use App\Services\Recommend\OfficialPageList;
 use App\Services\Recommend\RecommendGenarator;
 use App\Services\Recommend\SimilarSizeRoomService;
@@ -42,6 +41,7 @@ class OpenChatPageController
         CollapseKeywordEnumerationsInterface $collapseKeywordEnumerations,
         FileStorageInterface $fileStorage,
         OcPageCacheRepository $ocPageCacheRepository,
+        OfficialPageList $officialPageList,
         int $open_chat_id,
         ?string $isAdminPage,
     ) {
@@ -142,7 +142,7 @@ class OpenChatPageController
             'openChatName' => $oc['name'],
         ];
 
-        $officialDto = ($oc['emblem'] ?? 0) > 0 ? $this->buildOfficialDto($oc['emblem']) : null;
+        $officialDto = ($oc['emblem'] ?? 0) > 0 ? $officialPageList->getListDto($oc['emblem']) : null;
 
         $formatedRowDescription = trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $oc['description']));
 
@@ -196,13 +196,6 @@ class OpenChatPageController
         /** @var AdminOpenChat $admin */
         $admin = app(AdminOpenChat::class);
         return $admin->getDto($open_chat_id);
-    }
-
-    private function buildOfficialDto(int $emblem): RecommendListDto
-    {
-        /** @var OfficialPageList $officialPageList */
-        $officialPageList = app(OfficialPageList::class);
-        return $officialPageList->getListDto($emblem);
     }
 
     /**

--- a/app/Controllers/Pages/RecommendOpenChatPageController.php
+++ b/app/Controllers/Pages/RecommendOpenChatPageController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Controllers\Pages;
 
 use App\Config\AppConfig;
-use App\Models\Repositories\Recommend\RecommendGrowthRepositoryInterface;
 use App\Services\Recommend\RecommendPageList;
+use App\Services\Recommend\ThemeDiscoveryService;
 use App\Services\Recommend\TagDefinition\Ja\RecommendTagDescription;
 use App\Services\Recommend\TagDefinition\Ja\RecommendTagFilters;
 use App\Services\Recommend\TagDefinition\Ja\RecommendUtility;
@@ -19,7 +19,6 @@ class RecommendOpenChatPageController
 {
     function __construct(
         private PageBreadcrumbsListSchema $breadcrumbsShema,
-        private RecommendGrowthRepositoryInterface $recommendGrowthRepository,
     ) {}
 
     /**
@@ -50,6 +49,7 @@ class RecommendOpenChatPageController
     function index(
         RecommendPageList $recommendPageList,
         StaticDataFile $staticDataGeneration,
+        ThemeDiscoveryService $themeDiscoveryService,
         string $tag
     ) {
         AppConfig::$listLimitTopRanking = 5;
@@ -121,7 +121,7 @@ class RecommendOpenChatPageController
 
         // テーマ発見セクション（/recommend 着地客の回遊導線）。表示ロジックは Service が確定し DTO を返す。
         // View へは `_discovery` で渡し、フレームワークの自動エスケープを通さない（View 側で明示エスケープ）。
-        $_discovery = app(\App\Services\Recommend\ThemeDiscoveryService::class)
+        $_discovery = $themeDiscoveryService
             ->build(
                 $staticDataGeneration->getTagList(),
                 $tag,
@@ -166,16 +166,10 @@ class RecommendOpenChatPageController
             $tag
         );
 
-        // テーマの勢い: 毎時バッチが .dat 生成時に事前計算して DTO に同梱している
-        // (RecommendStaticDataGenerator::setThemeMomentum)。アクセスごとの SQLite 集計はしない。
-        // null は未計算（旧 .dat / per-tag 即時生成）の場合のみで、そのときだけライブ集計に
-        // フォールバックする（[] は計算済みデータ不足なので再計算しない）。
-        // 集計窓の起点は現在時刻ではなく最終 cron 時刻($hourlyUpdatedAt)。クロール遅延や
-        // ローカルの古いデータでも窓が実データに乗るようにするため(時刻取得はこの利用元の責務)。
-        $growth = $recommend->themeMomentum ?? $this->recommendGrowthRepository->themeMomentum(
-            array_column($recommend->getList(false, null), 'id'),
-            $hourlyUpdatedAt
-        );
+        // テーマの勢い: 毎時バッチが .dat 生成時に事前計算して DTO に同梱している。
+        // .dat が無い場合のライブ集計フォールバックも静的データ層(getRecomendRanking)が保証する
+        // ため、コントローラでは同梱値を使うだけ（アクセスごとの SQLite 集計はしない）。
+        $growth = $recommend->themeMomentum ?? [];
 
         return view('recommend_content', compact(
             '_meta',

--- a/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
+++ b/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
@@ -42,7 +42,7 @@ class RecommendStaticDataGenerator
 
     function getRecomendRanking(string $tag): RecommendListDto
     {
-        return $this->fromFileOrDb(
+        $dto = $this->fromFileOrDb(
             'recommendStaticDataDir',
             hash('crc32', $tag),
             fn() => app(RecommendRankingBuilder::class)->getRanking(
@@ -52,6 +52,16 @@ class RecommendStaticDataGenerator
                 app(RecommendRankingRepository::class)
             )
         );
+
+        // テーマの勢いは毎時バッチが .dat に同梱する。null（新規タグの即時生成・旧 .dat）の場合も
+        // この層でライブ集計して埋め、呼び出し側へ null を漏らさない。
+        // 「静的データが無ければその場で生成してフォールバックする」のは静的データ層の責務
+        // （リスト本体の fromFileOrDb と同じ考え方）で、コントローラには持ち込まない。
+        if ($dto->themeMomentum === null) {
+            $this->setThemeMomentum($dto);
+        }
+
+        return $dto;
     }
 
     function getCategoryRanking(int $category): RecommendListDto


### PR DESCRIPTION
stg の変更を本番リリースします（#396 のみ・内部リファクタリング）。

## 含まれる変更

### #396 コントローラ設計の整理（挙動の変化なし）

- コントローラ内で `app()` によるその場インスタンス化をしていた箇所（テーマ発見セクション・公式ルーム一覧）を DI に統一
- 「テーマの勢い」データのフォールバック処理をコントローラから静的データ層へ移動し、コントローラから DB アクセス層への依存を完全に除去

表示・挙動は一切変わりません。

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj

---
_Generated by [Claude Code](https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj)_