### PR TITLE
[STG] skip-ci: 利用者の主要操作をGA計測（検索・コメント投稿・いいね・グラフ期間切替）

### DIFF
--- a/frontend/oc-app/src/comments/components/Button/LikeButton.tsx
+++ b/frontend/oc-app/src/comments/components/Button/LikeButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import LikeButtonUi from './LikeButtonUi'
 import { fetchApi } from '../../utils/utils'
+import { trackEvent } from '../../../util/track'
 
 export type LikeBtnState = LikeBtnApi & { commentId: number }
 
@@ -15,13 +16,21 @@ export default function LikeButton(props: LikeBtnState) {
       if (sendingRef.current) return
       sendingRef.current = true
 
+      // 未投票なら付与(POST)、投票済みなら取り消し(DELETE)
+      const isAdding = state.voted === ''
+
       try {
         const res = await fetchApi<LikeBtnApi>(
           `${window.location.origin}/comment_reaction/${state.commentId}`,
-          state.voted === '' ? 'POST' : 'DELETE',
+          isAdding ? 'POST' : 'DELETE',
           { type }
         )
         setState({ ...res, commentId: state.commentId })
+
+        // 付与時のみ計測。empathy=いいね！/negative=うーん…
+        if (isAdding) {
+          trackEvent('comment_vote', { vote_type: type === 'negative' ? 'dislike' : 'like' })
+        }
       } finally {
         sendingRef.current = false
       }

--- a/frontend/oc-app/src/comments/components/CommentForm.tsx
+++ b/frontend/oc-app/src/comments/components/CommentForm.tsx
@@ -11,6 +11,7 @@ import { inputNameState } from '../state/inputNameState'
 import { appInitTagDto } from '../config/appInitTagDto'
 import { errorDialogState } from '../state/errorDialogState'
 import { imageFilesState } from '../state/imageFilesState'
+import { trackEvent } from '../../util/track'
 
 export default function CommentForm() {
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -70,6 +71,7 @@ export default function CommentForm() {
         setName('')
         setText('')
         setImageFiles([])
+        trackEvent('comment_submit', { has_image: currentImages.length > 0 })
       } catch (error) {
         console.error(error)
         let message: string

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -3,6 +3,7 @@ import { graphStore } from './store'
 import { chartMeta, chatArgDto, fetchChart } from '../util/fetchRenderer'
 import OpenChatChart from '../classes/OpenChatChart'
 import { getCurrentUrlParams, getStoregeFixedLimitSetting, setUrlParams } from '../util/urlParam'
+import { trackEvent } from '../../util/track'
 
 export const chart = new OpenChatChart()
 export const loadingAtom = atom(false)
@@ -234,6 +235,10 @@ export function handleChangeLimit(limit: ChartLimit | 25) {
   }
 
   setUrlParamsFromChartStates()
+
+  // limit値→期間: 25=最新24時間 / 8=1週間 / 31=1ヶ月 / 0=全期間
+  const period = limit === 25 ? '24h' : limit === 8 ? '1week' : limit === 31 ? '1month' : 'all'
+  trackEvent('chart_period', { period })
 }
 
 export function handleChangeCategory(alignment: urlParamsValue<'category'> | null) {

--- a/frontend/oc-app/src/util/track.ts
+++ b/frontend/oc-app/src/util/track.ts
@@ -1,0 +1,10 @@
+// dataLayer 経由で GTM にカスタムイベントを送る。測定先(本番/STG)の出し分けは GTM 側(hostName ルックアップ)で行うので、ここではホスト判定しない。
+export function trackEvent(name: string, params?: Record<string, unknown>): void {
+  try {
+    const w = window as unknown as { dataLayer?: Record<string, unknown>[] }
+    w.dataLayer = w.dataLayer || []
+    w.dataLayer.push({ event: name, ...(params || {}) })
+  } catch {
+    /* noop */
+  }
+}

--- a/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
+++ b/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
@@ -5,6 +5,7 @@ import { useSetListParams } from './ListParamsHooks'
 import { useAtomValue } from 'jotai'
 import { keywordState } from '../store/atom'
 import { langCode } from '../config/config'
+import { trackEvent } from '../utils/track'
 
 export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => void) | undefined) {
   const [open, setOpen] = useState(false)
@@ -86,6 +87,8 @@ export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => v
       if (keyword.length > maxLength) {
         keyword = keyword.substring(0, maxLength)
       }
+
+      trackEvent('search', { search_term: keyword })
 
       if (siperSlideTo) {
         setParams((params) => {

--- a/frontend/ranking/src/utils/track.ts
+++ b/frontend/ranking/src/utils/track.ts
@@ -1,0 +1,10 @@
+// dataLayer 経由で GTM にカスタムイベントを送る。測定先(本番/STG)の出し分けは GTM 側(hostName ルックアップ)で行うので、ここではホスト判定しない。
+export function trackEvent(name: string, params?: Record<string, unknown>): void {
+  try {
+    const w = window as unknown as { dataLayer?: Record<string, unknown>[] }
+    w.dataLayer = w.dataLayer || []
+    w.dataLayer.push({ event: name, ...(params || {}) })
+  } catch {
+    /* noop */
+  }
+}


### PR DESCRIPTION
これまでオプチャグラフのサイト内操作はGoogleアナリティクスに一切記録されておらず、検索やコメントなど「何がどれだけ使われているか」を集計できませんでした（取れていたのはページ表示数だけ）。利用状況を把握できるよう、効果の高い4つの操作をイベントとして送ります。

## 計測する操作

- 検索の実行 … `search`（検索語 search_term）
- コメント投稿の成功 … `comment_submit`（画像添付の有無 has_image）
- いいね／うーんの押下 … `comment_vote`（vote_type = like / dislike）
- グラフの期間切替 … `chart_period`（period = 24h / 1week / 1month / all）

いずれも合計値をディメンションで見られるようにしています。

## 実装

各フロントアプリに最小の送信ヘルパ `trackEvent`（中身は `dataLayer.push`）を置き、上記4ハンドラから1行ずつ呼ぶだけ。送信先（本番GA4 / STG GA4）の出し分けはGTM側のhostNameルックアップで行うため、フロントではホスト判定しません（PHPは変更なし）。

検索・グラフ期間はURLにも反映されますが、サイト内のURL変更はGTMにHistory変更トリガーが無く今のGA4では拾えていないため、明示イベントで取得します。

## 動作確認

STG用GA4プロパティ（新設）へhostNameで振り分けるGTM設定を公開済み。STGでpage_view着信を確認。本イベントはこのフロントをSTGへ反映後に疎通確認します。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
