### PR TITLE
[STG] skip-ci: データAPIの管理者認証が大文字を含むキーで通らない問題を回避（admin+パスワード方式を追加）

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -627,7 +627,10 @@ Route::path(
 // /database/{username}/query・/schema 用の認証（いずれも POST）:
 //   - Basic認証ではなく、POSTボディの password で認証する
 //   - password は ApiUser の登録パスワードを SHA256 した16進文字列を送る
-//   - {username} が adminApiKey の場合は従来どおり password 不要
+//   - 管理者は {username} を admin にして password へ adminApiKey をそのまま送る
+//     （URLパスはフレームワークが小文字化するため、大文字を含むキーは
+//       {username} に直接入れても照合できない。POSTボディは小文字化されない）
+//   - {username} が adminApiKey の場合は従来どおり password 不要（小文字のみのキー用）
 $databaseApiPostAuth = function (string $username, $password = null) {
     if (MimimalCmsConfig::$urlRoot !== '') {
         return false;
@@ -635,7 +638,24 @@ $databaseApiPostAuth = function (string $username, $password = null) {
 
     allowCORS(); // OPTIONS プリフライトはここで終了
 
-    // 1. 管理用キー（password 不要）
+    // 1. 管理用キー
+    //    a) username=admin + POSTの password に adminApiKey
+    if ($username === 'admin') {
+        if (
+            SecretsConfig::$adminApiKey !== ''
+            && is_string($password)
+            && hash_equals(SecretsConfig::$adminApiKey, $password)
+        ) {
+            return true;
+        }
+        response([
+            'status' => 'error',
+            'message' => 'Authentication failed.',
+        ], 401)->send();
+        exit;
+    }
+
+    //    b) {username} に adminApiKey（password 不要）
     if ($username === SecretsConfig::$adminApiKey) {
         return true;
     }


### PR DESCRIPTION
データAPIの管理者キーに大文字が含まれていると認証できない問題の回避。

URLパスはフレームワークが小文字化する（`RequestParser.php:25`）ため、`/database/{管理キー}/query` の従来方式は大文字を含むキーだと絶対に一致しない。URLの小文字化仕様は変えられないので、小文字化されないPOSTボディ側で受ける方式を追加した。

- 新方式: `POST /database/admin/query` に `password=<adminApiKey>` を送る
- 従来方式（キーをusernameに直接入れる）は小文字のみのキー用に残す
- 一般ユーザー（ApiUser）の認証は変更なし

動作確認済み: admin+正キー=200 / admin+誤キー=401 / password無し=401 / 従来方式=200 / PHPStanパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
