### PR TITLE
[PROD] fix: アクセス集中時に統計グラフの表示が失敗するエラーを解消（SQLite接続の改善）

### DIFF
--- a/app/Models/Repositories/AllRoomStatsRepository.php
+++ b/app/Models/Repositories/AllRoomStatsRepository.php
@@ -127,7 +127,6 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
             ['today' => $today, 'today2' => $today, 'modifier' => $modifier]
         );
 
-        SQLiteOcgraphSqlapi::$pdo = null;
 
         return [
             'increased' => (int) ($existing['increased'] ?? 0),
@@ -169,7 +168,6 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
             ['today' => $today, 'modifier' => $modifier, 'today2' => $today, 'past_date' => $pastDate]
         )->fetch(\PDO::FETCH_ASSOC);
 
-        SQLiteOcgraphSqlapi::$pdo = null;
 
         return [
             'closed_rooms' => (int) ($result['closed_rooms'] ?? 0),
@@ -282,7 +280,6 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
             ['today' => $today, 'today2' => $today, 'today3' => $today, 'today4' => $today]
         );
 
-        SQLiteOcgraphSqlapi::$pdo = null;
 
         // トレンドをカテゴリーIDでインデックス
         $trendByCategory = [];

--- a/app/Models/Repositories/OcNarrativeRepository.php
+++ b/app/Models/Repositories/OcNarrativeRepository.php
@@ -64,7 +64,6 @@ class OcNarrativeRepository implements OcNarrativeRepositoryInterface
         try {
             SQLiteOcgraphSqlapi::connect(['mode' => '?mode=ro']);
             $row = SQLiteOcgraphSqlapi::fetch($query, ['id' => $openChatId]);
-            SQLiteOcgraphSqlapi::$pdo = null;
         } catch (\Throwable $e) {
             return ['hour' => null, 'day' => null, 'week' => null];
         }

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -12,8 +12,22 @@ abstract class AbstractSQLite extends DB implements DBInterface
 {
     public static ?\PDO $pdo = null;
 
-    private const MAX_RETRIES = 5;
-    private const RETRY_WAIT_MICROSECONDS = 100000; // 0.1 seconds
+    /**
+     * リトライ設計（クローラー殺到時の WAL 読み取り競合対策）:
+     *
+     * 「locking protocol」(SQLITE_PROTOCOL) は busy_timeout が効かない。WAL の読み取りマーク
+     * スロットは最大5個しかなく、読み側がクエリごとに接続を開き直す本アプリの構造上、
+     * アクセス集中時はスロット争奪のリトライ上限超過でこのエラーが出る。
+     * 一過性の輻輳なので、指数バックオフ＋ジッターで待てばほぼ確実に抜けられる。
+     *
+     * - 固定間隔だと全 php-fpm ワーカーが同周期で再衝突する（リトライハード）ため、
+     *   ±50% のジッターで分散させる
+     * - 最大待機合計は約2.4秒（+ジッター）に制限。殺到時にワーカーを長時間塞ぐと
+     *   fpm プール枯渇で別の障害になるため、無制限には待たない
+     */
+    private const MAX_RETRIES = 7;
+    private const RETRY_BASE_WAIT_MICROSECONDS = 50000;   // 初回 0.05 秒
+    private const RETRY_MAX_WAIT_MICROSECONDS = 800000;   // 1回あたり上限 0.8 秒
     private const RETRYABLE_ERRORS = [
         'database disk image is malformed',
         'database is locked',
@@ -80,7 +94,12 @@ abstract class AbstractSQLite extends DB implements DBInterface
                 $attempts++;
 
                 if ($attempts < self::MAX_RETRIES) {
-                    usleep(self::RETRY_WAIT_MICROSECONDS);
+                    $wait = min(
+                        self::RETRY_BASE_WAIT_MICROSECONDS * (2 ** ($attempts - 1)),
+                        self::RETRY_MAX_WAIT_MICROSECONDS
+                    );
+                    // ±50% ジッター（同時リトライの再衝突を分散）
+                    usleep(random_int((int)($wait / 2), (int)($wait * 1.5)));
                 }
             }
         }

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -38,10 +38,24 @@ abstract class AbstractSQLite extends DB implements DBInterface
     /**
      * @param ?array{storageFileKey: string, mode?: ?string} $config mode default is '?mode=rwc'
      */
+    /** @var array<class-string, string> 接続中のモード（接続使い回し判定用） */
+    private static array $connectedMode = [];
+
     public static function connect(?array $config = null): \PDO
     {
+        $mode = $config['mode'] ?? '?mode=rwc';
+
         if (static::$pdo !== null) {
-            return static::$pdo;
+            // 同一モードなら使い回す。WALの読み取りスナップショット取得や私的wal-index再構築は
+            // 接続のたびに発生するため、クエリごとの開き直しはアクセス集中時の
+            // 「locking protocol」の温床になる（リクエスト内では1接続を維持する）。
+            // モードが変わるときだけ張り直す（ro読み→rwc書きの取り違え防止。
+            // 以前は connect がモード指定を無視したため、各リポジトリが毎回
+            // `::$pdo = null` で切断するしかなかった——その明示切断は全廃済み）。
+            if ((self::$connectedMode[static::class] ?? null) === $mode) {
+                return static::$pdo;
+            }
+            static::$pdo = null;
         }
 
         if (empty($config['storageFileKey'])) {
@@ -49,9 +63,9 @@ abstract class AbstractSQLite extends DB implements DBInterface
         }
 
         $sqliteFilePath = app(FileStorageInterface::class)->getStorageFilePath($config['storageFileKey']);
-        $mode = $config['mode'] ?? '?mode=rwc';
 
         static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode);
+        self::$connectedMode[static::class] = $mode;
 
         // Set busy timeout for all modes (including read-only) to handle concurrent access
         static::$pdo->exec('PRAGMA busy_timeout=10000');

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
@@ -41,7 +41,6 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
 
         SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
         $result = SQLiteRankingPositionOhlc::fetchAll($query, ['open_chat_id' => $open_chat_id, 'category' => $category, 'type' => $typeValue]);
-        SQLiteRankingPositionOhlc::$pdo = null;
 
         return $result;
     }
@@ -76,7 +75,6 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
             'type' => $typeValue,
             'since' => $since,
         ]);
-        SQLiteRankingPositionOhlc::$pdo = null;
 
         if (!$row || !is_array($row)) {
             return [
@@ -121,7 +119,6 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
             'type' => $typeValue,
             'since' => $since,
         ]);
-        SQLiteRankingPositionOhlc::$pdo = null;
 
         if (!$row || !is_array($row) || (int)($row['sample_n'] ?? 0) === 0) {
             return ['avg_position' => null, 'sample_n' => 0];

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
@@ -43,7 +43,6 @@ class SqliteRankingPositionPageRepository implements RankingPositionPageReposito
 
         $result = SQLiteRankingPosition::fetchAll($query, compact('open_chat_id', 'category'));
 
-        SQLiteRankingPosition::$pdo = null;
 
         if (!$result) {
             return $dto;

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
@@ -99,7 +99,6 @@ class SqliteRankingPositionRepository implements RankingPositionRepositoryInterf
             ];
         }
 
-        SQLiteRankingPosition::$pdo = null;
 
         return $result;
     }

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
@@ -36,7 +36,6 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
 
         SQLiteStatisticsOhlc::connect(['mode' => '?mode=ro']);
         $result = SQLiteStatisticsOhlc::fetchAll($query, compact('open_chat_id'));
-        SQLiteStatisticsOhlc::$pdo = null;
 
         return $result;
     }
@@ -67,7 +66,6 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
             'week_start_date' => $weekStartDate,
             'month_start_date' => $monthStartDate,
         ]);
-        SQLiteStatisticsOhlc::$pdo = null;
 
         if (!is_array($result)) {
             return $emptyResult;

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
@@ -24,7 +24,6 @@ class SqliteStatisticsPageRepository implements StatisticsPageRepositoryInterfac
 
         SQLiteStatistics::connect(['mode' => '?mode=ro']);
         $result = SQLiteStatistics::fetchAll($query, compact('open_chat_id'));
-        SQLiteStatistics::$pdo = null;
 
         return $result;
     }

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
@@ -180,7 +180,6 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
 
         SQLiteStatistics::connect(['mode' => '?mode=ro']);
         $row = SQLiteStatistics::fetch($query, $params);
-        SQLiteStatistics::$pdo = null;
 
         $empty = [
             'curr' => null, 'curr_date' => null,


### PR DESCRIPTION
緊急リリース: クローラー集中時に SQLite 読み取りが `locking protocol` エラーで多発している問題への対処（#398）。

- SQLite接続をモード対応の使い回しに変更し、クエリごとの接続開き直し（エラーの温床）を全廃
- リトライを指数バックオフ＋ジッター化（同周期再衝突の解消）
- 読み取りモードは ro のまま（過去に revert された rw 化はしない。理由は #398 に記録）

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj

---
_Generated by [Claude Code](https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj)_