### PR TITLE
[PROD] skip-post: データAPIの収集対策をCloudflareに一本化しアプリ側の拒否処理を削除

### DIFF
--- a/.github/scripts/test-urls.sh
+++ b/.github/scripts/test-urls.sh
@@ -437,7 +437,7 @@ main() {
     fi
     echo ""
 
-    # 独自ヘッダー検証のテスト（ヘッダー無しのAPI直叩きは404が期待される結果）
+    # 独自ヘッダー検証のテスト（Cloudflare側で検証。ヘッダー無しの直叩きは404が期待される結果）
     log "API独自ヘッダー検証のテスト"
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
     echo -n "Testing: ${BASE_URL}/oclist (without ${API_CLIENT_HEADER}) ... " | tee -a "$LOG_FILE"

--- a/.github/scripts/test-urls.sh
+++ b/.github/scripts/test-urls.sh
@@ -437,20 +437,6 @@ main() {
     fi
     echo ""
 
-    # 独自ヘッダー検証のテスト（Cloudflare側で検証。ヘッダー無しの直叩きは404が期待される結果）
-    log "API独自ヘッダー検証のテスト"
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    echo -n "Testing: ${BASE_URL}/oclist (without ${API_CLIENT_HEADER}) ... " | tee -a "$LOG_FILE"
-    status_code=$(curl -k -s -o /dev/null -w "%{http_code}" --max-time 30 "${BASE_URL}/oclist?page=0&limit=20&category=0&sub_category=&keyword=&list=all&sort=member&order=desc")
-    if [ "$status_code" = "404" ]; then
-        echo -e "${GREEN}OK (Status: ${status_code})${NC}" | tee -a "$LOG_FILE"
-        PASSED_TESTS=$((PASSED_TESTS + 1))
-    else
-        echo -e "${RED}FAILED (Status: ${status_code}, expected 404)${NC}" | tee -a "$LOG_FILE"
-        FAILED_TESTS=$((FAILED_TESTS + 1))
-    fi
-    echo ""
-
     # レコメンドページ - 日本語
     log "レコメンドページのテスト（日本語）"
     test_url "${BASE_URL}/recommend/%E3%83%9D%E3%82%B1%E3%83%83%E3%83%88%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%EF%BC%88%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%EF%BC%89" "レコメンド（ポケモン）"

--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -130,30 +130,22 @@ Route::path('oc/{open_chat_id}/chart', [OpenChatChartApiController::class, 'char
     ->matchStr('mode', regex: ['line', 'candlestick'])
     ->matchNum('meta', max: 1, emptyAble: true)
     ->match(function (FileStorageInterface $fileStorage) {
-        if (!verifyApiClientHeader())
-            return false;
         checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
     });
 
 Route::path('oclist', [OpenChatRankingPageApiController::class, 'index'])
     ->match(function (FileStorageInterface $fileStorage) {
-        if (!verifyApiClientHeader())
-            return false;
         checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
     });
 
 Route::path('oclist-tags', [OpenChatRankingPageApiController::class, 'themeTags'])
     ->match(function (FileStorageInterface $fileStorage) {
-        if (!verifyApiClientHeader())
-            return false;
         checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
     });
 
 Route::path('mylist-api', [MyListApiController::class, 'index'])
     ->match(function () {
         if (MimimalCmsConfig::$urlRoot !== '')
-            return false;
-        if (!verifyApiClientHeader())
             return false;
 
         noStore();
@@ -163,15 +155,13 @@ Route::path('recent-comment-api', [RecentCommentApiController::class, 'index'])
     ->match(function (RecentCommentListRepositoryInterface $recentCommentListRepository) {
         if (MimimalCmsConfig::$urlRoot !== '')
             return false;
-        if (!verifyApiClientHeader())
-            return false;
         $time = $recentCommentListRepository->getLatestCommentTime();
         if ($time) checkLastModified($time);
     })
     ->matchNum('open_chat_id', min: 1, emptyAble: true);
 
 Route::path('recent-comment-api/nocache', [RecentCommentApiController::class, 'nocache'])
-    ->match(fn() => MimimalCmsConfig::$urlRoot === '' && verifyApiClientHeader())
+    ->match(fn() => MimimalCmsConfig::$urlRoot === '')
     ->matchNum('open_chat_id', min: 1, emptyAble: true);
 
 // タグ関連のルーティング
@@ -307,8 +297,6 @@ Route::path(
     ->match(function (Reception $reception, FileStorageInterface $fileStorage) {
         if (MimimalCmsConfig::$urlRoot !== '')
             return false;
-        if (!verifyApiClientHeader())
-            return false;
         checkLastModified($fileStorage->getContents('@hourlyCronUpdatedAtDatetime'));
     });
 
@@ -327,7 +315,6 @@ Route::path(
     ->matchFile('image0', ['image/jpeg'], 8192, emptyAble: true, requestMethod: 'post')
     ->matchFile('image1', ['image/jpeg'], 8192, emptyAble: true, requestMethod: 'post')
     ->matchFile('image2', ['image/jpeg'], 8192, emptyAble: true, requestMethod: 'post')
-    ->match(fn() => verifyApiClientHeader(), 'get')
     ->match(
         function (string $text, string $name) {
             if (MimimalCmsConfig::$urlRoot !== '')

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -253,27 +253,6 @@ function checkLastModified(
 }
 
 /**
- * JSON APIがサイト内のJS(fetch)から呼ばれたことを示す独自ヘッダーを検証する
- *
- * routing.phpのmatchクロージャで使用することを想定した関数。
- * curl等でURLを直叩きする機械的なデータ収集（無料API扱い）への対策で、
- * フロントの fetch は全て X-Ocg-Client: 1 を付与している。
- *
- * 失敗時は no-store を設定して false を返す（→ 404）。no-store が無いと
- * Cloudflareのキャッシュ対象パス（/oclist 等）で拒否レスポンスがエッジに
- * キャッシュされ、正規ユーザーにも404が返る事故になるため必須。
- */
-function verifyApiClientHeader(): bool
-{
-    if (($_SERVER['HTTP_X_OCG_CLIENT'] ?? '') === '1') {
-        return true;
-    }
-
-    noStore();
-    return false;
-}
-
-/**
  * @return string 成功メッセージ
  * @throws \RuntimeException 失敗時
  */

--- a/app/Views/ranking_ban_content.php
+++ b/app/Views/ranking_ban_content.php
@@ -389,7 +389,7 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 if (opts.push) history.pushState(state, '', pageUrl(state));
                 setBusy(true);
                 const s = Object.assign({}, state);
-                // X-Ocg-Client: サイト内JSからのfetchであることを示す（無いとAPI側で404。直叩き収集対策）
+                // X-Ocg-Client: サイト内JSからのfetchであることを示す（Cloudflare側で検証。直叩き収集対策）
                 fetch(fragmentUrl(s), { signal: aborter.signal, headers: { 'X-Ocg-Client': '1' } })
                     .then((res) => {
                         if (res.ok) return res.text();

--- a/frontend/oc-app/src/comments/utils/utils.ts
+++ b/frontend/oc-app/src/comments/utils/utils.ts
@@ -39,7 +39,7 @@ export async function fetchApi<T>(url: string, method: string = 'GET', bodyData:
 
   const response = await fetch(url, {
     method,
-    // X-Ocg-Client: サイト内JSからのfetchであることを示す（無いとGET APIが404。直叩き収集対策）
+    // X-Ocg-Client: サイト内JSからのfetchであることを示す（Cloudflare側で検証。直叩き収集対策）
     headers: { 'Content-Type': 'application/json', 'X-Ocg-Client': '1' },
     body,
   })

--- a/frontend/oc-app/src/graph/util/fetcher.ts
+++ b/frontend/oc-app/src/graph/util/fetcher.ts
@@ -10,7 +10,7 @@ export default async function fetcher<T>(url: string) {
     return cache.data[cacheIndex] as T
   }
 
-  // X-Ocg-Client: サイト内JSからのfetchであることを示す（無いとAPI側で404。直叩き収集対策）
+  // X-Ocg-Client: サイト内JSからのfetchであることを示す（Cloudflare側で検証。直叩き収集対策）
   const response = await fetch(url, { headers: { 'X-Ocg-Client': '1' } })
 
   const data: T | ErrorResponse = await response.json()

--- a/frontend/ranking/src/components/RecommendThemeShelf.tsx
+++ b/frontend/ranking/src/components/RecommendThemeShelf.tsx
@@ -14,7 +14,7 @@ import { useIsRightScrollable } from '../hooks/ScrollableHooks'
 const recommendHref = (slug: string) => `${rankingArgDto.urlRoot}/recommend/${slug}`
 
 const fetcher = (url: string): Promise<ThemeTag[]> =>
-  // X-Ocg-Client: サイト内JSからのfetchであることを示す（無いとAPI側で404。直叩き収集対策）
+  // X-Ocg-Client: サイト内JSからのfetchであることを示す（Cloudflare側で検証。直叩き収集対策）
   fetch(url, { headers: { Accept: 'application/json', 'X-Ocg-Client': '1' } }).then((r) =>
     r.ok ? r.json() : []
   )

--- a/frontend/ranking/src/hooks/InfiniteFetchApi.ts
+++ b/frontend/ranking/src/hooks/InfiniteFetchApi.ts
@@ -29,7 +29,7 @@ export class RateLimitError extends Error {
 export const RATE_LIMIT_RETRY_SECONDS = 10
 
 async function fetchApi<T>(url: string) {
-  // X-Ocg-Client: サイト内JSからのfetchであることを示す（無いとAPI側で404。直叩き収集対策）
+  // X-Ocg-Client: サイト内JSからのfetchであることを示す（Cloudflare側で検証。直叩き収集対策）
   let response = await fetch(url, { headers: { 'X-Ocg-Client': '1' } })
 
   // 429: スケルトンを出したまま(SWRのisValidatingが続く)10秒待って1回だけ再試行

--- a/public/js/fetchComment.js
+++ b/public/js/fetchComment.js
@@ -73,7 +73,7 @@ async function fetchComment(url = '/recent-comment-api', openChatId = 0) {
   const query = openChatId ? '?open_chat_id=' + openChatId : ''
 
   try {
-    // X-Ocg-Client: サイト内JSからのfetchであることを示す（無いとAPI側で404。直叩き収集対策）
+    // X-Ocg-Client: サイト内JSからのfetchであることを示す（Cloudflare側で検証。直叩き収集対策）
     const res = await fetch(url + query, { headers: { 'X-Ocg-Client': '1' } })
     if (res.status !== 200) {
       throw new Error()


### PR DESCRIPTION
stg PR: #435

データAPIの直叩き収集対策（X-Ocg-Client ヘッダー検証）を Cloudflare 側に一本化し、アプリ側の検証・拒否コードを削除。フロントのヘッダー付与は残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)