### PR TITLE
[PROD] fix: 掲載状況分析の一覧データにもサイト内利用限定の収集対策を適用（本番反映）

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -307,6 +307,8 @@ Route::path(
     ->match(function (Reception $reception, FileStorageInterface $fileStorage) {
         if (MimimalCmsConfig::$urlRoot !== '')
             return false;
+        if (!verifyApiClientHeader())
+            return false;
         checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
     });
 

--- a/app/Views/ranking_ban_content.php
+++ b/app/Views/ranking_ban_content.php
@@ -389,7 +389,8 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 if (opts.push) history.pushState(state, '', pageUrl(state));
                 setBusy(true);
                 const s = Object.assign({}, state);
-                fetch(fragmentUrl(s), { signal: aborter.signal })
+                // X-Ocg-Client: サイト内JSからのfetchであることを示す（無いとAPI側で404。直叩き収集対策）
+                fetch(fragmentUrl(s), { signal: aborter.signal, headers: { 'X-Ocg-Client': '1' } })
                     .then((res) => {
                         if (res.ok) return res.text();
                         if (res.status === 404) {


### PR DESCRIPTION
## 概要

#429 の本番反映。掲載状況分析ページ（labs/publication-analytics）の一覧データ取得エンドポイントに、他のデータAPIと同じ機械的収集対策（`X-Ocg-Client` ヘッダー検証）を適用する。

詳細は #429 を参照。

https://claude.ai/code/session_01Q9Va8wXA3MGkQxSqoQZyV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9Va8wXA3MGkQxSqoQZyV3)_