### PR TITLE
[PROD] skip-ci: ルームページの分析に表示されるブログ記事リンクが壊れている問題を修正

### DIFF
--- a/shared/MimimalCMS_Settings.php
+++ b/shared/MimimalCMS_Settings.php
@@ -25,6 +25,14 @@ date_default_timezone_set('Asia/Tokyo');
 
 $httpHost = 'openchat-review.me';
 
+// CLI(cron・バッチ)には HTTP_HOST が無く、url() 等のURLヘルパーが「http:///path」という
+// 不正な絶対URLを生成してしまう（oc_page_cache の事前レンダリングHTMLに混入し、
+// ルームページの分析ブログリンクが壊れていた）。本番ホストで補完する。
+if (PHP_SAPI === 'cli' && !isset($_SERVER['HTTP_HOST'])) {
+    $_SERVER['HTTP_HOST'] = $httpHost;
+    $_SERVER['HTTPS'] = 'on';
+}
+
 if (
     ($_SERVER['HTTP_HOST'] ?? '') === $httpHost
     || ($_SERVER['HTTPS'] ?? '') === 'on'


### PR DESCRIPTION
緊急リリース2本目: ルームページの分析に表示されるブログ記事リンクが `http:///blog/...`（ホスト空）になっている問題の修正（#400）。

CLI バッチで事前レンダリングする分析文HTMLで、HTTP_HOST 不在により url() が不正な絶対URLを生成していた。CLI 時は本番ホストで補完する。

**デプロイ後にバックフィル再実行が必要**（キャッシュ済みHTMLの不正リンクを直すため）: /admin/genocpagecache/ja → tw / th

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj

---
_Generated by [Claude Code](https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj)_