### PR TITLE
[PROD] fix: 分析データの読み取り・時刻基準を修正＋旧形式キャッシュ判定を削除

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -78,15 +78,9 @@ class OpenChatPageController
         // レンダリングはリクエスト時に oc_narrative_section テンプレートが行う。
         // 未生成（バックフィル前/生成不可）は null → 空表示。bot が叩く /oc 本体で重い計算をしない。
         $ocPageCache = $ocPageCacheRepository->get($open_chat_id);
-        $_narrative = null;
-        $_narrativeLegacyHtml = '';
-        if (!empty($ocPageCache['narrative_data'])) {
-            $_narrative = json_decode($ocPageCache['narrative_data'], true) ?: null;
-        } elseif (!empty($ocPageCache['narrative_html'])) {
-            // 旧形式（事前レンダリングHTML）の行。バックフィル/毎時フックで narrative_data に
-            // 置き換わるまでの移行期のみ。ホスト欠落URL(http:///)の応急修復も移行期間中は維持する。
-            $_narrativeLegacyHtml = str_replace('"http:///', '"/', $ocPageCache['narrative_html']);
-        }
+        $_narrative = !empty($ocPageCache['narrative_data'])
+            ? (json_decode($ocPageCache['narrative_data'], true) ?: null)
+            : null;
 
         // 関連ルームは recommend 静的キャッシュ(.dat / 母集団300件)から都度組み立てる。
         // ファイル読み＋unserialize のみで部屋ごとの MySQL クエリは発生しない。
@@ -165,7 +159,6 @@ class OpenChatPageController
             '_breadcrumbsShema',
             '_schema',
             '_narrative',
-            '_narrativeLegacyHtml',
             '_recommend',
             '_similarSize',
             '_hourlyRange',

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -16,7 +16,6 @@ use App\Services\Storage\FileStorageInterface;
  * - 読み: /oc 表示時に PK 一発 SELECT（mode=ro。読み取り専用接続。書き込み権限や
  *   WAL チェックポイントを発生させず、Web(www-data)から安全に読むため）。
  *   キャッシュ未生成（DBファイル無し・該当行無し）は null を返し、呼び出し側は空表示にフォールバックする。
- *   narrative_html は旧形式（事前レンダリングHTML）の行のための移行期読み取り専用。
  * - 書き: 背景バッチ（OcPageCacheGenerator）が単一プロセスで INSERT OR REPLACE する。
  *   値はクォートを含むため、SQLiteInsertImporter（値を素で埋め込む・OR IGNORE）は使わず、
  *   パラメータ化したプリペアドステートメント + トランザクションで upsert する。
@@ -30,16 +29,16 @@ class OcPageCacheRepository
 
     /**
      * narrative_data はデプロイ時の冪等ALTERで追加されたカラムのため、
-     * 移行された既存行では NULL があり得る（呼び出し側は empty() で判定する）。
+     * 未生成の既存行では NULL があり得る（呼び出し側は empty() で判定する）。
      *
-     * @return array{narrative_data: ?string, narrative_html: string}|null
+     * @return array{narrative_data: ?string}|null
      */
     public function get(int $open_chat_id): ?array
     {
         try {
             SQLiteOcPageCache::connect(['mode' => '?mode=ro']);
             $row = SQLiteOcPageCache::fetch(
-                'SELECT narrative_data, narrative_html FROM oc_page_cache WHERE open_chat_id = ?',
+                'SELECT narrative_data FROM oc_page_cache WHERE open_chat_id = ?',
                 [$open_chat_id]
             );
         } catch (\PDOException) {

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -12,7 +12,8 @@ use App\Models\SQLite\SQLiteOcPageCache;
  * （レンダリングはリクエスト時に oc_narrative_section テンプレートが行う）。
  * DB/テーブルは他のSQLite同様、setup(setup/schema/sqlite/oc_page_cache.sql)と prod-sync が用意する。
  *
- * - 読み: /oc 表示時に PK 一発 SELECT（mode=rw。mode=ro×WAL の locking protocol を避けるため）。
+ * - 読み: /oc 表示時に PK 一発 SELECT（mode=ro。読み取り専用接続。書き込み権限や
+ *   WAL チェックポイントを発生させず、Web(www-data)から安全に読むため）。
  *   キャッシュ未生成（DBファイル無し・該当行無し）は null を返し、呼び出し側は空表示にフォールバックする。
  *   narrative_html は旧形式（事前レンダリングHTML）の行のための移行期読み取り専用。
  * - 書き: 背景バッチ（OcPageCacheGenerator）が単一プロセスで INSERT OR REPLACE する。
@@ -30,7 +31,7 @@ class OcPageCacheRepository
     public function get(int $open_chat_id): ?array
     {
         try {
-            SQLiteOcPageCache::connect(['mode' => '?mode=rw']);
+            SQLiteOcPageCache::connect(['mode' => '?mode=ro']);
             $row = SQLiteOcPageCache::fetch(
                 'SELECT narrative_data, narrative_html FROM oc_page_cache WHERE open_chat_id = ?',
                 [$open_chat_id]

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\SQLite\Repositories;
 
 use App\Models\SQLite\SQLiteOcPageCache;
+use App\Services\Storage\FileStorageInterface;
 
 /**
  * ルーム個別ページの分析(narrative)事前計算データの読み書き。
@@ -22,6 +23,11 @@ use App\Models\SQLite\SQLiteOcPageCache;
  */
 class OcPageCacheRepository
 {
+    public function __construct(
+        private FileStorageInterface $fileStorage,
+    ) {
+    }
+
     /**
      * narrative_data はデプロイ時の冪等ALTERで追加されたカラムのため、
      * 移行された既存行では NULL があり得る（呼び出し側は empty() で判定する）。
@@ -57,7 +63,9 @@ class OcPageCacheRepository
         }
 
         $pdo = SQLiteOcPageCache::connect();
-        $now = (new \DateTime)->format('Y-m-d H:i:s');
+        // updated_at は「データの最終時点」= 毎時クロール完了時刻を採る（wall-clock の now ではない）。
+        // クロールが止まった環境で再生成しても、キャッシュの鮮度がデータと一致する。取得不能なら now。
+        $now = $this->generatedAt();
 
         $stmt = $pdo->prepare(
             'INSERT OR REPLACE INTO oc_page_cache
@@ -79,5 +87,21 @@ class OcPageCacheRepository
             $pdo->rollBack();
             throw $e;
         }
+    }
+
+    /**
+     * キャッシュ行の updated_at（= データの最終時点）。毎時クロール完了時刻を採り、
+     * 取得不能（ファイル無し/空/不正）なら wall-clock の now にフォールバックする。
+     */
+    private function generatedAt(): string
+    {
+        try {
+            $cron = trim((string)$this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
+            if ($cron !== '') {
+                return (new \DateTime($cron))->format('Y-m-d H:i:s');
+            }
+        } catch (\Throwable) {
+        }
+        return (new \DateTime)->format('Y-m-d H:i:s');
     }
 }

--- a/app/Services/Narrative/OcNarrativeService.php
+++ b/app/Services/Narrative/OcNarrativeService.php
@@ -85,21 +85,35 @@ class OcNarrativeService
     }
 
     /**
-     * メトリクスの「現在の基準日」を毎時クロール基準時刻 ('Y-m-d') から解決する。
-     * cron 時刻ファイルが空 / 不正 / 取得不能なら null を返し、Repository 側は従来の
-     * date('now') (SQLite 実行時刻) フォールバックで動く。
+     * メトリクス・経過日数の「現在」の基準時刻を毎時クロール完了時刻
+     * (@hourlyCronUpdatedAtDatetime) から解決する。
+     *
+     * narrative はクロールで採れたデータの「最終時点」を基準に経過日数・停滞判定を
+     * 行うべきで、wall-clock の now ではない。クロールが止まった環境（ローカル/共有）で
+     * 古いデータに now を当てると、経過日数が水増しされ「停滞」誤判定や経過月数の不正が起きる。
+     * 取得不能なら null（呼び出し側は new \DateTime('now') にフォールバック）。
      */
-    private function resolveBaseDate(): ?string
+    private function cronNow(): ?\DateTime
     {
         try {
             $cron = trim($this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
             if ($cron === '') {
                 return null;
             }
-            return (new \DateTime($cron))->format('Y-m-d');
+            return new \DateTime($cron);
         } catch (\Throwable $e) {
             return null;
         }
+    }
+
+    /**
+     * メトリクスの「現在の基準日」を毎時クロール基準時刻 ('Y-m-d') から解決する。
+     * cron 時刻ファイルが空 / 不正 / 取得不能なら null を返し、Repository 側は従来の
+     * date('now') (SQLite 実行時刻) フォールバックで動く。
+     */
+    private function resolveBaseDate(): ?string
+    {
+        return $this->cronNow()?->format('Y-m-d');
     }
 
     /**
@@ -126,7 +140,7 @@ class OcNarrativeService
             // 実開設日 (api_created_at) からの経過日数。null = 開設日が不明。
             // 「新規」ラベルは sample_n ではなく実開設日で判定する (疎クロールの古い小規模ルーム対策)。
             $created = $this->parseApiCreatedAt($oc);
-            $roomAgeDays = $created !== null ? (int)$created->diff(new \DateTime('now'))->days : null;
+            $roomAgeDays = $created !== null ? (int)$created->diff($this->cronNow() ?? new \DateTime('now'))->days : null;
 
             // 決定的な状態分類 (summary ラベル / trend 文 / pattern を一貫して導く)
             $state = $this->classify($metrics, $roomAgeDays);
@@ -703,7 +717,8 @@ class OcNarrativeService
     {
         try {
             $dt = new \DateTime($date);
-            $now = new \DateTime('now');
+            // wall-clock ではなくクロール最終時点を基準に経過日数を測る（停滞判定・経過月数の整合）
+            $now = $this->cronNow() ?? new \DateTime('now');
             $diff = $dt->diff($now);
             return (int)$diff->days;
         } catch (\Throwable $e) {

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -159,12 +159,9 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
       <?php if (isset($_adminDto)) : ?>
         <?php viewComponent('oc_content_admin', compact('_adminDto')); ?>
       <?php endif ?>
-      <?php // 分析はキャッシュ済み「データ」からリクエスト時にレンダリング（url()等はここで解決される） ?>
+      <?php // 分析はキャッシュ済み「データ」からリクエスト時にレンダリング（url()等はここで解決される）。未生成は空 ?>
       <?php if ($_narrative !== null): ?>
         <?php viewComponent('oc_narrative_section', ['narrative' => $_narrative, 'oc' => $oc]) ?>
-      <?php else: ?>
-        <?php // 旧形式（事前レンダリングHTML）の行が再生成されるまでの移行期のみ。未生成は空 ?>
-        <?php echo $_narrativeLegacyHtml ?>
       <?php endif ?>
       <section class="openchat-graph-section" style="padding-bottom: 0rem; padding-top: var(--sp-section-gap);">
         <div class="title-bar" style="margin-bottom: 1.5rem;">


### PR DESCRIPTION
ローカル検証で見つかった分析(narrative)キャッシュの不具合修正を本番反映。

- get() の読み取りを mode=ro に（mode=rw による書き込み権限/WALエラーで分析文が出ない問題を解消）
- 経過日数/停滞判定/キャッシュ更新時刻を毎時クロール時刻基準に統一（古いデータへの now 適用による誤判定を解消）
- narrative_data 方式に統一済みのため旧形式(narrative_html)の移行フォールバックを撤去

https://claude.ai/code/session_011SVyQwGe3yqBKmbapqvbzj