### PR TITLE
[STG] fix: クローラー集中時の統計データ読み取りエラーを接続使い回し＋リトライ改善で抑止

### DIFF
--- a/app/Models/Repositories/AllRoomStatsRepository.php
+++ b/app/Models/Repositories/AllRoomStatsRepository.php
@@ -127,7 +127,6 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
             ['today' => $today, 'today2' => $today, 'modifier' => $modifier]
         );
 
-        SQLiteOcgraphSqlapi::$pdo = null;
 
         return [
             'increased' => (int) ($existing['increased'] ?? 0),
@@ -169,7 +168,6 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
             ['today' => $today, 'modifier' => $modifier, 'today2' => $today, 'past_date' => $pastDate]
         )->fetch(\PDO::FETCH_ASSOC);
 
-        SQLiteOcgraphSqlapi::$pdo = null;
 
         return [
             'closed_rooms' => (int) ($result['closed_rooms'] ?? 0),
@@ -282,7 +280,6 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
             ['today' => $today, 'today2' => $today, 'today3' => $today, 'today4' => $today]
         );
 
-        SQLiteOcgraphSqlapi::$pdo = null;
 
         // トレンドをカテゴリーIDでインデックス
         $trendByCategory = [];

--- a/app/Models/Repositories/OcNarrativeRepository.php
+++ b/app/Models/Repositories/OcNarrativeRepository.php
@@ -64,7 +64,6 @@ class OcNarrativeRepository implements OcNarrativeRepositoryInterface
         try {
             SQLiteOcgraphSqlapi::connect(['mode' => '?mode=ro']);
             $row = SQLiteOcgraphSqlapi::fetch($query, ['id' => $openChatId]);
-            SQLiteOcgraphSqlapi::$pdo = null;
         } catch (\Throwable $e) {
             return ['hour' => null, 'day' => null, 'week' => null];
         }

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -12,8 +12,22 @@ abstract class AbstractSQLite extends DB implements DBInterface
 {
     public static ?\PDO $pdo = null;
 
-    private const MAX_RETRIES = 5;
-    private const RETRY_WAIT_MICROSECONDS = 100000; // 0.1 seconds
+    /**
+     * リトライ設計（クローラー殺到時の WAL 読み取り競合対策）:
+     *
+     * 「locking protocol」(SQLITE_PROTOCOL) は busy_timeout が効かない。WAL の読み取りマーク
+     * スロットは最大5個しかなく、読み側がクエリごとに接続を開き直す本アプリの構造上、
+     * アクセス集中時はスロット争奪のリトライ上限超過でこのエラーが出る。
+     * 一過性の輻輳なので、指数バックオフ＋ジッターで待てばほぼ確実に抜けられる。
+     *
+     * - 固定間隔だと全 php-fpm ワーカーが同周期で再衝突する（リトライハード）ため、
+     *   ±50% のジッターで分散させる
+     * - 最大待機合計は約2.4秒（+ジッター）に制限。殺到時にワーカーを長時間塞ぐと
+     *   fpm プール枯渇で別の障害になるため、無制限には待たない
+     */
+    private const MAX_RETRIES = 7;
+    private const RETRY_BASE_WAIT_MICROSECONDS = 50000;   // 初回 0.05 秒
+    private const RETRY_MAX_WAIT_MICROSECONDS = 800000;   // 1回あたり上限 0.8 秒
     private const RETRYABLE_ERRORS = [
         'database disk image is malformed',
         'database is locked',
@@ -80,7 +94,12 @@ abstract class AbstractSQLite extends DB implements DBInterface
                 $attempts++;
 
                 if ($attempts < self::MAX_RETRIES) {
-                    usleep(self::RETRY_WAIT_MICROSECONDS);
+                    $wait = min(
+                        self::RETRY_BASE_WAIT_MICROSECONDS * (2 ** ($attempts - 1)),
+                        self::RETRY_MAX_WAIT_MICROSECONDS
+                    );
+                    // ±50% ジッター（同時リトライの再衝突を分散）
+                    usleep(random_int((int)($wait / 2), (int)($wait * 1.5)));
                 }
             }
         }

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -38,10 +38,24 @@ abstract class AbstractSQLite extends DB implements DBInterface
     /**
      * @param ?array{storageFileKey: string, mode?: ?string} $config mode default is '?mode=rwc'
      */
+    /** @var array<class-string, string> 接続中のモード（接続使い回し判定用） */
+    private static array $connectedMode = [];
+
     public static function connect(?array $config = null): \PDO
     {
+        $mode = $config['mode'] ?? '?mode=rwc';
+
         if (static::$pdo !== null) {
-            return static::$pdo;
+            // 同一モードなら使い回す。WALの読み取りスナップショット取得や私的wal-index再構築は
+            // 接続のたびに発生するため、クエリごとの開き直しはアクセス集中時の
+            // 「locking protocol」の温床になる（リクエスト内では1接続を維持する）。
+            // モードが変わるときだけ張り直す（ro読み→rwc書きの取り違え防止。
+            // 以前は connect がモード指定を無視したため、各リポジトリが毎回
+            // `::$pdo = null` で切断するしかなかった——その明示切断は全廃済み）。
+            if ((self::$connectedMode[static::class] ?? null) === $mode) {
+                return static::$pdo;
+            }
+            static::$pdo = null;
         }
 
         if (empty($config['storageFileKey'])) {
@@ -49,9 +63,9 @@ abstract class AbstractSQLite extends DB implements DBInterface
         }
 
         $sqliteFilePath = app(FileStorageInterface::class)->getStorageFilePath($config['storageFileKey']);
-        $mode = $config['mode'] ?? '?mode=rwc';
 
         static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode);
+        self::$connectedMode[static::class] = $mode;
 
         // Set busy timeout for all modes (including read-only) to handle concurrent access
         static::$pdo->exec('PRAGMA busy_timeout=10000');

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
@@ -41,7 +41,6 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
 
         SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
         $result = SQLiteRankingPositionOhlc::fetchAll($query, ['open_chat_id' => $open_chat_id, 'category' => $category, 'type' => $typeValue]);
-        SQLiteRankingPositionOhlc::$pdo = null;
 
         return $result;
     }
@@ -76,7 +75,6 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
             'type' => $typeValue,
             'since' => $since,
         ]);
-        SQLiteRankingPositionOhlc::$pdo = null;
 
         if (!$row || !is_array($row)) {
             return [
@@ -121,7 +119,6 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
             'type' => $typeValue,
             'since' => $since,
         ]);
-        SQLiteRankingPositionOhlc::$pdo = null;
 
         if (!$row || !is_array($row) || (int)($row['sample_n'] ?? 0) === 0) {
             return ['avg_position' => null, 'sample_n' => 0];

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
@@ -43,7 +43,6 @@ class SqliteRankingPositionPageRepository implements RankingPositionPageReposito
 
         $result = SQLiteRankingPosition::fetchAll($query, compact('open_chat_id', 'category'));
 
-        SQLiteRankingPosition::$pdo = null;
 
         if (!$result) {
             return $dto;

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
@@ -99,7 +99,6 @@ class SqliteRankingPositionRepository implements RankingPositionRepositoryInterf
             ];
         }
 
-        SQLiteRankingPosition::$pdo = null;
 
         return $result;
     }

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
@@ -36,7 +36,6 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
 
         SQLiteStatisticsOhlc::connect(['mode' => '?mode=ro']);
         $result = SQLiteStatisticsOhlc::fetchAll($query, compact('open_chat_id'));
-        SQLiteStatisticsOhlc::$pdo = null;
 
         return $result;
     }
@@ -67,7 +66,6 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
             'week_start_date' => $weekStartDate,
             'month_start_date' => $monthStartDate,
         ]);
-        SQLiteStatisticsOhlc::$pdo = null;
 
         if (!is_array($result)) {
             return $emptyResult;

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
@@ -24,7 +24,6 @@ class SqliteStatisticsPageRepository implements StatisticsPageRepositoryInterfac
 
         SQLiteStatistics::connect(['mode' => '?mode=ro']);
         $result = SQLiteStatistics::fetchAll($query, compact('open_chat_id'));
-        SQLiteStatistics::$pdo = null;
 
         return $result;
     }

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
@@ -180,7 +180,6 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
 
         SQLiteStatistics::connect(['mode' => '?mode=ro']);
         $row = SQLiteStatistics::fetch($query, $params);
-        SQLiteStatistics::$pdo = null;
 
         $empty = [
             'curr' => null, 'curr_date' => null,


### PR DESCRIPTION
## 問題の概要

海外からのクローラーが殺到すると、Googlebot を含む通常アクセスでも統計チャートAPI（/oc/{id}/stats）が
`SQLSTATE[HY000]: General error: 15 locking protocol` で 500 エラーになることがある。

### 原因（実験で確認済み）

- 各リポジトリが**読み取りクエリのたびに接続を開いて `::$pdo = null` で明示切断**していた。WAL の読み取りスナップショット取得や（-shm が使えない場合の）私的 wal-index 再構築は接続のたびに発生するため、この開閉チャーンがアクセス集中時の `SQLITE_PROTOCOL` の温床
- 明示切断していた理由は `connect()` が既存接続のモード指定を無視するため、ro 読み→rwc 書きのバッチで取り違えが起きないよう毎回捨てるしかなかったから
- このエラーには `busy_timeout`（設定済み10秒）が効かず、既存リトライは固定100ms×5回のため全 php-fpm ワーカーが同周期で再衝突していた

### 過去の経緯（#367/#368 → #369 で revert）

読み取りを `mode=rw` にする修正は過去に試行され、本番でエラーが増えて revert 済み。今回の実験で理由を特定:
**rw 接続は（`PRAGMA query_only=ON` や `wal_autocheckpoint=0` を付けても）最後の接続として閉じる際に
チェックポイント（書き込み）を実行し -wal を削除する**。クエリごとに開閉する構造では rw リーダーが大量の
チェックポイント実行者と化し、書き込み競合を逆に増やす。→ **読み取りは ro のままが正しい**
（ro はクローズ時チェックポイントを一切しない・-shm 欠損でも読めることも実験で確認）。

## 対処内容（2点・いずれも検証済み）

### 1. 接続のモード対応使い回し（[`AbstractSQLite::connect()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/sqlite-read-retry-hardening/app/Models/SQLite/AbstractSQLite.php)）

- 同一モードなら接続を使い回し、モード変更時だけ張り直す
- これによりリポジトリ側の明示切断13箇所を全廃（statistics / ohlc / ranking_position / ocgraph_sqlapi 系）
- リクエスト/バッチ内で1接続を維持。接続回数は旧実装比で厳密に同等以下
- 検証: 同モード再利用・モード切替時の張り直し・サブクラス間の接続独立・ro の書き込み拒否を実SQLiteで確認

### 2. リトライの指数バックオフ＋ジッター化（`AbstractSQLite::execute()`）

- 最大7回、待機 50ms→100→200→400→800→800ms（合計約2.4秒）、各待機±50%ジッター
- 同時リトライの再衝突（リトライハード）を分散。待機上限を絞り fpm プール枯渇を防止

接続モードは変更しない（ro 維持）。

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj