### PR TITLE
[STG] perf: コメントタイムラインのデータ取得を6分の1に高速化

### DIFF
--- a/app/Models/CommentRepositories/RecentCommentListRepository.php
+++ b/app/Models/CommentRepositories/RecentCommentListRepository.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models\CommentRepositories;
 
+use App\Config\AppConfig;
 use App\Models\CommentRepositories\CommentDB;
-use App\Models\Repositories\DB;
+use Shared\MimimalCmsConfig;
 
 class RecentCommentListRepository implements RecentCommentListRepositoryInterface
 {
@@ -20,52 +21,41 @@ class RecentCommentListRepository implements RecentCommentListRepositoryInterfac
         int $open_chat_id = 0,
         string $order = 'DESC',
     ): array {
+        $order = $order === 'ASC' ? 'ASC' : 'DESC';
+        // comment DB と open_chat DB は同一 MySQL サーバー上にあるためクロスDB JOIN できる
+        $mainDb = AppConfig::$dbName[MimimalCmsConfig::$urlRoot];
+
         $query =
             "SELECT
-                comment_id,
-                open_chat_id,
-                time,
-                name,
+                c.comment_id,
+                c.open_chat_id,
+                c.time,
+                c.name,
                 CASE
-                    WHEN flag = 5 THEN 5
-                    WHEN user_id = :user_id THEN 0
-                    ELSE flag
+                    WHEN c.flag = 5 THEN 5
+                    WHEN c.user_id = :user_id THEN 0
+                    ELSE c.flag
                 END AS flag,
-                text
+                c.text,
+                oc.name AS oc_name,
+                oc.img_url AS oc_img_url,
+                oc.category AS oc_category,
+                oc.member AS oc_member,
+                oc.emblem AS oc_emblem
             FROM
-                comment
+                comment AS c
+                LEFT JOIN `{$mainDb}`.`open_chat` AS oc ON oc.id = c.open_chat_id
             WHERE
-                NOT user_id = :adminId
-                AND (flag != 1 OR user_id = :user_id)
-                AND (open_chat_id != :open_chat_id OR open_chat_id = 0)
+                NOT c.user_id = :adminId
+                AND (c.flag != 1 OR c.user_id = :user_id)
+                AND (c.open_chat_id != :open_chat_id OR c.open_chat_id = 0)
+                AND (c.open_chat_id = 0 OR oc.id IS NOT NULL)
             ORDER BY
-                time {$order}
+                c.time {$order}
             LIMIT
                 :offset, :limit;";
 
         $comments = CommentDB::fetchAll($query, compact('offset', 'limit', 'adminId', 'user_id', 'open_chat_id'));
-        if (empty($comments)) return [];
-
-        $ids = array_unique(array_column($comments, 'open_chat_id'));
-        $ids = implode(',', $ids);
-
-        $ocQuery =
-            "SELECT
-                oc.id,
-                oc.name,
-                oc.img_url,
-                oc.category,
-                oc.member,
-                oc.emblem
-            FROM
-                open_chat AS oc
-            WHERE
-                id IN ({$ids})";
-
-
-        $oc = DB::fetchAll($ocQuery);
-
-        $idArray = array_column($oc, 'id');
 
         $result = [];
         foreach ($comments as $el) {
@@ -85,20 +75,17 @@ class RecentCommentListRepository implements RecentCommentListRepositoryInterfac
                 continue;
             }
 
-            $key = array_search($el['open_chat_id'], $idArray);
-            if ($key === false) continue;
-
             $result[] = [
                 'id' => $el['open_chat_id'],
                 'comment_id' => $el['comment_id'],
                 'user' => in_array($el['flag'], [0, 4]) ? ($el['name']  ?: '匿名') : '***',
-                'name' => $oc[$key]['name'],
-                'img_url' => $oc[$key]['img_url'],
-                'emblem' => $oc[$key]['emblem'],
+                'name' => $el['oc_name'],
+                'img_url' => $el['oc_img_url'],
+                'emblem' => $el['oc_emblem'],
                 'description' => in_array($el['flag'], [0, 4]) ? $el['text'] : '',
                 'time' => $el['time'],
-                'member' => $oc[$key]['member'],
-                'category' => $oc[$key]['category'],
+                'member' => $el['oc_member'],
+                'category' => $el['oc_category'],
             ];
         }
 

--- a/setup/schema/mysql/ocgraph_comment_schema.sql
+++ b/setup/schema/mysql/ocgraph_comment_schema.sql
@@ -33,7 +33,8 @@ CREATE TABLE `comment` (
   `time` datetime NOT NULL DEFAULT current_timestamp(),
   `flag` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`comment_id`),
-  KEY `idx_open_chat_id` (`open_chat_id`)
+  KEY `idx_open_chat_id` (`open_chat_id`),
+  KEY `idx_time` (`time`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 DROP TABLE IF EXISTS `like`;
 CREATE TABLE `like` (

--- a/setup/schema/mysql/ocgraph_commentth_schema.sql
+++ b/setup/schema/mysql/ocgraph_commentth_schema.sql
@@ -33,7 +33,8 @@ CREATE TABLE `comment` (
   `time` datetime NOT NULL DEFAULT current_timestamp(),
   `flag` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`comment_id`),
-  KEY `idx_open_chat_id` (`open_chat_id`)
+  KEY `idx_open_chat_id` (`open_chat_id`),
+  KEY `idx_time` (`time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 DROP TABLE IF EXISTS `like`;
 CREATE TABLE `like` (

--- a/setup/schema/mysql/ocgraph_commenttw_schema.sql
+++ b/setup/schema/mysql/ocgraph_commenttw_schema.sql
@@ -33,7 +33,8 @@ CREATE TABLE `comment` (
   `time` datetime NOT NULL DEFAULT current_timestamp(),
   `flag` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`comment_id`),
-  KEY `idx_open_chat_id` (`open_chat_id`)
+  KEY `idx_open_chat_id` (`open_chat_id`),
+  KEY `idx_time` (`time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 DROP TABLE IF EXISTS `like`;
 CREATE TABLE `like` (


### PR DESCRIPTION
## 問題の概要

コメントタイムライン（各ルームページ下部の「最近のコメント」と一覧ページ）のデータ取得が非効率だった。

1. コメントDBと部屋情報DBが同じMySQLサーバー上にあるのに、別々に2回クエリを投げてPHP側で1件ずつ突き合わせていた
2. コメントを新しい順に並べるためのインデックスがなく、毎回全コメントを読んでから並べ替えていた

## 対処内容

- 2回のクエリをDBまたぎJOINの1クエリに統合（[`RecentCommentListRepository::findRecentCommentOpenChatAll()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/perf-comments-timeline-cross-db-join/app/Models/CommentRepositories/RecentCommentListRepository.php)）。DB名はAppConfigから動的取得
- `comment.time` にインデックスを追加（`setup/schema/mysql/` の編集のみ。デプロイ時に schema sync が ja/tw/th すべてへ自動反映）

## ビフォーアフター（ローカル実データ: コメント2,400件・部屋24万件、中央値）

| 処理 | Before | After | 効果 |
|---|---|---|---|
| ルームページのタイムライン取得（最頻・全ルームページで実行） | 1.33ms | 0.22ms | 6分の1 |
| タイムライン一覧 1ページ目 | 1.32ms | 0.33ms | 4分の1 |
| 更新時刻チェック（タイムラインページの毎リクエストで実行） | 0.77ms | 0.14ms | 5分の1 |
| ページ件数カウント | 0.83ms | 0.69ms | 17%減 |
| タイムライン一覧の深いページ（50ページ目付近・アクセス稀） | 2.88ms | 4.99ms | 悪化 |

内訳はインデックスの効果が大半（1.33ms→0.31ms）で、JOIN化でさらに28%短縮（→0.22ms）。クエリ数半減・PHP側の突き合わせループ廃止・部屋情報DBへの接続依存の削減も得られる。

深いページの悪化は、JOINが読み飛ばし分の行にも部屋情報の参照を行うため。サブクエリで先に絞る方式も計測したが、最頻パスが0.22ms→0.66msへ悪化するため、アクセス頻度（一覧54ページ中の後半のみ）を踏まえ最頻パス優先の構成を採用。

## 等価性確認

変更前ロジックと新実装を8パターン（API・一覧・深いページ・管理者除外・非公開コメント所有者・範囲外offset等）で厳密比較（===）し全件一致。JOIN化で挙動が変わりうる唯一のケース（削除済みルームを参照するコメント）は現データで0件。PHPStan通過、ローカル環境でページ・APIの実表示も確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
