### PR TITLE
[PROD] skip-post: 分析キャッシュをデータ保存に変更しレンダリングをリクエスト時に統一

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,11 @@ jobs:
         run: |
           ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do for name in statistics_ohlc ranking_position_ohlc oc_page_cache; do db="storage/$lang/SQLite/$name/$name.db"; if [ ! -f "$db" ]; then sqlite3 "$db" < "setup/schema/sqlite/$name.sql" && echo "Created: $db"; fi; done; done'
 
+      # 既存DBへの追加カラム反映（MySQLの加算スキーマ同期と同じ思想・冪等。カラムが既にあれば何もしない）
+      - name: Sync SQLite schema (additive, idempotent)
+        run: |
+          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do db="storage/$lang/SQLite/oc_page_cache/oc_page_cache.db"; if [ -f "$db" ]; then sqlite3 "$db" "ALTER TABLE oc_page_cache ADD COLUMN narrative_data TEXT" 2>/dev/null && echo "Added narrative_data: $db" || true; fi; done'
+
       # setup/schema/mysql/*.sql を source of truth に、全DBグループ(ocreview/ranking/comment/userlog)へ
       # 不足テーブル・カラム・索引を「加算のみ」で冪等反映する (MySQL/MariaDB 両対応)。
       # DROP/MODIFY は一切しない。DB名・接続情報はサーバの local-secrets.php が解決するため env 不要。

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -74,16 +74,18 @@ class OpenChatPageController
 
         }
 
-        // 分析文(narrative)は事前計算済みHTML断片を oc_page_cache(SQLite) からPK一発で読むだけ。
+        // 分析(narrative)は事前計算済み「データ」(JSON)を oc_page_cache(SQLite) からPK一発で読み、
+        // レンダリングはリクエスト時に oc_narrative_section テンプレートが行う。
         // 未生成（バックフィル前/生成不可）は null → 空表示。bot が叩く /oc 本体で重い計算をしない。
         $ocPageCache = $ocPageCacheRepository->get($open_chat_id);
-        $_narrativeHtml = $ocPageCache['narrative_html'] ?? '';
-
-        // 応急修復: 過去にCLIで生成されたキャッシュにはホスト欠落URL(href="http:///...")が
-        // 残っている(HTTP_HOST不在時のurl()の不具合・生成側は修正済み)。バックフィルで
-        // 再生成されるまでの間、表示時にルート相対URLへ置換して直す（正常なHTMLには無害）。
-        if ($_narrativeHtml !== '') {
-            $_narrativeHtml = str_replace('"http:///', '"/', $_narrativeHtml);
+        $_narrative = null;
+        $_narrativeLegacyHtml = '';
+        if (!empty($ocPageCache['narrative_data'])) {
+            $_narrative = json_decode($ocPageCache['narrative_data'], true) ?: null;
+        } elseif (!empty($ocPageCache['narrative_html'])) {
+            // 旧形式（事前レンダリングHTML）の行。バックフィル/毎時フックで narrative_data に
+            // 置き換わるまでの移行期のみ。ホスト欠落URL(http:///)の応急修復も移行期間中は維持する。
+            $_narrativeLegacyHtml = str_replace('"http:///', '"/', $ocPageCache['narrative_html']);
         }
 
         // 関連ルームは recommend 静的キャッシュ(.dat / 母集団300件)から都度組み立てる。
@@ -123,7 +125,7 @@ class OpenChatPageController
         $collapsedDescription = $collapseKeywordEnumerations->collapse($oc['description'], extraText: $oc['name']);
         $formatedDescription = trim(preg_replace("/(\r\n){3,}|\r{3,}|\n{3,}/", "\n\n", $collapsedDescription));
 
-        // 分析文(narrative)は oc_page_cache から読み済み（$_narrativeHtml）。関連ルームは上で組み立て済み。
+        // 分析(narrative)データは oc_page_cache から読み済み（$_narrative）。関連ルームは上で組み立て済み。
         // meta への narrative 連携は無し(null)＝#372以降の現行挙動を踏襲（meta description は room description ベース）。
         $_meta = $meta->generateMetadata($open_chat_id, [...$oc, 'description' => $formatedDescription], null)->setImageUrl(imgUrl($oc['img_url']));
         $_meta->thumbnail = imgPreviewUrl($oc['img_url']);
@@ -162,7 +164,8 @@ class OpenChatPageController
             '_commentArgDto',
             '_breadcrumbsShema',
             '_schema',
-            '_narrativeHtml',
+            '_narrative',
+            '_narrativeLegacyHtml',
             '_recommend',
             '_similarSize',
             '_hourlyRange',

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -7,26 +7,32 @@ namespace App\Models\SQLite\Repositories;
 use App\Models\SQLite\SQLiteOcPageCache;
 
 /**
- * ルーム個別ページの事前計算HTML断片（分析文・関連ルーム）の読み書き。
+ * ルーム個別ページの分析(narrative)事前計算データの読み書き。
+ * キャッシュに入れるのは分析の「データ」(JSON)のみで、HTMLは保存しない
+ * （レンダリングはリクエスト時に oc_narrative_section テンプレートが行う）。
  * DB/テーブルは他のSQLite同様、setup(setup/schema/sqlite/oc_page_cache.sql)と prod-sync が用意する。
  *
  * - 読み: /oc 表示時に PK 一発 SELECT（mode=rw。mode=ro×WAL の locking protocol を避けるため）。
  *   キャッシュ未生成（DBファイル無し・該当行無し）は null を返し、呼び出し側は空表示にフォールバックする。
+ *   narrative_html は旧形式（事前レンダリングHTML）の行のための移行期読み取り専用。
  * - 書き: 背景バッチ（OcPageCacheGenerator）が単一プロセスで INSERT OR REPLACE する。
- *   HTML はクォートを含むため、SQLiteInsertImporter（値を素で埋め込む・OR IGNORE）は使わず、
+ *   値はクォートを含むため、SQLiteInsertImporter（値を素で埋め込む・OR IGNORE）は使わず、
  *   パラメータ化したプリペアドステートメント + トランザクションで upsert する。
  */
 class OcPageCacheRepository
 {
     /**
-     * @return array{narrative_html: string, recommend_html: string}|null
+     * narrative_data はデプロイ時の冪等ALTERで追加されたカラムのため、
+     * 移行された既存行では NULL があり得る（呼び出し側は empty() で判定する）。
+     *
+     * @return array{narrative_data: ?string, narrative_html: string}|null
      */
     public function get(int $open_chat_id): ?array
     {
         try {
             SQLiteOcPageCache::connect(['mode' => '?mode=rw']);
             $row = SQLiteOcPageCache::fetch(
-                'SELECT narrative_html, recommend_html FROM oc_page_cache WHERE open_chat_id = ?',
+                'SELECT narrative_data, narrative_html FROM oc_page_cache WHERE open_chat_id = ?',
                 [$open_chat_id]
             );
         } catch (\PDOException) {
@@ -38,9 +44,10 @@ class OcPageCacheRepository
     }
 
     /**
-     * 部屋単位HTMLを一括 upsert する（背景バッチ専用・単一プロセス直列書き込み）。
+     * 部屋単位の分析データを一括 upsert する（背景バッチ専用・単一プロセス直列書き込み）。
+     * 旧形式カラム(narrative_html/recommend_html)は空で上書きし、再生成された行から旧形式を排除する。
      *
-     * @param array<array{open_chat_id: int, narrative_html: string, recommend_html: string}> $rows
+     * @param array<array{open_chat_id: int, narrative_data: string}> $rows
      */
     public function upsertMany(array $rows): void
     {
@@ -53,8 +60,8 @@ class OcPageCacheRepository
 
         $stmt = $pdo->prepare(
             'INSERT OR REPLACE INTO oc_page_cache
-                (open_chat_id, narrative_html, recommend_html, updated_at)
-             VALUES (?, ?, ?, ?)'
+                (open_chat_id, narrative_data, narrative_html, recommend_html, updated_at)
+             VALUES (?, ?, \'\', \'\', ?)'
         );
 
         $pdo->beginTransaction();
@@ -62,8 +69,7 @@ class OcPageCacheRepository
             foreach ($rows as $r) {
                 $stmt->execute([
                     $r['open_chat_id'],
-                    $r['narrative_html'],
-                    $r['recommend_html'],
+                    $r['narrative_data'],
                     $now,
                 ]);
             }

--- a/app/Services/StaticData/OcPageCacheGenerator.php
+++ b/app/Services/StaticData/OcPageCacheGenerator.php
@@ -12,18 +12,21 @@ use App\Views\Classes\CollapseKeywordEnumerationsInterface;
 use Shared\MimimalCmsConfig;
 
 /**
- * ルーム個別ページの「分析文(narrative)」を事前計算し、
- * レンダリング済みHTML断片として oc_page_cache(SQLite) に保存する。
+ * ルーム個別ページの「分析(narrative)」データを事前計算し、
+ * JSON({summary,detail,meta_description,pattern}) として oc_page_cache(SQLite) に保存する。
+ *
+ * キャッシュに入れるのは「データ」のみ。HTMLは保存しない——レンダリング
+ * (oc_narrative_section テンプレート・url() 等のURLヘルパー)はリクエスト時に行う。
+ * CLIでHTMLを生成すると HTTP_HOST 不在で url() が壊れる事故(#400)の再発を構造的に防ぐ。
  *
  * /oc 表示時はこのキャッシュをPK一発SELECTで読むだけにし、bot クロール時に
- * narrative の重い読み取りを発生させない。
+ * narrative の重い統計読み取りを発生させない。
  *
  * 関連ルーム(recommend/similarSize)はここでは生成しない。/oc 表示時に
- * recommend 静的キャッシュ(.dat / 母集団300件)から都度組み立てる方式に移行した
- * （SimilarSizeRoomService）。recommend_html カラムは互換のため空文字で埋める。
+ * recommend 静的キャッシュ(.dat / 母集団300件)から都度組み立てる（SimilarSizeRoomService）。
  *
- * 注: 出力HTMLは url()/t() 等が現在の MimimalCmsConfig::$urlRoot に依存するため、
- * 言語別 cron 文脈（urlRoot 設定済み）から呼ぶこと。保存先 SQLite も urlRoot の storage 配下になる。
+ * 注: 言語別 cron 文脈（urlRoot 設定済み）から呼ぶこと。分類ラベルと保存先 SQLite が
+ * urlRoot に依存するため。
  */
 class OcPageCacheGenerator
 {
@@ -68,14 +71,11 @@ class OcPageCacheGenerator
                 $categoryLabel
             );
 
-            ob_start();
-            viewComponent('oc_narrative_section', ['narrative' => $narrative, 'oc' => $oc]);
-            $narrativeHtml = ob_get_clean();
-
             $rows[] = [
                 'open_chat_id' => $id,
-                'narrative_html' => (string)$narrativeHtml,
-                'recommend_html' => '',
+                'narrative_data' => $narrative === null
+                    ? ''
+                    : json_encode($narrative, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             ];
         }
 

--- a/app/Views/components/oc_narrative_section.php
+++ b/app/Views/components/oc_narrative_section.php
@@ -2,7 +2,8 @@
 
 /**
  * 分析文(narrative)セクション。
- * OcPageCacheGenerator が事前計算してHTML化し、/oc 表示時はキャッシュHTMLをそのまま出力する。
+ * OcPageCacheGenerator が事前計算した「データ」(oc_page_cache.narrative_data) を受け取り、
+ * /oc 表示時にレンダリングする（url() 等のURLヘルパーはリクエスト文脈で解決される）。
  *
  * - summary があれば分析本文 + 状態に合った記事リンク
  * - summary が無くても pattern があれば記事リンクだけ出す（「空ならブログリンクだけ」）

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -159,8 +159,13 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
       <?php if (isset($_adminDto)) : ?>
         <?php viewComponent('oc_content_admin', compact('_adminDto')); ?>
       <?php endif ?>
-      <?php // 分析文は oc_page_cache の事前計算済みHTMLを生出力（_接頭辞=自動エスケープ対象外）。未生成は空 ?>
-      <?php echo $_narrativeHtml ?>
+      <?php // 分析はキャッシュ済み「データ」からリクエスト時にレンダリング（url()等はここで解決される） ?>
+      <?php if ($_narrative !== null): ?>
+        <?php viewComponent('oc_narrative_section', ['narrative' => $_narrative, 'oc' => $oc]) ?>
+      <?php else: ?>
+        <?php // 旧形式（事前レンダリングHTML）の行が再生成されるまでの移行期のみ。未生成は空 ?>
+        <?php echo $_narrativeLegacyHtml ?>
+      <?php endif ?>
       <section class="openchat-graph-section" style="padding-bottom: 0rem; padding-top: var(--sp-section-gap);">
         <div class="title-bar" style="margin-bottom: 1.5rem;">
           <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">

--- a/setup/schema/sqlite/oc_page_cache.sql
+++ b/setup/schema/sqlite/oc_page_cache.sql
@@ -1,12 +1,14 @@
 -- SQLite schema for oc_page_cache database
--- ルーム個別ページの「分析文(narrative)」「関連ルーム(recommend/similarSize)」を
--- 事前計算したレンダリング済みHTML断片で保持する（部屋単位）。
+-- ルーム個別ページの「分析文(narrative)」の事前計算データを保持する（部屋単位）。
+-- キャッシュに入れるのは分析の「データ」(JSON)のみ。HTMLは保存しない——
+-- レンダリング(テンプレート・url() 等)はリクエスト時に行う。
 -- /oc 表示時はこのテーブルをPK一発SELECTで読むだけにし、bot クロール時に
--- narrative の重い読み取りや recommend/similarSize の MySQL を発生させない。
+-- narrative の重い統計読み取りを発生させない。
 
 CREATE TABLE IF NOT EXISTS oc_page_cache (
     open_chat_id INTEGER PRIMARY KEY,        -- オープンチャットID
-    narrative_html TEXT NOT NULL DEFAULT '', -- 分析文セクションのHTML（空=データ無し）
-    recommend_html TEXT NOT NULL DEFAULT '', -- 関連ルーム(similarSize優先・無ければおすすめ)のHTML
+    narrative_data TEXT NOT NULL DEFAULT '', -- 分析データJSON {summary,detail,meta_description,pattern}（空=データ無し）
+    narrative_html TEXT NOT NULL DEFAULT '', -- [旧形式・廃止] 事前レンダリングHTML。再生成で空になる
+    recommend_html TEXT NOT NULL DEFAULT '', -- [旧形式・廃止] 関連ルームHTML。関連ルームはリクエスト時組み立てに移行済み
     updated_at TEXT NOT NULL                 -- 生成時刻 Y-m-d H:i:s
 );

--- a/shared/MimimalCMS_Settings.php
+++ b/shared/MimimalCMS_Settings.php
@@ -25,14 +25,6 @@ date_default_timezone_set('Asia/Tokyo');
 
 $httpHost = 'openchat-review.me';
 
-// CLI(cron・バッチ)には HTTP_HOST が無く、url() 等のURLヘルパーが「http:///path」という
-// 不正な絶対URLを生成してしまう（oc_page_cache の事前レンダリングHTMLに混入し、
-// ルームページの分析ブログリンクが壊れていた）。本番ホストで補完する。
-if (PHP_SAPI === 'cli' && !isset($_SERVER['HTTP_HOST'])) {
-    $_SERVER['HTTP_HOST'] = $httpHost;
-    $_SERVER['HTTPS'] = 'on';
-}
-
 if (
     ($_SERVER['HTTP_HOST'] ?? '') === $httpHost
     || ($_SERVER['HTTPS'] ?? '') === 'on'


### PR DESCRIPTION
stg の変更を本番リリースします（#407）。

## 含まれる変更

### #407 分析キャッシュをHTML保存からデータ(JSON)保存に変更（内部リファクタリング）

- ルームページの分析(narrative)キャッシュには「データ」だけを保存し、レンダリング（テンプレート・URL生成）はリクエスト時に実行する設計に変更
- CLIバッチで生成したHTMLにホスト欠落URL（http:///）が混入する事故を構造的に排除
- #402 で入れたフレームワーク設定変更（CLIのHTTP_HOST補完）は取り消し
- 既存DBへの narrative_data カラム追加はデプロイ時の冪等ALTERで自動反映（移行はローカルで完全再現テスト済み）
- 旧形式の行は再生成まで従来表示（表示の空白期間なし）

## デプロイ後の作業

バックフィル再実行（/admin/genocpagecache/ja → tw / th）でデータ形式への移行が即完了します。

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj

---
_Generated by [Claude Code](https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj)_