### PR TITLE
[STG] feat: 「LINEで開く」遷移とグラフ操作の詳細をアクセス解析で計測

### DIFF
--- a/app/Views/components/oc_jump_page.php
+++ b/app/Views/components/oc_jump_page.php
@@ -113,6 +113,22 @@ $_css[] = 'pages/oc-jump';
   <?php GAd::loadAdsTag() ?>
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
   <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
+  <?php // 「LINEで開く」クリックを GA4(GTM dataLayer経由)で計測。LINEへ遷移直前でも beacon で飛ぶ。
+        // カテゴリはIDがロケールごとに別物なので、ロケール解決済みの名称(getCategoryName)で送る。 ?>
+  <script>
+    (function () {
+      var b = document.getElementById('line-open-button')
+      if (!b) return
+      b.addEventListener('click', function () {
+        (window.dataLayer = window.dataLayer || []).push({
+          event: 'oc_jump',
+          oc_id: <?php echo (int)$oc['id'] ?>,
+          oc_name: <?php echo json_encode((string)$oc['name'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>,
+          oc_category: <?php echo json_encode(getCategoryName((int)$oc['category']), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>
+        })
+      })
+    })()
+  </script>
 </body>
 
 </html>

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -262,6 +262,9 @@ export function handleChangeRankingRising(alignment: ToggleChart) {
 
   fetchChart(false)
   setUrlParamsFromChartStates()
+
+  // 順位グラフ種別: ranking=ランキング / rising=急上昇 / none=表示なし
+  trackEvent('chart_rank', { rank_type: alignment })
 }
 
 export function handleChangeEnableZoom(value: boolean) {
@@ -357,4 +360,7 @@ export function handleChangeChartMode(mode: ChartMode) {
 
   fetchChart(true)
   setUrlParamsFromChartStates()
+
+  // グラフ種別: candlestick=ローソク足 / line=折れ線
+  trackEvent('chart_mode', { mode })
 }


### PR DESCRIPTION
オプチャグラフで一番重要な操作のひとつ「LINEで開く」（参加確認ページからLINEへ実際に遷移するボタン）が、これまでGoogleアナリティクスで計測されていませんでした。どの部屋がどれだけLINE遷移されたか＝実質のコンバージョンが分かるよう、ボタンのクリックを `oc_jump` として送ります。

## LINEで開く（oc_jump）

- 計測する値: 部屋ID（oc_id）／部屋名（oc_name）／カテゴリ名（oc_category）
- カテゴリはIDがロケール（日本語/繁体字/タイ語）ごとに別物なので、ロケール解決済みの名称で送ります。
- LINEへ遷移する直前のクリックでも、GA4はbeacon送信のため取りこぼしません。

## グラフ操作の細分化

期間切替（`chart_period`）だけでなく、グラフ種別とランキング種別も取れるようにしました。

- `chart_mode` … ローソク足／折れ線（mode = candlestick / line）
- `chart_rank` … ランキング／急上昇／表示なし（rank_type = ranking / rising / none）

GTM側のイベント・ディメンション設定は反映済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
