### PR TITLE
[STG] fix: 広告ブロック検出が全ページで無効化していた問題を修正（高さ100pxの控えめな広告を5ページに再設置）

### DIFF
--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -30,7 +30,8 @@ class GoogleAdsenseConfig
         // OC-third-横長
         'ocThirdWide' => ['slotId' => '4386252007', 'cssClass' => 'rectangle2-ads'],
         // OCセパレーター-レスポンシブ
-        'ocSeparatorResponsive' => ['slotId' => '2542775305', 'cssClass' => null],
+        // ロード前から高さ100pxを確保する横長(horizontal-ads)で出す。format=auto だとロードまで高さ0でCLSが出るため
+        'ocSeparatorResponsive' => ['slotId' => '2542775305', 'cssClass' => 'horizontal-ads'],
         // OCセパレーター-rectangle
         'ocSeparatorRectangle' => ['slotId' => '2078443048', 'cssClass' => 'rectangle3-ads'],
         // OC-リスト-bottom-横長
@@ -46,7 +47,8 @@ class GoogleAdsenseConfig
         // サイトトップ2-横長
         'siteTopWide' => ['slotId' => '4015067592', 'cssClass' => 'horizontal-ads'],
         // サイトセパレーター-レスポンシブ
-        'siteSeparatorResponsive' => ['slotId' => '4243068812', 'cssClass' => null],
+        // ロード前から高さ100pxを確保する横長(horizontal-ads)で出す（上と同じ理由）
+        'siteSeparatorResponsive' => ['slotId' => '4243068812', 'cssClass' => 'horizontal-ads'],
         // サイトセパレーター-rectangle
         'siteSeparatorRectangle' => ['slotId' => '9793281538', 'cssClass' => 'rectangle-ads'],
         // サイトセパレーター-横長
@@ -70,7 +72,8 @@ class GoogleAdsenseConfig
         // おすすめ-リスト-bottom-横長
         'recommendListBottomWide' => ['slotId' => '3676170522', 'cssClass' => 'rectangle2-ads'],
         // おすすめセパレーター-レスポンシブ
-        'recommendSeparatorResponsive' => ['slotId' => '7064673271', 'cssClass' => null],
+        // ロード前から高さ100pxを確保する横長(horizontal-ads)で出す（上と同じ理由）
+        'recommendSeparatorResponsive' => ['slotId' => '7064673271', 'cssClass' => 'horizontal-ads'],
         // おすすめセパレーター-Rectangle
         'recommendSeparatorRectangle' => ['slotId' => '8031174545', 'cssClass' => 'rectangle3-ads'],
         // おすすめ-footer-rectangle

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -35,9 +35,10 @@
                 </div>
             </div>
 
-            <?php // 手動広告(siteSeparatorResponsive)は撤去済み(impRPM¥45/CTR0.32%, 2026-06実測)。自動広告は維持。
+            <?php // CTA直後に高さ100px固定の横長1枠（旧auto形式はimpRPM¥45と低単価で一度撤去、横長で再設置）。
                   // SEO 流入の初見読者に Offerwall を出さないよう、blog では Offerwall のみタグ側で抑制する ?>
             <?php \App\Views\Ads\GoogleAdsense::gTag(suppressOfferwall: true) ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
 
             <?php if (!empty($_faqHtml)): ?>
                 <div class="blog-faq"><?php echo $_faqHtml ?></div>

--- a/app/Views/blog_index_content.php
+++ b/app/Views/blog_index_content.php
@@ -33,6 +33,10 @@
                     <?php endforeach ?>
                 </ul>
             <?php endif ?>
+
+            <?php // 記事カード一覧の下に高さ100px固定の横長1枠。記事ページと同様に Offerwall のみ抑制する ?>
+            <?php \App\Views\Ads\GoogleAdsense::gTag(suppressOfferwall: true) ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
         </div>
     </main>
     <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -211,6 +211,12 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
     <?php // 関連ルーム(類似サイズ/おすすめ)は recommend 静的キャッシュ(.dat)から都度組み立て（MySQL不使用） ?>
     <?php viewComponent('oc_recommend_aside', ['similarSize' => $_similarSize, 'recommend' => $_recommend, 'oc' => $oc]) ?>
 
+    <?php if ($enableAdsense): ?>
+      <?php // 関連ルームの下に高さ100px固定の横長1枠（高さ確保済みでCLSなし。回遊導線は遮らない）。
+            // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
+      <?php GAd::output('ocSeparatorResponsive') ?>
+    <?php endif ?>
+
 
     <?php if (MimimalCmsConfig::$urlRoot === ''): // TODO:日本以外ではコメントが無効
     ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -79,8 +79,7 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
             <?php viewComponent('open_chat_list_recommend', compact('recommend', 'listArray') + ['showListMedal' => true, 'currentCount' => 0, 'showApiCreatedAt' => true]) ?>
 
             <?php if (isset($_dto->tagRecordCounts[$_tagIndex]) && ((int)$_dto->tagRecordCounts[$_tagIndex]) > $count) : ?>
-              <hr class="hr-top" style="margin: 1rem auto;">
-              <a class="top-ranking-readMore unset ranking-url white-btn" href="<?php echo url('ranking?keyword=' . urlencode('tag:' . $_tagIndex)) ?>">
+              <a class="top-ranking-readMore unset ranking-url white-btn" style="margin-top: 1rem;" href="<?php echo url('ranking?keyword=' . urlencode('tag:' . $_tagIndex)) ?>">
                 <span class="ranking-readMore" style="font-size: 11.5px;"><?php echo sprintfT('「%s」をすべて見る', $tag) ?><span class="small" style="font-size: 11.5px;"><?php echo sprintfT('%s件', $_dto->tagRecordCounts[$_tagIndex]) ?></span></span>
               </a>
             <?php endif ?>
@@ -96,6 +95,12 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
       <?php endif ?>
 
     </section>
+
+    <?php if ($enableAdsense && isset($recommend)): ?>
+      <?php // ランキングリスト直下に高さ100px固定の横長1枠（リストは分断しない。高さ確保済みでCLSなし）。
+            // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
+      <?php GAd::output('recommendSeparatorResponsive') ?>
+    <?php endif ?>
 
     <?php if (isset($_discovery) && !$_discovery->isEmpty()) : ?>
       <?php viewComponent('theme_discovery', ['discovery' => $_discovery]) ?>

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -90,6 +90,13 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
         <?php viewComponent('top_ranking_comment_list_hour', compact('dto')) ?>
         <?php viewComponent('top_ranking_comment_list_hour24', compact('dto')) ?>
+
+        <?php if ($enableAdsense): ?>
+            <?php // 最近のコメントの上に高さ100px固定の横長1枠（ファーストビューより下のセクション間。高さ確保済みでCLSなし）。
+                  // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
+        <?php endif ?>
+
         <?php if (MimimalCmsConfig::$urlRoot === ''): ?>
             <?php viewComponent('top_ranking_recent_comments') ?>
         <?php endif ?>

--- a/public/style/components/site_header.css
+++ b/public/style/components/site_header.css
@@ -694,6 +694,11 @@ html.is-ios .site_header_outer.header-hidden {
   box-sizing: border-box;
 }
 
+/* 横長広告は前後のセクション(関連ルーム等)に密着しないよう上下に余白を確保 */
+.horizontal-ads-parent {
+  margin: 1rem 0;
+}
+
 .responsive-google-parent {
   padding: 0;
   box-sizing: border-box;

--- a/public/style/components/theme_discovery.css
+++ b/public/style/components/theme_discovery.css
@@ -11,7 +11,6 @@
   text-align: left;
   margin-top: 10px;
   padding: 18px 1rem 6px;
-  border-top: 1px solid var(--c-cool-border-soft);
 }
 
 .theme-disco__title {


### PR DESCRIPTION
## 問題の概要

広告ブロックを使っているユーザーへの警告表示が、サイト全体で動かなくなっていた。

検出スクリプトはページ内に広告枠が最低1つ無いと何も判定しない作りだが、これまでの改善で手動広告を全ページから撤去したため、判定の前提が消えていた。

## 対処内容

トップ・ルームページ・おすすめ・ブログ記事・ブログ一覧の5ページに、高さ100px固定の横長広告を1枠ずつ再設置する。

- 位置はいずれもファーストビューより下のセクション間（トップ=最近のコメントの上、ルームページ=関連ルームの下、おすすめ=ランキングの下、ブログ=記事CTAの直後/カード一覧の下）。一覧やリストは分断しない
- 枠の高さをロード前から100pxで確保するため、広告表示時にページがガタつかない（CLSなし）
- 過去に撤去した280pxの大型枠とは別物で、邪魔にならない低い横長のみ
- ブログ一覧は広告タグ自体が無かったため、記事ページと同様にOfferwall（全画面の案内）を抑制した状態で追加

### あわせて修正した表示の細かい問題

- おすすめページ「すべて見る」ボタンの上の罫線を削除（ボタン自体に枠線があり二重線だった）
- テーマ発見セクションの上の罫線を削除
- 広告枠の上下に余白を追加し、前後のセクションと密着しないように調整

## 確認内容

- 5ページすべてで広告枠（高さ100px）が出力されることをローカルで確認
- ヘッドレスブラウザで枠の実寸・前後の余白を実測し、スクリーンショットで確認
- PHPStanは既存エラーのみで変更起因なし
