### PR TITLE
[STG] feat: デプロイ前のテストを充実させ、デプロイ直後の本番自動チェックとDiscord通知を追加

### DIFF
--- a/.github/scripts/post-deploy-smoke.sh
+++ b/.github/scripts/post-deploy-smoke.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# デプロイ直後の本番スモークテスト（deploy.yml の Post-deploy smoke test から実行）
+# 各言語の top / ランキングAPI / ルームページ / グラフAPI / レコメンド (+jaのみコメントAPI) を確認する。
+# 約16リクエスト・数秒で完了。失敗時は exit 1（deploy.yml 側で Discord のデプロイ失敗通知が発火する）。
+#
+# 環境変数:
+#   SITE_URL  チェック対象のベースURL（デフォルト: https://openchat-review.me）
+#   IS_STG    "true" なら ja のみチェック（stg には tw/th のDBが無い）
+#
+# 手動実行例:
+#   SITE_URL=https://openchat-review-dev.me IS_STG=true ./.github/scripts/post-deploy-smoke.sh
+
+set -u
+
+SITE_URL="${SITE_URL:-https://openchat-review.me}"
+IS_STG="${IS_STG:-false}"
+UA="Mozilla/5.0 (compatible; ocgraph-deploy-smoke)"
+QUERY="page=0&limit=1&category=0&sub_category=&keyword=&list=all&sort=member&order=desc"
+FAIL=0
+
+check() { # 説明 URL [本文に必要なパターン]
+    local out status
+    out=$(mktemp)
+    status=$(curl -sL -A "$UA" -o "$out" -w "%{http_code}" --max-time 15 "$2" || echo 000)
+    if [ "$status" = "200" ] && { [ -z "${3:-}" ] || grep -q "$3" "$out"; }; then
+        echo "OK  $1 ($status)"
+    else
+        echo "::error::スモーク失敗: $1 (status=$status) $2 body: $(head -c 120 "$out")"
+        FAIL=1
+    fi
+    rm -f "$out"
+}
+
+for LOC in "" /tw /th; do
+    # stgにはja以外のDBが無いためjaのみチェック
+    if [ "$IS_STG" = "true" ] && [ -n "$LOC" ]; then
+        continue
+    fi
+
+    check "トップ${LOC}" "${SITE_URL}${LOC}"
+
+    # ランキングAPIから実在ルームIDを取得（このAPI自体のスモークも兼ねる）
+    OC_ID=$(curl -sL -A "$UA" --max-time 15 "${SITE_URL}${LOC}/oclist?${QUERY}" | grep -oE '"id":[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+    if [ -z "$OC_ID" ]; then
+        echo "::error::スモーク失敗: ランキングAPI${LOC} からルームIDを取得できない"
+        FAIL=1
+        continue
+    fi
+    echo "OK  ランキングAPI${LOC} (id=${OC_ID})"
+
+    check "ルームページ${LOC}" "${SITE_URL}${LOC}/oc/${OC_ID}"
+    check "グラフAPI${LOC}" "${SITE_URL}${LOC}/oc/${OC_ID}/stats?category=0" '"date":\['
+
+    case "$LOC" in
+        "")    RECO="%E3%83%9D%E3%82%B1%E3%83%83%E3%83%88%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%EF%BC%88%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%EF%BC%89" ;;
+        "/tw") RECO="%E7%BE%BD%E7%90%83" ;;
+        "/th") RECO="Roblox" ;;
+    esac
+    check "レコメンド${LOC}" "${SITE_URL}${LOC}/recommend/${RECO}"
+
+    # コメント機能はja運用のみ
+    if [ -z "$LOC" ]; then
+        check "コメントAPI" "${SITE_URL}/comment/${OC_ID}?page=0&limit=10" '^\['
+    fi
+done
+
+exit "$FAIL"

--- a/.github/scripts/test-urls.sh
+++ b/.github/scripts/test-urls.sh
@@ -77,6 +77,32 @@ test_url() {
     fi
 }
 
+# JSON APIテスト関数（ステータス200に加え、レスポンス本文が期待パターンを含むか確認）
+test_json_url() {
+    local url="$1"
+    local expected_pattern="$2"
+    local description="$3"
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+    echo -n "Testing JSON: ${url} ... " | tee -a "$LOG_FILE"
+
+    local body_file=$(mktemp)
+    local status_code=$(curl -k -s -o "$body_file" -w "%{http_code}" --max-time 30 "$url")
+
+    if [ "$status_code" = "200" ] && grep -qE "$expected_pattern" "$body_file"; then
+        echo -e "${GREEN}OK${NC}" | tee -a "$LOG_FILE"
+        rm -f "$body_file"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+        return 0
+    else
+        echo -e "${RED}FAILED (Status: ${status_code}, Body: $(head -c 100 "$body_file"))${NC}" | tee -a "$LOG_FILE"
+        rm -f "$body_file"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        return 1
+    fi
+}
+
 # サイトマップにURLが含まれているかテスト
 test_sitemap_contains_url() {
     local sitemap_dir="$1"
@@ -331,6 +357,23 @@ main() {
     fi
     echo ""
 
+    # 統計グラフデータAPI（graphが初回ロードで非同期取得する /oc/{id}/stats）のテスト
+    # date配列が空でないことまで確認し「200だがグラフが空」の劣化も検知する
+    log "統計グラフデータAPIのテスト"
+    if [ -n "$JA_OC_ID" ]; then
+        test_json_url "${BASE_URL}/oc/${JA_OC_ID}/stats?category=0" '"date":\["' "統計グラフデータ（category=0）"
+        test_json_url "${BASE_URL}/oc/${JA_OC_ID}/stats?category=8" '"positionAvailability"' "統計グラフデータ（category=8）"
+    fi
+
+    if [ -n "$TH_OC_ID" ]; then
+        test_json_url "${BASE_URL}/th/oc/${TH_OC_ID}/stats?category=0" '"date":\["' "統計グラフデータ（タイ語）"
+    fi
+
+    if [ -n "$TW_OC_ID" ]; then
+        test_json_url "${BASE_URL}/tw/oc/${TW_OC_ID}/stats?category=0" '"date":\["' "統計グラフデータ（繁体字）"
+    fi
+    echo ""
+
     # 各種ページ
     log "各種ページのテスト（多言語）"
     test_url "${BASE_URL}/policy" "ポリシーページ"
@@ -446,6 +489,10 @@ main() {
     log "コメントページのテスト"
     test_url "${BASE_URL}/comment/0?page=0&limit=10" "コメント（ID=0）"
     test_url "${BASE_URL}/comment/1?page=10&limit=10" "コメント（ID=1、page=10）"
+    # 個別ルームページが初回ロードで呼ぶ実在ルームIDでのコメント一覧（JSON配列が返ること）
+    if [ -n "$JA_OC_ID" ]; then
+        test_json_url "${BASE_URL}/comment/${JA_OC_ID}?page=0&limit=10" '^\[' "コメント一覧（実在ルームID）"
+    fi
     test_url "${BASE_URL}/comments-timeline" "コメントタイムライン"
     echo ""
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,6 +201,13 @@ jobs:
             exit 1
           fi
 
+      # デプロイ直後の本番スモークテスト（最小限・数秒で完了）
+      # 失敗するとjobがfailし、既存の「Notify Discord (deploy failure)」で通知される
+      - name: Post-deploy smoke test
+        env:
+          SITE_URL: ${{ steps.config.outputs.tweet_url }}
+        run: bash ./.github/scripts/post-deploy-smoke.sh
+
       - name: Notify Discord (deploy success)
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
「CIが通ったら即デプロイ」で回すための安全網を、デプロイ前後の2箇所で強化する。

## 1. デプロイ前: CIのURLテストを充実（5件追加）

ルームページの統計グラフを初回ロードから非同期取得に変えた改修（1b5fad702）で新設されたAPI `/oc/{id}/stats` が、CIのURLテストで未カバーだった。壊れると全ルームページのグラフが表示されなくなるため、デプロイ前に検知できるようにする。

- `/oc/{id}/stats` のスモークテスト4件（日本語 category=0/8、繁体字、タイ語）
- ルームページが初回ロードで呼ぶコメント一覧APIを実在ルームIDで1件（既存はID=0/1の固定値のみだった）
- 新ヘルパー `test_json_url` はステータスに加えてJSONの中身も軽く確認する。メンバー数推移の配列が空でないことまで見るので「200は返るがグラフが空」も検知できる。キー存在レベルの緩い確認なので、仕様の細かい変更では壊れない

## 2. デプロイ後: 本番の主要ページ・APIを自動チェックして異常をDiscord通知

デプロイで本番が壊れても、これまでは利用者経由でしか気づけなかった。デプロイ直後に `.github/scripts/post-deploy-smoke.sh` を実行し、異常があれば既存のDiscord通知（デプロイ失敗）で即座に分かるようにする。deploy.yml には呼び出し1行のみ追加。

- 各言語（日本語・繁体字・タイ語）で トップ / ランキングAPI / ルームページ / グラフAPI / レコメンド、日本語のみコメントAPI
- ルームIDはランキングAPIの応答から動的に取得（固定IDのハードコード無し）
- 計16リクエスト・数秒で完了するため、デプロイ時間はほぼ変わらない。stgデプロイ時は日本語のみ（stgにはtw/thのDBが無いため）
- 失敗してもデプロイ自体は完了済みでロールバックはしない。「壊れたら即気づいて直す」ための検知網
- スクリプトを現在の本番・stg両方にそのまま実行し、全チェック通過を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
