### PR TITLE
[STG] fix: 広告ブロック検出が判定できるよう広告の遅延読み込みを廃止

### DIFF
--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -11,10 +11,8 @@ class GoogleAdsense
      * 広告を出力
      *
      * @param string $slotKey スロット識別子（例: 'ocTopRectangle'）
-     * @param bool $forceShow 強制表示フラグ
      */
-
-    public static function output(string $slotKey, bool $forceShow = false)
+    public static function output(string $slotKey)
     {
         if (AppConfig::$isStaging) return;
 
@@ -71,30 +69,15 @@ class GoogleAdsense
     {
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
 
+        // 遅延読み込み(IntersectionObserver)はしない。security.js の広告ブロック検出
+        // （window load 時の未処理チェック・10秒間の1px潰し監視）は「広告がページ表示時に
+        // 読み込まれている」前提のため、遅延させると検出が成立しなくなる
         echo <<<EOT
         <script>
             document.addEventListener('DOMContentLoaded', function() {
-                var ads = Array.prototype.slice.call(document.querySelectorAll('ins.manual'));
-                if (!ads.length) return;
-                var push = function() { (adsbygoogle = window.adsbygoogle || []).push({}); };
-
-                // IntersectionObserver 非対応環境は従来どおり一括読み込み（フォールバック）
-                if (!('IntersectionObserver' in window)) {
-                    ads.forEach(push);
-                    return;
-                }
-
-                // 各広告がビューポート手前 600px に入って初めて読み込む。
-                // 下部広告がユーザー到達前に「表示済み」化するのを防ぎ視認率(viewability)を上げる。
-                // push() は DOM 順で最も先頭の未読み込み ins を埋めるため、上→下のスクロールで順に充填される。
-                var io = new IntersectionObserver(function(entries, obs) {
-                    entries.forEach(function(entry) {
-                        if (!entry.isIntersecting) return;
-                        push();
-                        obs.unobserve(entry.target);
-                    });
-                }, { rootMargin: '600px 0px' });
-                ads.forEach(function(ad) { io.observe(ad); });
+                document.querySelectorAll('ins.manual').forEach(function() {
+                    (adsbygoogle = window.adsbygoogle || []).push({});
+                });
             });
         </script>
         EOT;


### PR DESCRIPTION
## 問題の概要

直前のPR #443 で広告を再設置したが、広告ブロック検出（security.js）はまだ動かない状態だった。

検出は「ページ表示時に広告が読み込まれている」前提で判定する（ページ読み込み完了時の未処理チェックと、開始10秒間の監視）。一方、広告の読み込みはスクロールして枠に近づいてから行う遅延方式だったため、判定のタイミングでは広告が常に未読み込みで、検出が一度も成立しなかった。

## 対処内容

広告の遅延読み込みを廃止し、ページ表示時に即読み込みする方式に戻す。

- 視認率の最適化（下部広告をスクロール到達まで読み込まない仕組み）より検出の成立を優先
- あわせて、どこからも使われていない引数（forceShow）を削除

## 確認内容

- PHP構文チェック・PHPStan（既存エラーのみ・変更起因なし）
- ローカルでページ表示に影響がないこと
