### PR TITLE
[STG] skip-ci: ランキングのボタン操作を計測＋全イベントに言語(locale)ディメンションを付与

### DIFF
--- a/frontend/ranking/src/components/ListToggleChips.tsx
+++ b/frontend/ranking/src/components/ListToggleChips.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react'
 import { Chip, Stack } from '@mui/material'
 import { useSetListParams } from '../hooks/ListParamsHooks'
 import { t } from '../config/translation'
+import { trackEvent } from '../utils/track'
 
 type ToggleButtons = [ListParams['list'], string][]
 
@@ -22,6 +23,7 @@ const ListToggleChips = memo(function ListToggleButton({
   const setParams = useSetListParams()
   const handleChange = (newList: ListParams['list']) => {
     if (newList) {
+      trackEvent('ranking_action', { action: `period:${newList}` })
       setParams((params) => ({ ...params, list: newList, order: '', sort: '' }))
     }
   }

--- a/frontend/ranking/src/components/OCListSortMenu.tsx
+++ b/frontend/ranking/src/components/OCListSortMenu.tsx
@@ -4,6 +4,7 @@ import SortIcon from '@mui/icons-material/Sort'
 import { isSP } from '../utils/utils'
 import { useSetListParams } from '../hooks/ListParamsHooks'
 import { t } from '../config/translation'
+import { trackEvent } from '../utils/track'
 
 export const rankingOptions2: SortOptions = [
   /* [['ランキング順', t('並び順')], 'asc', 'rank'], */
@@ -44,6 +45,7 @@ export const OCListSortMenu = memo(function OCListSortMenu({
   }
 
   const handleMenuItemClick = (e: ClickEvent, i: number) => {
+    trackEvent('ranking_action', { action: `sort:${options[i][2]}_${options[i][1]}` })
     setParams((params) => ({ ...params, order: options[i][1], sort: options[i][2] }))
     setAnchorEl(null)
   }

--- a/frontend/ranking/src/components/OcListMainTabs.tsx
+++ b/frontend/ranking/src/components/OcListMainTabs.tsx
@@ -20,6 +20,7 @@ import SiteHeader from './SiteHeader'
 import { useInView } from 'react-intersection-observer'
 import { t } from '../config/translation'
 import RecommendThemeShelf from './RecommendThemeShelf'
+import { trackEvent } from '../utils/track'
 
 function LinkTab(props: { label?: string; href?: string }) {
   return (
@@ -75,6 +76,8 @@ function OcListSwiper({
   const onSlideChange = useCallback((swiper: SwiperCore) => {
     const newValue = swiper.activeIndex
     if (currentIndex.current === newValue) return
+
+    trackEvent('ranking_action', { action: `category:${OPEN_CHAT_CATEGORY[newValue][1]}` })
 
     setParams((params) => {
       const category = OPEN_CHAT_CATEGORY[newValue][1]

--- a/frontend/ranking/src/components/OcListMainTabsVertical.tsx
+++ b/frontend/ranking/src/components/OcListMainTabsVertical.tsx
@@ -11,6 +11,7 @@ import SiteHeaderVertical from './SiteHeaderVertical'
 import SiteHeaderVerticalSearch from './SiteHeaderVerticalSearch'
 import { t } from '../config/translation'
 import RecommendThemeShelf from './RecommendThemeShelf'
+import { trackEvent } from '../utils/track'
 
 function TabPanel({ children, value, index }: TabPanelProps) {
   return <div hidden={value !== index}>{value === index && children}</div>
@@ -36,6 +37,8 @@ export default function OcListMainTabsVertical({ cateIndex }: { cateIndex: numbe
 
   const handleChange = (e: React.SyntheticEvent, newValue: number) => {
     if (e.type === 'click' && !samePageLinkNavi(e as LinkEvent)) return
+
+    trackEvent('ranking_action', { action: `category:${OPEN_CHAT_CATEGORY[newValue][1]}` })
 
     const category = OPEN_CHAT_CATEGORY[newValue][1]
     const url = updateURLSearchParams({ ...params, sub_category: '' })

--- a/frontend/ranking/src/components/SubCategoryChips.tsx
+++ b/frontend/ranking/src/components/SubCategoryChips.tsx
@@ -10,6 +10,7 @@ import { rankingArgDto } from '../config/config'
 import { useAtom } from 'jotai'
 import { subCategoryChipsStackScrollLeft } from '../store/atom'
 import { t } from '../config/translation'
+import { trackEvent } from '../utils/track'
 
 const Chips = memo(function Chips({
   sub_category,
@@ -22,6 +23,9 @@ const Chips = memo(function Chips({
   const existsProp = category && Object.hasOwn(rankingArgDto.subCategories, category)
 
   const handleChange = (newValue: ListParams['sub_category']) => {
+    if (newValue) {
+      trackEvent('ranking_action', { action: `subcategory:${newValue}` })
+    }
     setStackScrollLeft(stackParentRef.current?.scrollLeft || 0)
     setParams((params) => ({ ...params, sub_category: newValue }))
   }


### PR DESCRIPTION
ランキング画面のボタン操作（期間切替・並び替え・カテゴリ切替・サブカテゴリ選択）が計測されていなかったので、単一イベント `ranking_action` で記録します。「どのボタンを押したか」を1つの値（`action`）で表します。

- `period:daily` など（期間チップ）
- `sort:increase_desc` など（並び替え）
- `category:<id>`（カテゴリタブ／スワイプ。タブ・スワイプとも1箇所に集約して二重発火なし）
- `subcategory:<名>`（サブカテゴリ。選択時のみ）

あわせて、全イベント共通の言語ディメンション `locale`（ja / tw / th）をGTM側でページパスから付与しました（page_view・検索・LINEで開く・グラフ・コメント・ランキング操作の全部に付きます）。本番プロパティは全言語が混ざるため、言語で切り分けられるようにするためです。

GTM側のイベント・ディメンション設定は反映済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
