### PR TITLE
[STG] feat: デプロイ直後に本番サイトの主要ページとAPIを自動チェックして異常をDiscordに通知

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,6 +201,66 @@ jobs:
             exit 1
           fi
 
+      # デプロイ直後の本番スモークテスト（最小限・数秒で完了）
+      # 失敗するとjobがfailし、既存の「Notify Discord (deploy failure)」で通知される
+      - name: Post-deploy smoke test
+        env:
+          SITE_URL: ${{ steps.config.outputs.tweet_url }}
+        run: |
+          UA="Mozilla/5.0 (compatible; ocgraph-deploy-smoke)"
+          QUERY="page=0&limit=1&category=0&sub_category=&keyword=&list=all&sort=member&order=desc"
+          FAIL=0
+
+          check() { # 説明 URL [本文に必要なパターン]
+            local out status
+            out=$(mktemp)
+            status=$(curl -sL -A "$UA" -o "$out" -w "%{http_code}" --max-time 15 "$2" || echo 000)
+            if [ "$status" = "200" ] && { [ -z "${3:-}" ] || grep -q "$3" "$out"; }; then
+              echo "OK  $1 ($status)"
+            else
+              echo "::error::スモーク失敗: $1 (status=$status) $2 body: $(head -c 120 "$out")"
+              FAIL=1
+            fi
+            rm -f "$out"
+          }
+
+          for LOC in "" /tw /th; do
+            # stgにはja以外のDBが無いためjaのみチェック
+            if [ "$IS_STG" = "true" ] && [ -n "$LOC" ]; then
+              continue
+            fi
+
+            check "トップ${LOC}" "${SITE_URL}${LOC}"
+
+            # ランキングAPIから実在ルームIDを取得（このAPI自体のスモークも兼ねる）
+            OC_ID=$(curl -sL -A "$UA" --max-time 15 "${SITE_URL}${LOC}/oclist?${QUERY}" | grep -oE '"id":[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+            if [ -z "$OC_ID" ]; then
+              echo "::error::スモーク失敗: ランキングAPI${LOC} からルームIDを取得できない"
+              FAIL=1
+              continue
+            fi
+            echo "OK  ランキングAPI${LOC} (id=${OC_ID})"
+
+            check "ルームページ${LOC}" "${SITE_URL}${LOC}/oc/${OC_ID}"
+            check "グラフAPI${LOC}" "${SITE_URL}${LOC}/oc/${OC_ID}/stats?category=0" '"date":\['
+
+            case "$LOC" in
+              "")    RECO="%E3%83%9D%E3%82%B1%E3%83%83%E3%83%88%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%EF%BC%88%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%EF%BC%89" ;;
+              "/tw") RECO="%E7%BE%BD%E7%90%83" ;;
+              "/th") RECO="Roblox" ;;
+            esac
+            check "レコメンド${LOC}" "${SITE_URL}${LOC}/recommend/${RECO}"
+
+            # コメントAPIはja運用のみ
+            if [ -z "$LOC" ]; then
+              check "コメントAPI" "${SITE_URL}/comment/${OC_ID}?page=0&limit=10" '^\['
+            fi
+          done
+
+          if [ "$FAIL" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Notify Discord (deploy success)
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
デプロイで本番サイトが壊れた場合、これまでは利用者経由でしか気づけなかった。デプロイ直後に本番の主要ページとAPIを自動チェックし、異常があれば既存のDiscord通知（デプロイ失敗）で即座に分かるようにする。

## チェック内容（最小限・数秒で完了）

各言語（日本語・繁体字・タイ語）で以下を確認する。

- トップページ
- ランキングAPI（応答から実在ルームIDを取得し、以降のチェックに使う。固定IDのハードコード無し）
- ルームページ
- グラフ統計API（メンバー数データのキーがあることまで確認）
- レコメンドページ
- コメントAPI（日本語のみ）

合計16リクエスト・数秒で完了するため、デプロイ時間はほぼ変わらない。stgデプロイ時は日本語のみ（stgにはtw/thのDBが無いため）。

失敗してもデプロイ自体は完了済みでロールバックはしない。「壊れたら即気づいて直す」ための検知網。現在の本番・stg両方に対して、このステップ本文をそのまま実行して全チェックが通ることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
