### PR TITLE
[STG] fix: ルームページとグラフが間欠的に数秒〜30秒固まる問題を修正

### DIFF
--- a/app/Models/Repositories/AllRoomStatsRepository.php
+++ b/app/Models/Repositories/AllRoomStatsRepository.php
@@ -87,7 +87,7 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
     {
         $today = OpenChatServicesUtility::getCronModifiedStatsMemberDate();
 
-        SQLiteOcgraphSqlapi::connect(['mode' => '?mode=ro']);
+        SQLiteOcgraphSqlapi::connect(SQLiteOcgraphSqlapi::WEB_READER);
 
         // 現存ルーム（両方の日付にデータあり）の増減
         $existing = SQLiteOcgraphSqlapi::execute(
@@ -150,7 +150,7 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
         $today = OpenChatServicesUtility::getCronModifiedStatsMemberDate();
         $pastDate = date('Y-m-d', strtotime($modifier, strtotime($today)));
 
-        SQLiteOcgraphSqlapi::connect(['mode' => '?mode=ro']);
+        SQLiteOcgraphSqlapi::connect(SQLiteOcgraphSqlapi::WEB_READER);
 
         $result = SQLiteOcgraphSqlapi::execute(
             "SELECT
@@ -265,7 +265,7 @@ class AllRoomStatsRepository implements AllRoomStatsRepositoryInterface
         // SQLite: カテゴリー別 1ヶ月増減
         $today = OpenChatServicesUtility::getCronModifiedStatsMemberDate();
 
-        SQLiteOcgraphSqlapi::connect(['mode' => '?mode=ro']);
+        SQLiteOcgraphSqlapi::connect(SQLiteOcgraphSqlapi::WEB_READER);
 
         // SQLiteのnamed parameterは同一名を複数回バインドできないため、today2~4を別名で渡す
         $trendRows = SQLiteOcgraphSqlapi::fetchAll(

--- a/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
+++ b/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
@@ -131,7 +131,7 @@ class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
         $since = (clone $anchorDate)->modify("-{$days} days")->format('Y-m-d');
         $category = self::RANK_CATEGORY_OVERALL;
 
-        SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPosition::connect(SQLiteRankingPosition::WEB_READER);
         $rows = SQLiteRankingPosition::fetchAll(
             "SELECT date, MIN(position) AS value
              FROM ranking
@@ -193,7 +193,7 @@ class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
         // DateTime 由来の Y-m-d 固定書式なのでインライン化(注入リスクなし)。
         $since = (clone $anchorDate)->modify("-{$days} days")->format('Y-m-d');
 
-        SQLiteStatistics::connect(['mode' => '?mode=ro']);
+        SQLiteStatistics::connect(SQLiteStatistics::WEB_READER);
 
         $rows = SQLiteStatistics::fetchAll(
             "WITH bounds AS (

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -25,9 +25,28 @@ abstract class AbstractSQLite extends DB implements DBInterface
      * - 最大待機合計は約2.4秒（+ジッター）に制限。殺到時にワーカーを長時間塞ぐと
      *   fpm プール枯渇で別の障害になるため、無制限には待たない
      */
+    /**
+     * Web リクエスト中の読み取り接続の共通プロファイル。
+     *
+     * - mode=rw: WAL の -shm(wal-index 共有メモリ)を共有し「読みは書きを待たない」を使う。
+     *   mode=ro は -shm に触れないため接続のたびに私的 wal-index 再構築＋DBファイルの
+     *   排他ロックが走り、バッチの書き込み・checkpoint と衝突して読み取り同士まで
+     *   直列化する（2026-06-12 の /oc 間欠20秒ストール障害）
+     * - busyTimeout=20ms: 1回のロック待ちを短く刻む。続きはリトライ側のジッター付き
+     *   待機で互いにずらして再試行する（下記 READER_RETRY_*）。既定の10秒のまま rw 化
+     *   すると競合時に全リクエストが10秒待ちになる（PR #367→#370 差し戻しの事故）
+     */
+    public const WEB_READER = ['mode' => '?mode=rw', 'busyTimeout' => 20];
+
     protected const MAX_RETRIES = 7;
+    // 書き込み(rwc)接続用: busy_timeout=10秒が主に待つので、間隔はゆっくり長く
     private const RETRY_BASE_WAIT_MICROSECONDS = 50000;   // 初回 0.05 秒
     private const RETRY_MAX_WAIT_MICROSECONDS = 800000;   // 1回あたり上限 0.8 秒
+    // 読み取り(ro/rw)接続用: 最初は細かく刻んでジッターで互いにずらし（典型の競合は
+    // 数十msで抜ける）、続くなら指数的に粘る。10回合計でも最悪2秒程度で諦める
+    protected const READER_MAX_RETRIES = 10;
+    private const READER_RETRY_BASE_WAIT_MICROSECONDS = 5000;   // 初回 5ms
+    private const READER_RETRY_MAX_WAIT_MICROSECONDS = 300000;  // 1回あたり上限 0.3 秒
     private const RETRYABLE_ERRORS = [
         'database disk image is malformed',
         'database is locked',
@@ -36,12 +55,10 @@ abstract class AbstractSQLite extends DB implements DBInterface
     ];
 
     /**
-     * @param ?array{storageFileKey: string, mode?: ?string, busyTimeout?: ?int} $config
+     * @param ?array{storageFileKey?: string, filePath?: string, mode?: ?string, busyTimeout?: ?int} $config
      *  mode default is '?mode=rwc' / busyTimeout default is 10000ms。
-     *  busyTimeout はロック競合時に各クエリが待つ上限。ページ表示の途中で読む
-     *  「無くても表示できるデータ」は短い値＋呼び出し側の null フォールバックで
-     *  ロック待ちがレスポンスを塞がないようにする（PR #367 → #370 差し戻しの教訓:
-     *  rw 化だけだと競合時に busy_timeout=10秒 を全員が待ち全ページが激遅化する）。
+     *  Web リクエスト中の読み取りは self::WEB_READER を渡す（rw + 短い busy_timeout）。
+     *  バッチの読み取りは '?mode=rw' のみ指定し busyTimeout は既定の10秒のままにする。
      */
     /** @var array<class-string, string> 接続中のモード（接続使い回し判定用） */
     private static array $connectedMode = [];
@@ -63,11 +80,13 @@ abstract class AbstractSQLite extends DB implements DBInterface
             static::$pdo = null;
         }
 
-        if (empty($config['storageFileKey'])) {
-            throw new \InvalidArgumentException('storageFileKey is required');
+        if (empty($config['storageFileKey']) && empty($config['filePath'])) {
+            throw new \InvalidArgumentException('storageFileKey or filePath is required');
         }
 
-        $sqliteFilePath = app(FileStorageInterface::class)->getStorageFilePath($config['storageFileKey']);
+        // filePath は多言語パスを持たない固定パスDB（ocgraph_sqlapi 等）用
+        $sqliteFilePath = $config['filePath']
+            ?? app(FileStorageInterface::class)->getStorageFilePath($config['storageFileKey']);
 
         static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode);
         self::$connectedMode[static::class] = $mode;
@@ -91,10 +110,16 @@ abstract class AbstractSQLite extends DB implements DBInterface
 
     public static function execute(string $query, ?array $params = null): \PDOStatement
     {
+        // 読み取り接続(ro/rw)は busy_timeout が短い前提で、待ちの主体はジッター付きリトライ
+        $isReader = !str_contains(self::$connectedMode[static::class] ?? '?mode=rwc', 'rwc');
+        $maxRetries = $isReader ? static::READER_MAX_RETRIES : static::MAX_RETRIES;
+        $baseWait = $isReader ? self::READER_RETRY_BASE_WAIT_MICROSECONDS : self::RETRY_BASE_WAIT_MICROSECONDS;
+        $maxWait = $isReader ? self::READER_RETRY_MAX_WAIT_MICROSECONDS : self::RETRY_MAX_WAIT_MICROSECONDS;
+
         $attempts = 0;
         $lastException = null;
 
-        while ($attempts < static::MAX_RETRIES) {
+        while ($attempts < $maxRetries) {
             try {
                 return parent::execute($query, $params);
             } catch (\PDOException $e) {
@@ -113,17 +138,14 @@ abstract class AbstractSQLite extends DB implements DBInterface
                 $lastException = $e;
                 $attempts++;
 
-                if ($attempts < static::MAX_RETRIES) {
-                    $wait = min(
-                        self::RETRY_BASE_WAIT_MICROSECONDS * (2 ** ($attempts - 1)),
-                        self::RETRY_MAX_WAIT_MICROSECONDS
-                    );
+                if ($attempts < $maxRetries) {
+                    $wait = min($baseWait * (2 ** ($attempts - 1)), $maxWait);
                     // ±50% ジッター（同時リトライの再衝突を分散）
                     usleep(random_int((int)($wait / 2), (int)($wait * 1.5)));
                 }
             }
         }
 
-        throw $lastException ?? new \RuntimeException("Failed to execute query after " . static::MAX_RETRIES . " attempts.");
+        throw $lastException ?? new \RuntimeException("Failed to execute query after {$maxRetries} attempts.");
     }
 }

--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -25,7 +25,7 @@ abstract class AbstractSQLite extends DB implements DBInterface
      * - 最大待機合計は約2.4秒（+ジッター）に制限。殺到時にワーカーを長時間塞ぐと
      *   fpm プール枯渇で別の障害になるため、無制限には待たない
      */
-    private const MAX_RETRIES = 7;
+    protected const MAX_RETRIES = 7;
     private const RETRY_BASE_WAIT_MICROSECONDS = 50000;   // 初回 0.05 秒
     private const RETRY_MAX_WAIT_MICROSECONDS = 800000;   // 1回あたり上限 0.8 秒
     private const RETRYABLE_ERRORS = [
@@ -36,7 +36,12 @@ abstract class AbstractSQLite extends DB implements DBInterface
     ];
 
     /**
-     * @param ?array{storageFileKey: string, mode?: ?string} $config mode default is '?mode=rwc'
+     * @param ?array{storageFileKey: string, mode?: ?string, busyTimeout?: ?int} $config
+     *  mode default is '?mode=rwc' / busyTimeout default is 10000ms。
+     *  busyTimeout はロック競合時に各クエリが待つ上限。ページ表示の途中で読む
+     *  「無くても表示できるデータ」は短い値＋呼び出し側の null フォールバックで
+     *  ロック待ちがレスポンスを塞がないようにする（PR #367 → #370 差し戻しの教訓:
+     *  rw 化だけだと競合時に busy_timeout=10秒 を全員が待ち全ページが激遅化する）。
      */
     /** @var array<class-string, string> 接続中のモード（接続使い回し判定用） */
     private static array $connectedMode = [];
@@ -68,11 +73,12 @@ abstract class AbstractSQLite extends DB implements DBInterface
         self::$connectedMode[static::class] = $mode;
 
         // Set busy timeout for all modes (including read-only) to handle concurrent access
-        static::$pdo->exec('PRAGMA busy_timeout=10000');
+        static::$pdo->exec('PRAGMA busy_timeout=' . (int)($config['busyTimeout'] ?? 10000));
 
-        // Apply write-related PRAGMA settings only for read-write mode
-        // Read-only mode (mode=ro) cannot execute journal_mode and synchronous
-        if (!str_contains($mode, 'mode=ro')) {
+        // WAL/synchronous の設定は書き込み側(rwc/既定)の接続だけが行う。
+        // mode=ro は実行不可、mode=rw(読み取り用途) は journal_mode の実行自体が
+        // ロックを取り読み書きの競合を増やすため実行しない（WAL化は一度行えば永続する）
+        if (str_contains($mode, 'rwc')) {
             // Enable WAL mode for concurrent read/write performance
             static::$pdo->exec('PRAGMA journal_mode=WAL');
 
@@ -88,7 +94,7 @@ abstract class AbstractSQLite extends DB implements DBInterface
         $attempts = 0;
         $lastException = null;
 
-        while ($attempts < self::MAX_RETRIES) {
+        while ($attempts < static::MAX_RETRIES) {
             try {
                 return parent::execute($query, $params);
             } catch (\PDOException $e) {
@@ -107,7 +113,7 @@ abstract class AbstractSQLite extends DB implements DBInterface
                 $lastException = $e;
                 $attempts++;
 
-                if ($attempts < self::MAX_RETRIES) {
+                if ($attempts < static::MAX_RETRIES) {
                     $wait = min(
                         self::RETRY_BASE_WAIT_MICROSECONDS * (2 ** ($attempts - 1)),
                         self::RETRY_MAX_WAIT_MICROSECONDS
@@ -118,6 +124,6 @@ abstract class AbstractSQLite extends DB implements DBInterface
             }
         }
 
-        throw $lastException ?? new \RuntimeException("Failed to execute query after " . self::MAX_RETRIES . " attempts.");
+        throw $lastException ?? new \RuntimeException("Failed to execute query after " . static::MAX_RETRIES . " attempts.");
     }
 }

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -13,9 +13,15 @@ use App\Services\Storage\FileStorageInterface;
  * （レンダリングはリクエスト時に oc_narrative_section テンプレートが行う）。
  * DB/テーブルは他のSQLite同様、setup(setup/schema/sqlite/oc_page_cache.sql)と prod-sync が用意する。
  *
- * - 読み: /oc 表示時に PK 一発 SELECT（mode=ro。読み取り専用接続。書き込み権限や
- *   WAL チェックポイントを発生させず、Web(www-data)から安全に読むため）。
- *   キャッシュ未生成（DBファイル無し・該当行無し）は null を返し、呼び出し側は空表示にフォールバックする。
+ * - 読み: /oc 表示時に PK 一発 SELECT（mode=rw・busy_timeout 200ms）。
+ *   mode=ro は WAL の -shm(wal-index 共有メモリ)に触れないため、接続のたびに
+ *   私的 wal-index 再構築＋DBファイルの排他ロックが走り、毎時バッチの書き込み・
+ *   checkpoint と衝突して /oc が間欠的に数秒〜数十秒固まる（2026-06-12 本番障害）。
+ *   rw なら -shm を共有でき WAL 本来の「読みは書きをブロックしない」が機能する。
+ *   busy_timeout を既定の10秒のままにすると競合時に全リクエストが10秒待ちになる
+ *   （PR #367→#370 差し戻しの事故）ため、無くても表示できるデータであるこの読みは
+ *   200ms で諦めて null（空表示）にフォールバックする。
+ *   キャッシュ未生成（DBファイル無し・該当行無し）も同様に null を返す。
  * - 書き: 背景バッチ（OcPageCacheGenerator）が単一プロセスで INSERT OR REPLACE する。
  *   値はクォートを含むため、SQLiteInsertImporter（値を素で埋め込む・OR IGNORE）は使わず、
  *   パラメータ化したプリペアドステートメント + トランザクションで upsert する。
@@ -36,7 +42,7 @@ class OcPageCacheRepository
     public function get(int $open_chat_id): ?array
     {
         try {
-            SQLiteOcPageCache::connect(['mode' => '?mode=ro']);
+            SQLiteOcPageCache::connect(['mode' => '?mode=rw', 'busyTimeout' => 200]);
             $row = SQLiteOcPageCache::fetch(
                 'SELECT narrative_data FROM oc_page_cache WHERE open_chat_id = ?',
                 [$open_chat_id]

--- a/app/Models/SQLite/Repositories/OcPageCacheRepository.php
+++ b/app/Models/SQLite/Repositories/OcPageCacheRepository.php
@@ -13,14 +13,14 @@ use App\Services\Storage\FileStorageInterface;
  * （レンダリングはリクエスト時に oc_narrative_section テンプレートが行う）。
  * DB/テーブルは他のSQLite同様、setup(setup/schema/sqlite/oc_page_cache.sql)と prod-sync が用意する。
  *
- * - 読み: /oc 表示時に PK 一発 SELECT（mode=rw・busy_timeout 200ms）。
+ * - 読み: /oc 表示時に PK 一発 SELECT（WEB_READER: mode=rw・busy_timeout 20ms）。
  *   mode=ro は WAL の -shm(wal-index 共有メモリ)に触れないため、接続のたびに
  *   私的 wal-index 再構築＋DBファイルの排他ロックが走り、毎時バッチの書き込み・
  *   checkpoint と衝突して /oc が間欠的に数秒〜数十秒固まる（2026-06-12 本番障害）。
  *   rw なら -shm を共有でき WAL 本来の「読みは書きをブロックしない」が機能する。
  *   busy_timeout を既定の10秒のままにすると競合時に全リクエストが10秒待ちになる
- *   （PR #367→#370 差し戻しの事故）ため、無くても表示できるデータであるこの読みは
- *   200ms で諦めて null（空表示）にフォールバックする。
+ *   （PR #367→#370 差し戻しの事故）ため、短い busy を刻んでジッターでずらして再試行し、
+ *   無くても表示できるデータであるこの読みは2回で諦めて null（空表示）にフォールバックする。
  *   キャッシュ未生成（DBファイル無し・該当行無し）も同様に null を返す。
  * - 書き: 背景バッチ（OcPageCacheGenerator）が単一プロセスで INSERT OR REPLACE する。
  *   値はクォートを含むため、SQLiteInsertImporter（値を素で埋め込む・OR IGNORE）は使わず、
@@ -42,7 +42,7 @@ class OcPageCacheRepository
     public function get(int $open_chat_id): ?array
     {
         try {
-            SQLiteOcPageCache::connect(['mode' => '?mode=rw', 'busyTimeout' => 200]);
+            SQLiteOcPageCache::connect(SQLiteOcPageCache::WEB_READER);
             $row = SQLiteOcPageCache::fetch(
                 'SELECT narrative_data FROM oc_page_cache WHERE open_chat_id = ?',
                 [$open_chat_id]

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionOhlcRepository.php
@@ -39,7 +39,7 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
             ORDER BY
                 date ASC";
 
-        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPositionOhlc::connect(SQLiteRankingPositionOhlc::WEB_READER);
         $result = SQLiteRankingPositionOhlc::fetchAll($query, ['open_chat_id' => $open_chat_id, 'category' => $category, 'type' => $typeValue]);
 
         return $result;
@@ -68,7 +68,7 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
 
         $since = '-' . max(1, $days) . ' days';
 
-        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPositionOhlc::connect(SQLiteRankingPositionOhlc::WEB_READER);
         $row = SQLiteRankingPositionOhlc::fetch($query, [
             'open_chat_id' => $open_chat_id,
             'category' => $category,
@@ -112,7 +112,7 @@ class SqliteRankingPositionOhlcRepository implements RankingPositionOhlcReposito
                 AND type = :type
                 AND date >= date('now', :since)";
 
-        SQLiteRankingPositionOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPositionOhlc::connect(SQLiteRankingPositionOhlc::WEB_READER);
         $row = SQLiteRankingPositionOhlc::fetch($query, [
             'open_chat_id' => $open_chat_id,
             'category' => $category,

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionPageRepository.php
@@ -39,7 +39,7 @@ class SqliteRankingPositionPageRepository implements RankingPositionPageReposito
 
         $dto = new RankingPositionPageRepoDto;
 
-        SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPosition::connect(SQLiteRankingPosition::WEB_READER);
 
         $result = SQLiteRankingPosition::fetchAll($query, compact('open_chat_id', 'category'));
 

--- a/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
+++ b/app/Models/SQLite/Repositories/RankingPosition/SqliteRankingPositionRepository.php
@@ -64,7 +64,7 @@ class SqliteRankingPositionRepository implements RankingPositionRepositoryInterf
     ): array {
         $result = [];
 
-        SQLiteRankingPosition::connect(['mode' => '?mode=ro']);
+        SQLiteRankingPosition::connect(SQLiteRankingPosition::WEB_READER);
 
         foreach (['ranking', 'rising'] as $tableName) {
             $row = SQLiteRankingPosition::fetch(

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsOhlcRepository.php
@@ -34,7 +34,7 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
             ORDER BY
                 date ASC";
 
-        SQLiteStatisticsOhlc::connect(['mode' => '?mode=ro']);
+        SQLiteStatisticsOhlc::connect(SQLiteStatisticsOhlc::WEB_READER);
         $result = SQLiteStatisticsOhlc::fetchAll($query, compact('open_chat_id'));
 
         return $result;
@@ -55,7 +55,7 @@ class SqliteStatisticsOhlcRepository implements StatisticsOhlcRepositoryInterfac
         $emptyResult = ['all_count' => 0, 'week_count' => 0, 'month_count' => 0];
 
         try {
-            SQLiteStatisticsOhlc::connect(['mode' => '?mode=ro']);
+            SQLiteStatisticsOhlc::connect(SQLiteStatisticsOhlc::WEB_READER);
         } catch (\PDOException) {
             // DBファイル未作成（OHLC統計の記録開始前の環境）は「データ無し」として扱う
             return $emptyResult;

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsPageRepository.php
@@ -22,7 +22,7 @@ class SqliteStatisticsPageRepository implements StatisticsPageRepositoryInterfac
             ORDER BY
                 date ASC";
 
-        SQLiteStatistics::connect(['mode' => '?mode=ro']);
+        SQLiteStatistics::connect(SQLiteStatistics::WEB_READER);
         $result = SQLiteStatistics::fetchAll($query, compact('open_chat_id'));
 
         return $result;

--- a/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
+++ b/app/Models/SQLite/Repositories/Statistics/SqliteStatisticsRepository.php
@@ -178,7 +178,7 @@ class SqliteStatisticsRepository implements StatisticsRepositoryInterface
             $params['base_date'] = $baseDate;
         }
 
-        SQLiteStatistics::connect(['mode' => '?mode=ro']);
+        SQLiteStatistics::connect(SQLiteStatistics::WEB_READER);
         $row = SQLiteStatistics::fetch($query, $params);
 
         $empty = [

--- a/app/Models/SQLite/SQLiteOcPageCache.php
+++ b/app/Models/SQLite/SQLiteOcPageCache.php
@@ -11,11 +11,11 @@ class SQLiteOcPageCache extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * /oc 表示の途中で読まれる「無くても表示できる」DBのため、ロック競合時に
-     * リトライ待機の積み上げ（約2.4秒）でページを塞がない。
-     * 読み手はさらに busyTimeout を短くして null フォールバックする。
+     * /oc 表示の途中で読まれる「無くても表示できる」DBのため、読み取りは2回
+     * （busy 20ms×2＋ジッター ≈ 最悪50ms程度）で諦めて null フォールバックする。
+     * 書き込み（背景バッチ）は既定のリトライのまま。
      */
-    protected const MAX_RETRIES = 2;
+    protected const READER_MAX_RETRIES = 2;
 
     /**
      * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'

--- a/app/Models/SQLite/SQLiteOcPageCache.php
+++ b/app/Models/SQLite/SQLiteOcPageCache.php
@@ -11,13 +11,21 @@ class SQLiteOcPageCache extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string} $config mode default is '?mode=rwc'
+     * /oc 表示の途中で読まれる「無くても表示できる」DBのため、ロック競合時に
+     * リトライ待機の積み上げ（約2.4秒）でページを塞がない。
+     * 読み手はさらに busyTimeout を短くして null フォールバックする。
+     */
+    protected const MAX_RETRIES = 2;
+
+    /**
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
         return parent::connect([
             'storageFileKey' => 'sqliteOcPageCacheDb',
-            'mode' => $config['mode'] ?? null
+            'mode' => $config['mode'] ?? null,
+            'busyTimeout' => $config['busyTimeout'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteOcgraphSqlapi.php
+++ b/app/Models/SQLite/SQLiteOcgraphSqlapi.php
@@ -21,37 +21,19 @@ class SQLiteOcgraphSqlapi extends AbstractSQLite implements DBInterface
      * Note: This database is Japanese-only and does not use multi-language paths.
      * It connects to a fixed path instead of using FileStorageService::getStorageFilePath().
      *
-     * Optimizations applied:
-     * - WAL (Write-Ahead Logging) mode for better concurrent read/write performance
-     * - NORMAL synchronous mode for balanced performance and durability
-     * - 10-second busy timeout to handle concurrent access
+     * 接続の実体は AbstractSQLite::connect に委譲する（busy_timeout・モード追跡付きの
+     * 接続使い回し・WAL等のPRAGMA適用条件を全SQLiteで統一するため。以前の独自実装は
+     * mode=ro だと busy_timeout が未設定・最初に開いたモードを使い回す問題があった）。
      *
-     * @param ?array $config array{mode?: ?string} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
      * @return \PDO
      */
     public static function connect(?array $config = null): \PDO
     {
-        if (static::$pdo !== null) {
-            return static::$pdo;
-        }
-
-        $mode = $config['mode'] ?? '?mode=rwc';
-        static::$pdo = new \PDO('sqlite:file:' . AppConfig::SQLITE_OCGRAPH_SQLAPI_DB_PATH . $mode);
-
-        // Apply PRAGMA settings only for read-write mode
-        // Read-only mode (mode=ro) cannot execute PRAGMA statements
-        if (!str_contains($mode, 'mode=ro')) {
-            // Apply SQLite optimizations (inherited from AbstractSQLite pattern)
-            // Enable WAL mode for concurrent read/write performance
-            static::$pdo->exec('PRAGMA journal_mode=WAL');
-
-            // Set synchronous mode to NORMAL for balanced performance
-            static::$pdo->exec('PRAGMA synchronous=NORMAL');
-
-            // Set busy timeout to 10 seconds to handle concurrent access
-            static::$pdo->exec('PRAGMA busy_timeout=10000');
-        }
-
-        return static::$pdo;
+        return parent::connect([
+            'filePath' => AppConfig::SQLITE_OCGRAPH_SQLAPI_DB_PATH,
+            'mode' => $config['mode'] ?? null,
+            'busyTimeout' => $config['busyTimeout'] ?? null,
+        ]);
     }
 }

--- a/app/Models/SQLite/SQLiteRankingPosition.php
+++ b/app/Models/SQLite/SQLiteRankingPosition.php
@@ -11,13 +11,14 @@ class SQLiteRankingPosition extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
         return parent::connect([
             'storageFileKey' => 'sqliteRankingPositionDb',
-            'mode' => $config['mode'] ?? null
+            'mode' => $config['mode'] ?? null,
+            'busyTimeout' => $config['busyTimeout'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteRankingPositionOhlc.php
+++ b/app/Models/SQLite/SQLiteRankingPositionOhlc.php
@@ -11,13 +11,14 @@ class SQLiteRankingPositionOhlc extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
         return parent::connect([
             'storageFileKey' => 'sqliteRankingPositionOhlcDb',
-            'mode' => $config['mode'] ?? null
+            'mode' => $config['mode'] ?? null,
+            'busyTimeout' => $config['busyTimeout'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteStatistics.php
+++ b/app/Models/SQLite/SQLiteStatistics.php
@@ -11,13 +11,14 @@ class SQLiteStatistics extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
         return parent::connect([
             'storageFileKey' => 'sqliteStatisticsDb',
-            'mode' => $config['mode'] ?? null
+            'mode' => $config['mode'] ?? null,
+            'busyTimeout' => $config['busyTimeout'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteStatisticsOhlc.php
+++ b/app/Models/SQLite/SQLiteStatisticsOhlc.php
@@ -11,13 +11,14 @@ class SQLiteStatisticsOhlc extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
         return parent::connect([
             'storageFileKey' => 'sqliteStatisticsOhlcDb',
-            'mode' => $config['mode'] ?? null
+            'mode' => $config['mode'] ?? null,
+            'busyTimeout' => $config['busyTimeout'] ?? null,
         ]);
     }
 }

--- a/app/Services/Cron/OcreviewApiDataImporter.php
+++ b/app/Services/Cron/OcreviewApiDataImporter.php
@@ -130,14 +130,16 @@ class OcreviewApiDataImporter
         // ターゲットデータベース（SQLite: ocgraph_sqlapi）に接続
         $this->targetPdo = SQLiteOcgraphSqlapi::connect();
 
-        // 統計データベース（SQLite: statistics）に読み取り専用で接続
+        // 統計データベース（SQLite: statistics）に読み取りで接続
+        // （mode=ro は WAL の -shm に触れず私的 wal-index＋排他ロック化するため rw で開く。
+        //   バッチは busy_timeout 既定10秒のまま長く待つ）
         $this->sqliteStatisticsPdo = SQLiteStatistics::connect([
-            'mode' => '?mode=ro'
+            'mode' => '?mode=rw'
         ]);
 
-        // ランキング履歴データベース（SQLite: ranking_position）に読み取り専用で接続
+        // ランキング履歴データベース（SQLite: ranking_position）に読み取りで接続
         $this->sqliteRankingPositionPdo = SQLiteRankingPosition::connect([
-            'mode' => '?mode=ro'
+            'mode' => '?mode=rw'
         ]);
     }
 


### PR DESCRIPTION
ルームページ(/oc/{id})の表示とグラフ読み込みが、本番・stgともに間欠的に2〜30秒固まっていた（2026-06-12発生）。ページを連打すると速く開くことがある、という症状。

## 原因

SQLite(WALモード)の読み取りを `mode=ro` で開いていたこと。

- `mode=ro` はWALの共有メモリ(-shm)に触れないため、接続のたびに「私的wal-indexの再構築＋DBファイルの排他ロック」が発生する
- 毎時バッチの書き込み・checkpointと衝突し、本来並行できる読み取り同士まで直列化していた
- 固まっている瞬間のPHPプロセスはカーネルのディスクロック待ち(D state)で、開いているファイルは毎回 oc_page_cache.db だった（サーバ内で実測）
- 遅延時間が「2.20秒」「10秒」に量子化していたのは、リトライ待機の合計(約2.4秒)と busy_timeout(10秒)の組み合わせ

直接の発火点は6/11導入の分析文キャッシュ(oc_page_cache)だが、グラフAPI・おすすめ・全ルーム統計の読み取りにも同じ `mode=ro` 構造があるため、まとめて直す。

## 対処（全SQLite読み取りに適用）

「大きく1回待つ」のをやめ、「短い待ちを刻んで、ジッターでずらしながら再試行」に統一:

- 共通プロファイル `WEB_READER` を導入: `mode=rw`（-shmを共有しWAL本来の並行読みを回復）＋ busy_timeout **20ms**
- 待ちの続きはジッター付きリトライで分散（5ms→10ms→…→上限0.3秒の指数、最大10回 ≒ 最悪約2秒。典型は数十msで抜ける）
- ページ直結の oc_page_cache 読みだけは2回（最悪50ms程度）で諦め、分析文を空表示にして即レスポンス
- バッチ(OcreviewApiDataImporter)の読み取りは rw 化のみ（busy 10秒のまま長く待つ）
- journal_mode等のPRAGMAは書き込み接続(rwc)だけが実行
- SQLiteOcgraphSqlapi の独自接続を共通実装に委譲（ro だと busy_timeout 未設定・最初に開いたモードを使い回すバグも解消）
- データAPI(/database)のユーザーSQL実行だけは多層防御として `mode=ro` を維持

単純なrw化だけだと競合時に全リクエストが10秒待ちになり全ページが激遅化する（PR #367→#370差し戻しの事故）。短く刻む＋ずらすがセットで必要。

## stg実測（同条件で連続リクエスト）

| 条件 | 1秒超の発生率 | 最大 |
| --- | --- | --- |
| 修正前(mode=ro) | 6.6% (13/198) | 14.4秒（別計測では30秒も） |
| ページのみ修正 | 0.2% (1/517) | 2.6秒 |
| 全体修正(ページ+グラフAPI) | 0.2% (5/2592)・グラフAPIはゼロ (0/1296, max 0.55秒) | 1.1秒 |
