### PR TITLE
[STG] skip-ci: skip-post: 認証バッジ画像をSTG/共有環境でも自ドメインから配信

### DIFF
--- a/public/style/react/OpenChat.css
+++ b/public/style/react/OpenChat.css
@@ -17,12 +17,12 @@
 
 .super-icon.official {
   width: 20px;
-  background-image: url(https://openchat-review.me/assets/line_svg_sprite.svg);
+  background-image: url(/../assets/line_svg_sprite.svg);
   background-position: -62px -76px;
 }
 
 .super-icon.sp {
-  background-image: url(https://openchat-review.me/assets/line_svg_sprite.svg);
+  background-image: url(/../assets/line_svg_sprite.svg);
   background-position: -33px -76px;
 }
 


### PR DESCRIPTION
ランキングや個別ルームに出る公式/スペシャル運営の認証バッジ画像が、STGや共有環境でも本番(openchat-review.me)から読み込まれていた。

`public/style/react/OpenChat.css` の `.super-icon.official` / `.super-icon.sp` だけ背景画像がフルURL(`https://openchat-review.me/assets/line_svg_sprite.svg`)でベタ書きされていたのが原因。同じバッジを参照する `site_header.css` は相対パスなので、それに合わせて相対パスに統一し、表示中のドメインから配信されるようにした。

CSSのみの変更（PHP非変更）のため skip-ci。リリース履歴に出す必要がないため skip-post。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
