### PR TITLE
[STG] feat: 広告ブロックを解除して広告を見るようになった数をアナリティクスで計測

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,20 @@ CI Test (`ci.yml`) は Mock環境のクローリング+URLテストのみで、*
 
 Example: `skip-ci: Fix typo in README`
 
+**デフォルト方針（PHPを触らない PR は skip-ci）:**
+CI(`ci.yml`)は Mock環境のクローリング+URLテストなので、その挙動は基本的に PHP 側で決まる。
+そのため **PHP コードを一切変更していない PR は、デフォルトで skip-ci にする**（フロントJS/CSS・
+ドキュメント・翻訳JSON 等だけの変更）。確実に効かせるため **PR タイトルを `skip-ci:` 始まりにする**
+（ラベルだけは PR 作成時にレースして効かないことがある。既存 PR に後付けする場合は、ラベルを
+付けてから次の push をすると `synchronize` で再評価されて効く）。
+
+**例外（PHP を触っていなくても skip-ci を付けない）:**
+PHP 非変更でも CI を通した方がよいと判断したら付けない。例:
+
+- ルーティング・ページ表示に影響しうる View テンプレート/JS の変更（URLテストで表示崩れ・500 を拾える）
+- mock 環境・クローラ設定・依存（composer/npm）・CI 設定(`ci.yml`/`docker-compose.ci.yml`)自体の変更
+- 挙動への影響に少しでも不安がある変更
+
 **Important**: When `skip-ci` is used:
 
 - CI tests (`ci.yml` の Mock クローリング+URLテスト) are skipped

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ Posted from: `<hostname>:<作業ディレクトリ>`
 ```
 
 - モデルはその時のセッションの実際のモデルを書く（例: Opus 4.8 → `Generated with Claude Code (Opus 4.8 / `claude-opus-4-8[1m]`)`、Sonnet 4.6 のときは Sonnet 4.6）
-- `<hostname>` は `hostname`、`<作業ディレクトリ>` は `pwd` の値（例: `user-B550M-Pro4:/home/user/repos/Open-Chat-Graph`）
+- `<hostname>` は `hostname`、`<作業ディレクトリ>` は `pwd` の値だが**ホームディレクトリは `~` に短縮**する（例: `/home/user/repos/Open-Chat-Graph` → `user-B550M-Pro4:~/repos/Open-Chat-Graph`）
 - これは本文末尾の表示用ブロック。コミットメッセージ末尾の `Co-Authored-By: Claude ...` とは別物（コミットは従来どおり Co-Authored-By を付ける）
 
 ### Writing Clear Titles

--- a/public/js/security.js
+++ b/public/js/security.js
@@ -27,9 +27,101 @@ const ADBLOCK_NOTICE_MESSAGES = {
   },
 }
 
+// GA4 計測。アドブロック利用者の多くは GA/GTM ドメインごと遮断するため、
+// 「ブロックされた瞬間」の送信はそもそも届かない。そこで送信せずローカルに記録だけ残し、
+// 後日 広告が正常表示された(=ブロッカー解除/許可リスト追加された)訪問で初めて GA に送る。
+// → 「ブロック → 解除」に転じた数(=オーバーレイが効いて広告を見るようになった数)が取れる。
+const GA_MEASUREMENT_ID = 'G-DBS3CW3XH5'
+const BLOCKED_FLAG_KEY = 'ocgab_blocked_at'
+
+// 検出した端末にフラグ(初回ブロック時刻)を残す。送信はしない(この瞬間は届かない前提)。
+function markBlockedLocally() {
+  try {
+    if (!localStorage.getItem(BLOCKED_FLAG_KEY)) {
+      localStorage.setItem(BLOCKED_FLAG_KEY, String(Date.now()))
+    }
+  } catch (e) {}
+}
+
+// GTM とは別に gtag.js を読み込み、カスタムイベントを GA4 へ直送する。
+// send_page_view:false なのでページビューは二重計上しない。本番ホストのみ。
+function sendGaEvent(name, params) {
+  if (location.hostname !== 'openchat-review.me') return
+  try {
+    window.dataLayer = window.dataLayer || []
+    if (!window.gtag) {
+      window.gtag = function () {
+        window.dataLayer.push(arguments)
+      }
+    }
+    if (!window.__ocgabGtagLoaded) {
+      window.__ocgabGtagLoaded = true
+      const s = document.createElement('script')
+      s.async = true
+      s.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_MEASUREMENT_ID
+      document.head.appendChild(s)
+      window.gtag('js', new Date())
+      window.gtag('config', GA_MEASUREMENT_ID, { send_page_view: false })
+    }
+    window.gtag('event', name, params || {})
+  } catch (e) {}
+}
+
+// 広告が実際に表示されているか(潰されていない iframe が1枚以上ある)
+function adsAreRendering() {
+  let filled = 0
+  document
+    .querySelectorAll('.adsbygoogle[data-adsbygoogle-status="done"]')
+    .forEach((el) => {
+      if (el.getAttribute('data-ad-status') === 'unfilled') return
+      const iframe = el.querySelector('iframe')
+      if (!iframe) return
+      const style = window.getComputedStyle(iframe)
+      if (parseFloat(style.width) > 1 && parseFloat(style.height) > 1) filled++
+    })
+  return filled > 0
+}
+
+// 前回ブロックされた端末で、今回 広告が正常表示された=解除された とみなし GA に送る。
+function reportRecoveryIfNeeded() {
+  let raw
+  try {
+    raw = localStorage.getItem(BLOCKED_FLAG_KEY)
+  } catch (e) {
+    return
+  }
+  if (!raw) return
+  // まだ広告が出ていない / まだ潰されている間は判定しない
+  if (!adsAreRendering() || detectAdBlock()) return
+
+  // 二重送信を防ぐためフラグ削除に成功してから送る
+  try {
+    localStorage.removeItem(BLOCKED_FLAG_KEY)
+  } catch (e) {
+    return
+  }
+
+  const blockedAt = parseInt(raw, 10)
+  const elapsedMs = Date.now() - blockedAt
+  const THIRTY_DAYS = 30 * 24 * 3600 * 1000
+  // 不正値・古すぎる(30日超)は帰属できないので送らず破棄
+  if (!(blockedAt > 0) || elapsedMs < 0 || elapsedMs > THIRTY_DAYS) return
+
+  const bucket =
+    elapsedMs < 30 * 60 * 1000
+      ? 'within_30min'
+      : elapsedMs < 24 * 3600 * 1000
+      ? 'within_1day'
+      : 'within_30days'
+  sendGaEvent('adblock_recovered', { recovery_elapsed: bucket })
+}
+
 function whiteOut() {
   // 多重表示を防ぐ
   if (document.getElementById('ocgab-overlay')) return
+
+  // この端末は「ブロックされた」とローカルに記録(後日の解除検出に使う)
+  markBlockedLocally()
 
   // 現在の表示言語を <html lang> から判定 (ja / zh-TW → zh / th / その他 → en)
   const rawLang = (document.documentElement.lang || 'ja').toLowerCase()
@@ -291,4 +383,14 @@ if (typeof admin === 'undefined' || !admin) {
   // すでに潰れている場合に備えた初回チェック
   tryDetect()
   console.log('AdBlock検出の監視を開始しました')
+}
+
+if (typeof admin === 'undefined' || !admin) {
+  // 「ブロック → 解除」計測。前回ブロックされた端末で広告が正常表示されたら GA に送る。
+  // 広告は遅延描画されるので load 後に数回リトライ(送信は一度きり: フラグ削除で以後no-op)。
+  window.addEventListener('load', function () {
+    reportRecoveryIfNeeded()
+    setTimeout(reportRecoveryIfNeeded, 2000)
+    setTimeout(reportRecoveryIfNeeded, 5000)
+  })
 }


### PR DESCRIPTION
## 何をするか

広告ブロックのオーバーレイが効いて「ブロッカーを外して広告を見るようになった」端末の数を、Google アナリティクス(GA4)で集計できるようにする。

これまでオーバーレイ([`public/js/security.js`](../blob/oc-pdca/feat/ga-adblock-recovery-event/public/js/security.js) の `whiteOut()`)は表示するだけで、効果が数字で見えなかった。

## なぜ「検出した瞬間」に送らないのか

広告ブロッカーの利用者は、広告だけでなく Google アナリティクス自体(google-analytics.com / googletagmanager.com)もまとめて遮断していることが多い。そのため「ブロックを検出した瞬間」にアナリティクスへ送っても、その通信ごと遮断されて届かない。サイレントに遮断されている利用者は検出後の送信も不可能。

→ 検出した瞬間の送信は捨て、ブラウザのローカル(localStorage)に記録だけ残す。後日その人がブロッカーを外して(=広告が正常表示される状態で)再訪したときに初めて送る。このタイミングならアナリティクスも素通りするので確実に届く。

結果として「ブロック → 解除」に転じた数(オーバーレイが仕事をした数)が取れる。

なお「ブロックされたまま離脱した率」はアナリティクスでは原理的に取れない(離脱した人は一度もアナリティクスに到達しないため)。今回はスコープ外。

## 動き

1. 検出時(`whiteOut()`): localStorage に初回ブロック時刻を保存するだけ。送信しない。
2. 広告が正常表示された訪問(load 後に数回チェック): フラグがあれば「解除された」とみなし、`gtag('event', 'adblock_recovered')` を GA4 (`G-DBS3CW3XH5`) へ直送してフラグを削除。経過時間バケット(`within_30min` / `within_1day` / `within_30days`)を付与。

## 安全策

- 本番ホスト(openchat-review.me)でのみ送信。stg/ローカルのノイズを入れない
- `send_page_view: false` でページビューを二重計上しない
- 30日を超えた古いフラグは帰属できないので送らず破棄
- フラグ削除に成功してから送信し、二重送信を防ぐ

## 確認方法(マージ・デプロイ後)

GA4 のリアルタイム/イベントレポートで `adblock_recovered` の件数を見る。`recovery_elapsed` を内訳で見たい場合のみ、GA4 でカスタムディメンション登録が必要(イベント件数自体は登録不要で見える)。

---
🤖 Generated with Claude Code (Opus 4.8 / `claude-opus-4-8[1m]`)
Posted from: `user-B550M-Pro4:/home/user/repos/Open-Chat-Graph`
