### PR TITLE
[STG] skip-ci: データAPIの旧キー直接方式を削除し、Basic認証必須をREADMEに明記

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -3,8 +3,8 @@
 オプチャグラフ（[openchat-review.me](https://openchat-review.me/)）が収集した LINEオープンチャットのデータ（SQLite）に対する、読み取り専用の SQL API。
 
 - エンドポイント: `POST /database/{username}/query`
-- POSTボディに `stmt`（SQL）と `password` を渡す。結果は JSON。
-- `password` は申請時に渡すパスワードの **SHA256（16進）**。`{username}` はパスに入れる（[認証情報の取得](#認証情報の取得)）。
+- **Basic認証**（`{username}` / `{password}` をそのまま）を付け、POSTボディに `stmt`（SQL）と `password` を渡す。結果は JSON。
+- POSTボディの `password` は申請時に渡すパスワードの **SHA256（16進）**。`{username}` はパスに入れる（[認証情報の取得](#認証情報の取得)）。
 
 ---
 
@@ -14,13 +14,22 @@
 
 X（旧Twitter）の [@openchat_graph](https://x.com/openchat_graph) のDMでご相談ください。利用目的を伺ったうえでお渡しします。
 
-以下、受け取った値を `{username}` / `{password}` と表記します。リクエストでは `password` をそのままではなく SHA256（16進）にして送ります。
+以下、受け取った値を `{username}` / `{password}` と表記します。リクエストでは2つの認証を両方付けます。
+
+- Basic認証: `{username}` / `{password}` をそのまま
+- POSTボディの `password`: `{password}` の SHA256（16進）
 
 ---
 
 ## リクエスト
 
-`POST`。ボディに `stmt`（SELECT文）と `password`（パスワードの SHA256・16進）を渡す。レスポンスは下記の形の JSON。
+`POST`。Basic認証（`{username}` / `{password}`）を付け、ボディに `stmt`（SELECT文）と `password`（パスワードの SHA256・16進）を渡す。レスポンスは下記の形の JSON。
+
+```bash
+curl -u "{username}:{password}" -X POST "https://openchat-review.me/database/{username}/query" \
+  --data-urlencode "password={passwordのSHA256}" \
+  --data-urlencode "stmt=SELECT display_name FROM openchat_master LIMIT 5"
+```
 
 ```json
 {
@@ -33,7 +42,7 @@ X（旧Twitter）の [@openchat_graph](https://x.com/openchat_graph) のDMでご
 ```
 
 - `data` が結果行の配列。`SELECT` した列名がキー。0件なら `[]`。
-- スキーマ定義（DDL）の取得は `/database/{username}/schema`（同じく `POST` + `password`）。
+- スキーマ定義（DDL）の取得は `/database/{username}/schema`（同じく `POST` + Basic認証 + `password`）。
 
 ---
 
@@ -71,6 +80,7 @@ X（旧Twitter）の [@openchat_graph](https://x.com/openchat_graph) のDMでご
 | 状況 | ステータス | `message` |
 | --- | --- | --- |
 | `{username}`（URLパス）が未登録 | 403 | `User not found` |
+| Basic認証が未指定／一致しない | 401 | `Basic authentication is required to access the database API. Sorry, we initially forgot to include this requirement in the docs.` |
 | `password` が一致しない／未指定 | 401 | `Authentication failed.` |
 | `stmt` が未指定 | 400 | `The "stmt" parameter is required and must be a string.` |
 | `SELECT` 以外 | 400 | `UPDATE / DELETE / INSERT statements are not allowed` |
@@ -84,7 +94,7 @@ X（旧Twitter）の [@openchat_graph](https://x.com/openchat_graph) のDMでご
 
 ## スキーマ
 
-カラム定義（DDL）は `POST /database/{username}/schema`（`password` 必須）で取得する。以下は各テーブルの概要のみ。
+カラム定義（DDL）は `POST /database/{username}/schema`（Basic認証 + `password` 必須）で取得する。以下は各テーブルの概要のみ。
 
 | テーブル | 概要 |
 | --- | --- |

--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -633,7 +633,6 @@ Route::path(
 //     大文字を含むキーは {username} に直接入れても照合できない。Basic認証は小文字化されない）
 //   - 登録ユーザー: Basic認証（username / 登録パスワード）に加えて、
 //     POSTボディの password（登録パスワードを SHA256 した16進文字列）も必要（二重認証）
-//   - {username} が adminApiKey の場合は従来どおり認証なしで許可（小文字のみのキー用）
 $databaseApiPostAuth = function (string $username, $password = null) {
     if (MimimalCmsConfig::$urlRoot !== '') {
         return false;
@@ -645,7 +644,8 @@ $databaseApiPostAuth = function (string $username, $password = null) {
         header('WWW-Authenticate: Basic realm="Database SQL API"');
         response([
             'status' => 'error',
-            'message' => 'Basic authentication is required to access the database API.',
+            'message' => 'Basic authentication is required to access the database API. '
+                . 'Sorry, we initially forgot to include this requirement in the docs.',
         ], 401)->send();
         exit;
     };
@@ -663,12 +663,7 @@ $databaseApiPostAuth = function (string $username, $password = null) {
         $requireBasicAuth();
     }
 
-    // 2. {username} に adminApiKey（従来方式・小文字のみのキー用）
-    if ($username === SecretsConfig::$adminApiKey) {
-        return true;
-    }
-
-    // 3. 登録ユーザー: Basic認証 + POSTの password（SHA256）の二重認証
+    // 2. 登録ユーザー: Basic認証 + POSTの password（SHA256）の二重認証
     $apiUsers = class_exists(ApiUser::class) ? ApiUser::$apiUser : [];
     foreach ($apiUsers as $apiUser) {
         if ($apiUser['username'] === $username) {
@@ -689,7 +684,7 @@ $databaseApiPostAuth = function (string $username, $password = null) {
         }
     }
 
-    // 4. 未登録ユーザーは 403
+    // 3. 未登録ユーザーは 403
     response([
         'status' => 'error',
         'message' => 'User not found',


### PR DESCRIPTION
PR #427 / #431 の仕上げ。

- 管理者認証は username=admin の Basic認証のみに一本化（adminApiKey をURLに直接入れる旧方式を削除）
- Basic認証エラーのメッセージに、ドキュメント記載漏れへのお詫びを英語で追加
- API_README.md に Basic認証＋POST password（SHA256）の二重認証を明記し、curl例を追加

動作確認済み: 旧方式=403 / admin Basicのみ=200 / 登録ユーザー二重=200 / Basicなし=401(新メッセージ) / PHPStanパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)