### PR TITLE
[STG] skip-ci: グラフ操作の計測を統合し表示状態の組み合わせを取れるように

### DIFF
--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -235,10 +235,22 @@ export function handleChangeLimit(limit: ChartLimit | 25) {
   }
 
   setUrlParamsFromChartStates()
+  trackChartChange('period')
+}
 
-  // limit値→期間: 25=最新24時間 / 8=1週間 / 31=1ヶ月 / 0=全期間
+// グラフ操作はどれでも chart_change を送り、period/mode/rank_type/category の全状態と、
+// 今回変えた項目(changed)を毎回含める。これで「ローソク足×1ヶ月」等の組み合わせを集計できる。
+// (URLはreplaceStateで書くだけでGA4は遷移後を拾えないため、状態はイベントに載せる)
+function trackChartChange(changed: 'period' | 'mode' | 'rank' | 'category') {
+  const limit = graphStore.get(limitAtom)
   const period = limit === 25 ? '24h' : limit === 8 ? '1week' : limit === 31 ? '1month' : 'all'
-  trackEvent('chart_period', { period })
+  trackEvent('chart_change', {
+    changed,
+    period,
+    mode: graphStore.get(chartModeAtom),
+    rank_type: graphStore.get(rankingRisingAtom),
+    category: graphStore.get(categoryAtom),
+  })
 }
 
 export function handleChangeCategory(alignment: urlParamsValue<'category'> | null) {
@@ -246,6 +258,7 @@ export function handleChangeCategory(alignment: urlParamsValue<'category'> | nul
   graphStore.set(categoryAtom, alignment)
   fetchChart(false)
   setUrlParamsFromChartStates()
+  trackChartChange('category')
 }
 
 export function handleChangeRankingRising(alignment: ToggleChart) {
@@ -262,9 +275,7 @@ export function handleChangeRankingRising(alignment: ToggleChart) {
 
   fetchChart(false)
   setUrlParamsFromChartStates()
-
-  // 順位グラフ種別: ranking=ランキング / rising=急上昇 / none=表示なし
-  trackEvent('chart_rank', { rank_type: alignment })
+  trackChartChange('rank')
 }
 
 export function handleChangeEnableZoom(value: boolean) {
@@ -360,7 +371,5 @@ export function handleChangeChartMode(mode: ChartMode) {
 
   fetchChart(true)
   setUrlParamsFromChartStates()
-
-  // グラフ種別: candlestick=ローソク足 / line=折れ線
-  trackEvent('chart_mode', { mode })
+  trackChartChange('mode')
 }


### PR DESCRIPTION
先にグラフ操作（期間・グラフ種別・ランキング種別・カテゴリ）を別々のイベントで計測していましたが、これだと「その時どの組み合わせで見ていたか」（例: ローソク足で1ヶ月表示）が分かりませんでした。各イベントが自分の1項目しか持たないためです。

どの操作でも単一の `chart_change` を送り、`period` / `mode` / `rank_type` / `category` の全状態と、今回変えた項目（`changed`）を毎回含めるようにしました。これで組み合わせをそのまま集計でき、何を操作したかも `changed` で分かります。

補足: グラフの状態はURLにも入りますが、サイト内の変更は `replaceState` のためGA4が遷移後を拾えません。なので状態はイベントに載せます。

GTM側は `chart_change` を追加し、旧 `chart_period` / `chart_mode` / `chart_rank` は廃止済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
