### PR TITLE
[STG] skip-ci: キーワード検索のGA計測を全経路で確実に（検索フォーム・URL直アクセスの取りこぼし解消）

### DIFF
--- a/frontend/ranking/src/components/KeywordSearchTracker.tsx
+++ b/frontend/ranking/src/components/KeywordSearchTracker.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+import { useAtomValue } from 'jotai'
+import { keywordState } from '../store/atom'
+import { trackEvent } from '../utils/track'
+
+// キーワード検索が実行されたとき(keywordが空→非空、または値が変化)に1回だけ計測する。
+// トップフォームからのGET着地・URL直アクセス・アプリ内検索の全経路を網羅し、
+// カテゴリ/並び替え変更(keyword不変)やクリア(空)では撃たない。検索語は search_term に入れる。
+export default function KeywordSearchTracker() {
+  const keyword = useAtomValue(keywordState)
+  const prevRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (keyword && keyword !== prevRef.current) {
+      trackEvent('keyword_search', { search_term: keyword })
+    }
+    prevRef.current = keyword
+  }, [keyword])
+
+  return null
+}

--- a/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
+++ b/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
@@ -5,7 +5,6 @@ import { useSetListParams } from './ListParamsHooks'
 import { useAtomValue } from 'jotai'
 import { keywordState } from '../store/atom'
 import { langCode } from '../config/config'
-import { trackEvent } from '../utils/track'
 
 export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => void) | undefined) {
   const [open, setOpen] = useState(false)
@@ -87,8 +86,6 @@ export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => v
       if (keyword.length > maxLength) {
         keyword = keyword.substring(0, maxLength)
       }
-
-      trackEvent('search', { search_term: keyword })
 
       if (siperSlideTo) {
         setParams((params) => {

--- a/frontend/ranking/src/pages/OCListPage.tsx
+++ b/frontend/ranking/src/pages/OCListPage.tsx
@@ -7,6 +7,7 @@ import { getValidListParams } from '../hooks/ListParamsHooks'
 import { listParamsState, keywordState } from '../store/atom'
 import { useMediaQuery } from '@mui/material'
 import OcListMainTabsVertical from '../components/OcListMainTabsVertical'
+import KeywordSearchTracker from '../components/KeywordSearchTracker'
 
 export default function OCListPage() {
   const { category } = useParams()
@@ -33,6 +34,7 @@ export default function OCListPage() {
 
   return (
     <Provider store={store}>
+      <KeywordSearchTracker />
       {matches ? (
         <OcListMainTabsVertical cateIndex={cateIndex} />
       ) : (


### PR DESCRIPTION
先のGA計測で、キーワード検索だけ取りこぼしがありました。トップページの検索フォームからランキングへ遷移（GET）した場合や、検索結果URLに直接アクセスした場合に検索が記録されません（アプリ内のフォーム送信時しか送っていなかったため）。

検索キーワードの状態が「空→非空」または値が変わったときに1回だけ送る方式へ変更し、トップフォーム・URL直アクセス・アプリ内検索の全経路を漏れなく拾います。カテゴリ・並び替えの変更や、検索のクリア時には送りません。

あわせてイベント名を `search` から `keyword_search` に変更しました（キーワード検索に限定した指標であることを明確にするため）。検索語は `search_term` の値に入ります。

GTM側のイベント名（keyword_search）への変更は反映済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
