### PR TITLE
[STG] skip-ci: fix: ローソク足グラフの日付ラベルがスマホで重なって読めなくなる問題を修正

### DIFF
--- a/frontend/oc-app/src/graph/classes/ChartJS/Factories/buildOptions.ts
+++ b/frontend/oc-app/src/graph/classes/ChartJS/Factories/buildOptions.ts
@@ -194,14 +194,15 @@ export default function buildOptions(
   }
 
   // ローソク足モード: CandlestickControllerがautoSkipを極端に効かせるため無効化
-  // 1週間・1ヶ月は全ラベル表示（折れ線と同じ）。全期間のみcallbackで間引く
+  // autoSkipが無いと狭い画面で全ラベルが重なって潰れるため、月・全期間はcallbackで間引く
+  // （折れ線はautoSkipが自動で間引くが、ローソク足では手動間引きが必須）
   if (ocChart.getMode() === 'candlestick') {
     options.scales!.x!.ticks!.autoSkip = false
 
     const dataLen = ocChart.ohlcData.length
 
-    if (limit === 0) {
-      const maxLabels = 20
+    if (!isWeekly) {
+      const maxLabels = limit === 31 ? 15 : 20
       const step = Math.max(1, Math.ceil(dataLen / maxLabels))
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       options.scales!.x!.ticks!.callback = function (this: any, _val: any, index: number) {


### PR DESCRIPTION
## 問題の概要

ローソク足グラフの1ヶ月タブで、X軸の日付ラベル31個が全て描画され、スマホなど狭い画面で重なって黒く潰れて読めなくなっていた。

### 原因

#430 相当の修正（1b1e68e9d）で「折れ線と同様に31個全て表示できる」として手動間引きを全期間タブのみに限定したが、前提が誤りだった。折れ線は Chart.js の autoSkip が画面幅に応じて自動で間引くのに対し、ローソク足は autoSkip を無効化しているため、手動間引きを外すと全ラベルがそのまま描画される。

## 対処内容

[`buildOptions.ts`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/fix/candlestick-label-overlap/frontend/oc-app/src/graph/classes/ChartJS/Factories/buildOptions.ts#L196-L213) の間引きロジックを元に戻した（1ヶ月=15個・全期間=20個、1週間のみ全表示）。再発防止のため「autoSkip 無効化中は手動間引きが必須」である理由をコメントに明記。

ダークテーマ凡例の修正（同コミットの buildPlugin.ts 側）は問題ないためそのまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)