### PR TITLE
[STG] fix: ダークテーマで読めないプルダウンとページ毎に違うフッター文字サイズを修正、Google検索結果の定型文ノイズも除去

### DIFF
--- a/app/Views/components/footer_inner.php
+++ b/app/Views/components/footer_inner.php
@@ -2,6 +2,8 @@
 <?php // 罫線(hr)レス: 区切りは余白のみ。値は tokens.css の --sp-* で一元管理 ?>
 <footer class="footer-elem-outer" style="padding: var(--sp-section-gap) 0 0 0;">
     <nav class="footer-link-box-outer">
+        <?php // フッターの定型文をGoogle検索スニペットに出さない。data-nosnippetはnavに付けられない(div/section/spanのみ)ためdivで包む ?>
+        <div data-nosnippet>
         <section class="unset footer-link-box" style="padding: 0 1rem;">
             <ul class="footer-link-inner">
                 <li><a class="unset" href="<?php echo url('') ?>"><?php echo t('トップ') ?></a></li>
@@ -50,5 +52,6 @@
                 <?php endforeach ?>
             </div>
             <div class="copyright">© <?php echo t('オプチャグラフ') ?><span><a class="unset" style="cursor: pointer;" href="https://github.com/Open-Chat-Graph" target="_blank">Project on GitHub @Open-Chat-Graph</a><span class="line-link-icon777"></span></span></div>
+        </div>
     </nav>
 </footer>

--- a/app/Views/components/oc_recommend_aside.php
+++ b/app/Views/components/oc_recommend_aside.php
@@ -11,6 +11,8 @@
 ?>
 <?php if (isset($similarSize) && $similarSize) : ?>
   <aside class="recommend-list-aside" id="similar-size-rooms">
+    <?php // おすすめ枠をGoogle検索スニペットから除外。data-nosnippetはasideに付けられない(div/section/spanのみ)ためdivで包む ?>
+    <div data-nosnippet>
     <?php viewComponent('similar_size_rooms', [
       'rooms'         => $similarSize['rooms'],
       'recommend'     => $similarSize['recommend'],
@@ -19,9 +21,12 @@
       'category'      => $oc['category'] ?? null,
       'tag'           => $oc['tag1'] ?? null,
     ]) ?>
+    </div>
   </aside>
 <?php elseif (!empty($recommend[3])) : ?>
   <aside class="recommend-list-aside" id="recommend-list-aside1">
+    <div data-nosnippet>
     <?php viewComponent('recommend_list2', ['recommend' => $recommend[3], 'member' => $oc['member'], 'tag' => '', 'id' => $oc['id']]) ?>
+    </div>
   </aside>
 <?php endif ?>

--- a/app/Views/components/recommend_list2.php
+++ b/app/Views/components/recommend_list2.php
@@ -21,6 +21,8 @@ if ($recommend->type === RecommendListType::Category) {
 
 ?>
 
+<?php // おすすめ枠をGoogle検索スニペットから除外。data-nosnippetはarticleに付けられない(div/section/spanのみ)ため外側をdivで包む ?>
+<div data-nosnippet>
 <article class="top-ranking not-rank" style="<?php echo $style ?? '' ?>">
     <header class="openchat-list-title-area unset">
         <div class="openchat-list-date unset ranking-url">
@@ -48,3 +50,4 @@ if ($recommend->type === RecommendListType::Category) {
     <?php endif ?>
 
 </article>
+</div>

--- a/app/Views/components/similar_size_rooms.php
+++ b/app/Views/components/similar_size_rooms.php
@@ -40,6 +40,8 @@ $scope = $isTagMode ? ($tag ?? '') : $categoryName;
 // tag_member / cat_member は「人数が近い」軸の並びなので順位は意味を持たず、付けない。
 $isRanked = $mode === 'tag_top';
 ?>
+<?php // おすすめ枠をGoogle検索スニペットから除外。data-nosnippetはarticleに付けられない(div/section/spanのみ)ため外側をdivで包む ?>
+<div data-nosnippet>
 <article class="top-ranking<?php echo $isRanked ? '' : ' not-rank' ?>" style="margin-top: 24px;" aria-labelledby="similar-size-rooms-title">
     <header style="display: block; margin: 0 0 12px 0;">
         <h2 id="similar-size-rooms-title" style="display: block; margin: 0; padding: 0; font-size: 15px; font-weight: bold; color: var(--c-text-1); line-height: 1.4;">
@@ -71,3 +73,4 @@ $isRanked = $mode === 'tag_top';
         </a>
     <?php endif ?>
 </article>
+</div>

--- a/app/Views/components/top_ranking_comment_list_hour.php
+++ b/app/Views/components/top_ranking_comment_list_hour.php
@@ -11,6 +11,8 @@ $hourlyStart = $dto->hourlyUpdatedAt->format('G:i');
 $_hourlyRange = $hourlyStart . '〜<time datetime="' . $hourlyTime . '">' . $hourlyEnd . '</time>';
 ?>
 
+<?php // 毎時変動するランキングをGoogle検索スニペットから除外。data-nosnippetはarticleに付けられない(div/section/spanのみ)ため外側をdivで包む ?>
+<div data-nosnippet>
 <article class="top-ranking">
     <header class="openchat-list-title-area unset">
         <div class="openchat-list-date unset ranking-url">
@@ -27,3 +29,4 @@ $_hourlyRange = $hourlyStart . '〜<time datetime="' . $hourlyTime . '">' . $hou
         <span class="ranking-readMore"><?php echo t('1時間の人数増加ランキングをもっと見る') ?></span>
     </a>
 </article>
+</div>

--- a/app/Views/components/top_ranking_comment_list_hour24.php
+++ b/app/Views/components/top_ranking_comment_list_hour24.php
@@ -1,3 +1,5 @@
+<?php // 毎時変動するランキングをGoogle検索スニペットから除外。data-nosnippetはarticleに付けられない(div/section/spanのみ)ため外側をdivで包む ?>
+<div data-nosnippet>
 <article class="top-ranking">
     <header class="openchat-list-title-area unset">
         <div class="openchat-list-date unset ranking-url">
@@ -12,3 +14,4 @@
         <span class="ranking-readMore"><?php echo t('24時間の人数増加ランキングをもっと見る') ?></span>
     </a>
 </article>
+</div>

--- a/app/Views/components/top_ranking_comment_list_member.php
+++ b/app/Views/components/top_ranking_comment_list_member.php
@@ -1,3 +1,5 @@
+<?php // 毎時変動するランキングをGoogle検索スニペットから除外。data-nosnippetはarticleに付けられない(div/section/spanのみ)ため外側をdivで包む ?>
+<div data-nosnippet>
 <article class="top-ranking created-at">
     <header class=" openchat-list-title-area unset">
         <div class="openchat-list-date unset ranking-url">
@@ -11,3 +13,4 @@
         <span class="ranking-readMore"><?php echo t('人数ランキングをもっと見る') ?></span>
     </a>
 </article>
+</div>

--- a/app/Views/components/top_ranking_comment_list_week.php
+++ b/app/Views/components/top_ranking_comment_list_week.php
@@ -1,3 +1,5 @@
+<?php // 変動するランキングをGoogle検索スニペットから除外。data-nosnippetはarticleに付けられない(div/section/spanのみ)ため外側をdivで包む ?>
+<div data-nosnippet>
 <article class="top-ranking">
     <header class="openchat-list-title-area unset">
         <div class="openchat-list-date unset ranking-url">
@@ -12,3 +14,4 @@
         <span class="ranking-readMore"><?php echo t('1週間の人数増加ランキングをもっと見る') ?></span>
     </a>
 </article>
+</div>

--- a/app/Views/components/top_ranking_recent_comments.php
+++ b/app/Views/components/top_ranking_recent_comments.php
@@ -1,3 +1,5 @@
+<?php // 変動するコメント投稿一覧をGoogle検索スニペットから除外。data-nosnippetはarticleに付けられない(div/section/spanのみ)ため外側をdivで包む ?>
+<div data-nosnippet>
 <article class="recent-comment-list">
     <header class="openchat-list-title-area unset">
         <div class="openchat-list-date unset ranking-url">
@@ -13,3 +15,4 @@
         <span class="ranking-readMore">コメントのタイムラインを見る</span>
     </a>
 </article>
+</div>

--- a/app/Views/components/topic_tag.php
+++ b/app/Views/components/topic_tag.php
@@ -33,7 +33,8 @@ function greenTag($word)
 ?>
 
 <article class="top-ranking topic-tag">
-    <div>
+    <?php // 毎時変動する急上昇テーマをGoogle検索スニペットから除外 ?>
+    <div data-nosnippet>
         <header class="openchat-list-title-area unset" style="margin-bottom: 0px;">
             <div class="openchat-list-date unset ranking-url">
                 <h2 class="unset">

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -45,12 +45,13 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
             </div>
           </div>
 
-          <div class="talkroom_number_of_members">
+          <?php // 毎時変動する人数・増減はGoogle検索スニペットから除外（説明文はスニペットに使われるべきなので付けない） ?>
+          <div class="talkroom_number_of_members" data-nosnippet>
             <span class="number_of_members"><?php echo sprintfT('メンバー %s人', number_format($oc['member'])) ?></span>
           </div>
 
           <?php if (isset($_hourlyRange)) : ?>
-            <div class="talkroom_number_of_stats stats-hourly" style="line-height: 135%; margin-top: 3px;">
+            <div class="talkroom_number_of_stats stats-hourly" data-nosnippet style="line-height: 135%; margin-top: 3px;">
               <div class="number-box ">
                 <span aria-hidden="true" style="margin-right: 1px; font-size: 9px; user-select: none;">🔥</span>
                 <span style="margin-right: 4px;" class="openchat-itme-stats-title"><?php echo $_hourlyRange ?></span>
@@ -61,7 +62,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
             </div>
           <?php endif ?>
 
-          <div class="talkroom_number_of_stats stats-daily">
+          <div class="talkroom_number_of_stats stats-daily" data-nosnippet>
 
             <?php if (isset($oc['rh24_diff_member']) && $oc['rh24_diff_member'] >= AppConfig::RECOMMEND_MIN_MEMBER_DIFF_H24) : ?>
               <div class="number-box " style="margin-right: 6px;">
@@ -163,7 +164,8 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
       <?php if ($_narrative !== null): ?>
         <?php viewComponent('oc_narrative_section', ['narrative' => $_narrative, 'oc' => $oc]) ?>
       <?php endif ?>
-      <section class="openchat-graph-section" style="padding-bottom: 0rem; padding-top: var(--sp-section-gap);">
+      <?php // 変動データ(日付・人数・グラフ)のセクション全体をGoogle検索スニペットから除外 ?>
+      <section class="openchat-graph-section" data-nosnippet style="padding-bottom: 0rem; padding-top: var(--sp-section-gap);">
         <div class="title-bar" style="margin-bottom: 1.5rem;">
           <img class="openchat-item-title-img" aria-hidden="true" alt="<?php echo $oc['name'] ?>" src="<?php echo imgPreviewUrl($oc['img_url']) ?>">
           <div style="display: flex; flex-direction: column; gap: 2px;">

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -30,7 +30,7 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
                     <h1 class="oc-home-hero__title"><?php echo t('オプチャグラフ') ?></h1>
                 </div>
                 <?php // テーマ切替（フッターと同型ピル・3状態）。スタイルは site_footer.css を共用 ?>
-                <div class="footer-theme-toggle-row oc-home-hero__theme">
+                <div class="footer-theme-toggle-row oc-home-hero__theme" data-nosnippet>
                     <button class="footer-theme-toggle theme-toggle-btn unset" type="button" aria-label="<?php echo t('ダークモード切替') ?>">
                         <svg class="theme-icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                         <svg class="theme-icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
@@ -77,7 +77,7 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
         <?php if (MimimalCmsConfig::$urlRoot === ''): // TODO: 日本以外ではマイリストが無効
         ?>
-            <div id="myListDiv" style="transition: all 0.3s; opacity: 0;"></div>
+            <div id="myListDiv" data-nosnippet style="transition: all 0.3s; opacity: 0;"></div>
         <?php endif ?>
         <div class="modify-top-padding" style="margin-bottom: 0rem;">
             <?php viewComponent('topic_tag', ['topPageDto' => $dto]);

--- a/frontend/oc-app/src/graph/App.tsx
+++ b/frontend/oc-app/src/graph/App.tsx
@@ -75,7 +75,8 @@ function AppInner() {
   }, [])
 
   return (
-    <div>
+    // data-nosnippet: 変動データ(グラフ・期間ボタン)をGoogle検索スニペットから除外（マウント先sectionの付与に依存しない）
+    <div data-nosnippet>
       <div className="chart-canvas-box" style={{ position: 'absolute', top: 0, left: 0 }}>
         {loading && <LoadingSpinner />}
         <canvas

--- a/frontend/oc-app/src/graph/components/SettingButton.tsx
+++ b/frontend/oc-app/src/graph/components/SettingButton.tsx
@@ -199,6 +199,9 @@ export default function SettingButton() {
         }}
         slotProps={{
           paper: {
+            // メニューはbody直下にポータルされ、囲い側のdata-nosnippetが効かないため自前で付ける
+            // （MUIの型はdata-*属性を持たないためスプレッドで渡す）
+            ...({ 'data-nosnippet': '' } as Record<string, string>),
             sx: isDark
               ? {
                   /* 旧試験実装の isDark 調整値（明るい slate-700 紙面 + slate-100 文字） */

--- a/public/style/components/room_list.css
+++ b/public/style/components/room_list.css
@@ -851,6 +851,14 @@
   font-size: 13px;
 }
 
+/* select自体はopacity:0で不可視だが、開いた時のポップアップの配色はselect/optionの色から決まる。
+   未指定だとUA既定の白背景にページ由来の明色文字が乗り、ダークテーマで読めなくなる環境があるため明示する */
+.page-select select,
+.page-select select option {
+  background-color: var(--c-bg);
+  color: var(--c-text-1);
+}
+
 .page-select label {
   margin: auto;
   position: relative;

--- a/public/style/pages/room_page.css
+++ b/public/style/pages/room_page.css
@@ -843,9 +843,9 @@ html {
   .title-bar .number-box,
   .openchat-header,
   .graph-title,
-  nav,
+  /* フッター(nav.footer-link-box-outer)は対象外: 拡大すると他ページとフッターの文字サイズが揃わない */
+  nav:not(.footer-link-box-outer),
   #comment-root,
-  .footer-link-box-outer,
   .title-bar-oc-name-wrapper {
     zoom: 110%;
   }


### PR DESCRIPTION
ダークテーマでページ切替プルダウンの選択肢が読めない問題、ルームページだけフッターの文字が大きい問題、Google検索結果に定型文が表示されるノイズの3件を修正する。

## 1. ページ切替プルダウンの選択肢が読めない（ダークテーマ）

コメントのタイムライン等のページ切替プルダウンを開くと、環境によって選択肢一覧が「白背景＋ほぼ白の文字」になり読めなかった。選択肢の色が未指定で、ブラウザ既定の白背景にダークテーマの明るい文字色だけが継承されていたのが原因。

[`room_list.css`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/fix/footer-zoom-select-dark-nosnippet/public/style/components/room_list.css) で select と選択肢にテーマの背景色・文字色を明示し、ライト/ダークどちらでも読めるようにした。

## 2. ルームページだけフッターの文字が大きい（PC幅）

PC幅でルームページ本文を110%拡大するスタイルがフッターまで巻き込んでおり、トップページ等と比べてフッターだけ1割大きく表示されていた。[`room_page.css`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/fix/footer-zoom-select-dark-nosnippet/public/style/pages/room_page.css) で拡大対象からフッターを除外し、全ページで同じサイズに統一した。

## 3. Google検索結果に出る定型文ノイズの除去

検索結果の説明文（スニペット）に「テーマ: ライトダーク自動. オプチャグラフ LINE社群成長統計…」のようなフッターの定型文が使われ、部屋の説明文が出ないことがあった。

Googleの仕様（data-nosnippet）で「検索結果の抜粋に使わない」印を以下に付与した。ページの見た目・アクセシビリティ・検索順位には影響せず、抜粋に使われなくなるだけ:

- フッター全体（リンク・テーマ切替・言語・コピーライト）とトップページのテーマ切替ボタン
- トップページの各ランキング棚・トピックタグ棚・マイリスト（毎時変動するため抜粋に不向き）
- ルームページのメンバー統計（「1時間 +30人(+6%)」等）・グラフ周辺・関連ルーム棚
- グラフ内部（期間切替ボタン・設定メニュー。設定メニューはページ最下部に別出しで描画されるため個別に付与）
- おすすめ棚コンポーネント全般（どのページで使われても除外）

部屋の説明文・ヒーロー・ブログ棚など、抜粋に使われるべき本文には付けていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
