### PR TITLE
[STG] fix: ルームページの分析に表示されるブログ記事リンクが壊れている問題を修正

### DIFF
--- a/shared/MimimalCMS_Settings.php
+++ b/shared/MimimalCMS_Settings.php
@@ -25,6 +25,14 @@ date_default_timezone_set('Asia/Tokyo');
 
 $httpHost = 'openchat-review.me';
 
+// CLI(cron・バッチ)には HTTP_HOST が無く、url() 等のURLヘルパーが「http:///path」という
+// 不正な絶対URLを生成してしまう（oc_page_cache の事前レンダリングHTMLに混入し、
+// ルームページの分析ブログリンクが壊れていた）。本番ホストで補完する。
+if (PHP_SAPI === 'cli' && !isset($_SERVER['HTTP_HOST'])) {
+    $_SERVER['HTTP_HOST'] = $httpHost;
+    $_SERVER['HTTPS'] = 'on';
+}
+
 if (
     ($_SERVER['HTTP_HOST'] ?? '') === $httpHost
     || ($_SERVER['HTTPS'] ?? '') === 'on'


### PR DESCRIPTION
## 問題

ルームページの「オプチャグラフの分析」内のブログ記事リンクが `http:///blog/...`（ホスト空）という不正URLになっている（例: /oc/438752）。

## 原因

分析文HTMLは CLI バッチ（毎時フック・バックフィル）で事前レンダリングされるが、CLI には `$_SERVER['HTTP_HOST']` が無く、`url()` ヘルパー（`getDomainAndHttpHost()`）が空ホストの絶対URLを生成していた。

## 対処

`shared/MimimalCMS_Settings.php`（composer autoload の files で全エントリポイントが必ず通る）で、CLI 実行時かつ HTTP_HOST 未設定のときに本番ホストで補完する。

## デプロイ後の作業（重要）

既にキャッシュ済みの分析文HTMLには不正リンクが残っているため、**バックフィルの再実行が必要**:
`/admin/genocpagecache/ja`（→ tw / th も実行済みであれば同様に）。毎時フックは変動ルームのみ自動修復する。

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj

---
_Generated by [Claude Code](https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj)_