### PR TITLE
[STG] fix: 広告を全ページで同じ固定サイズの横長1種に統一

### DIFF
--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -30,8 +30,7 @@ class GoogleAdsenseConfig
         // OC-third-横長
         'ocThirdWide' => ['slotId' => '4386252007', 'cssClass' => 'rectangle2-ads'],
         // OCセパレーター-レスポンシブ
-        // ロード前から高さ100pxを確保する横長(horizontal-ads)で出す。format=auto だとロードまで高さ0でCLSが出るため
-        'ocSeparatorResponsive' => ['slotId' => '2542775305', 'cssClass' => 'horizontal-ads'],
+        'ocSeparatorResponsive' => ['slotId' => '2542775305', 'cssClass' => null],
         // OCセパレーター-rectangle
         'ocSeparatorRectangle' => ['slotId' => '2078443048', 'cssClass' => 'rectangle3-ads'],
         // OC-リスト-bottom-横長
@@ -47,8 +46,7 @@ class GoogleAdsenseConfig
         // サイトトップ2-横長
         'siteTopWide' => ['slotId' => '4015067592', 'cssClass' => 'horizontal-ads'],
         // サイトセパレーター-レスポンシブ
-        // ロード前から高さ100pxを確保する横長(horizontal-ads)で出す（上と同じ理由）
-        'siteSeparatorResponsive' => ['slotId' => '4243068812', 'cssClass' => 'horizontal-ads'],
+        'siteSeparatorResponsive' => ['slotId' => '4243068812', 'cssClass' => null],
         // サイトセパレーター-rectangle
         'siteSeparatorRectangle' => ['slotId' => '9793281538', 'cssClass' => 'rectangle-ads'],
         // サイトセパレーター-横長
@@ -72,8 +70,7 @@ class GoogleAdsenseConfig
         // おすすめ-リスト-bottom-横長
         'recommendListBottomWide' => ['slotId' => '3676170522', 'cssClass' => 'rectangle2-ads'],
         // おすすめセパレーター-レスポンシブ
-        // ロード前から高さ100pxを確保する横長(horizontal-ads)で出す（上と同じ理由）
-        'recommendSeparatorResponsive' => ['slotId' => '7064673271', 'cssClass' => 'horizontal-ads'],
+        'recommendSeparatorResponsive' => ['slotId' => '7064673271', 'cssClass' => null],
         // おすすめセパレーター-Rectangle
         'recommendSeparatorRectangle' => ['slotId' => '8031174545', 'cssClass' => 'rectangle3-ads'],
         // おすすめ-footer-rectangle

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -35,10 +35,10 @@
                 </div>
             </div>
 
-            <?php // CTA直後に高さ100px固定の横長1枠（旧auto形式はimpRPM¥45と低単価で一度撤去、横長で再設置）。
+            <?php // CTA直後にOC横長1枠（固定）。
                   // SEO 流入の初見読者に Offerwall を出さないよう、blog では Offerwall のみタグ側で抑制する ?>
             <?php \App\Views\Ads\GoogleAdsense::gTag(suppressOfferwall: true) ?>
-            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
 
             <?php if (!empty($_faqHtml)): ?>
                 <div class="blog-faq"><?php echo $_faqHtml ?></div>

--- a/app/Views/blog_index_content.php
+++ b/app/Views/blog_index_content.php
@@ -34,9 +34,9 @@
                 </ul>
             <?php endif ?>
 
-            <?php // 記事カード一覧の下に高さ100px固定の横長1枠。記事ページと同様に Offerwall のみ抑制する ?>
+            <?php // 記事カード一覧の下にOC横長1枠（固定）。記事ページと同様に Offerwall のみ抑制する ?>
             <?php \App\Views\Ads\GoogleAdsense::gTag(suppressOfferwall: true) ?>
-            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
         </div>
     </main>
     <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -212,9 +212,9 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
     <?php viewComponent('oc_recommend_aside', ['similarSize' => $_similarSize, 'recommend' => $_recommend, 'oc' => $oc]) ?>
 
     <?php if ($enableAdsense): ?>
-      <?php // 関連ルームの下に高さ100px固定の横長1枠（高さ確保済みでCLSなし。回遊導線は遮らない）。
+      <?php // 関連ルームの下にOC横長1枠（固定。高さ確保済みでCLSなし。回遊導線は遮らない）。
             // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-      <?php GAd::output('ocSeparatorResponsive') ?>
+      <?php GAd::output('ocTopHorizontal') ?>
     <?php endif ?>
 
 

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -97,9 +97,9 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
     </section>
 
     <?php if ($enableAdsense && isset($recommend)): ?>
-      <?php // ランキングリスト直下に高さ100px固定の横長1枠（リストは分断しない。高さ確保済みでCLSなし）。
+      <?php // ランキングリスト直下にOC横長1枠（固定。リストは分断しない。高さ確保済みでCLSなし）。
             // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-      <?php GAd::output('recommendSeparatorResponsive') ?>
+      <?php GAd::output('ocTopHorizontal') ?>
     <?php endif ?>
 
     <?php if (isset($_discovery) && !$_discovery->isEmpty()) : ?>

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -92,9 +92,9 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
         <?php viewComponent('top_ranking_comment_list_hour24', compact('dto')) ?>
 
         <?php if ($enableAdsense): ?>
-            <?php // 最近のコメントの上に高さ100px固定の横長1枠（ファーストビューより下のセクション間。高さ確保済みでCLSなし）。
+            <?php // 最近のコメントの上にOC横長1枠（固定。高さ確保済みでCLSなし）。
                   // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-            <?php \App\Views\Ads\GoogleAdsense::output('siteSeparatorResponsive') ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
         <?php endif ?>
 
         <?php if (MimimalCmsConfig::$urlRoot === ''): ?>


### PR DESCRIPTION
## 内容

トップ・ルームページ・おすすめ・ブログ記事・ブログ一覧の広告を、ページごとに別々だったレスポンシブ枠から、すべて同じ固定サイズの横長広告1種に統一する。

- 使う枠を1つ（OC横長・高さ100px固定）に揃え、レスポンシブ枠は使わない
- 表示位置・読み込みタイミングは変更なし

## 確認

- 4ページとも同じ広告枠が出力されることをローカルで確認
- PHP構文チェック済み