### PR TITLE
[STG] feat: 参加確認ページを開いた段階も計測（LINE遷移率を出せるように）

### DIFF
--- a/app/Views/components/oc_jump_page.php
+++ b/app/Views/components/oc_jump_page.php
@@ -113,19 +113,22 @@ $_css[] = 'pages/oc-jump';
   <?php GAd::loadAdsTag() ?>
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
   <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
-  <?php // 「LINEで開く」クリックを GA4(GTM dataLayer経由)で計測。LINEへ遷移直前でも beacon で飛ぶ。
+  <?php // 参加確認ページを GA4(GTM dataLayer経由)で計測。開いた時点=open_jump、「LINEで開く」押下=oc_jump。
+        // 両者の比でLINE遷移率(コンバージョン)が出せる。LINEへ遷移直前のクリックでも beacon で飛ぶ。
         // カテゴリはIDがロケールごとに別物なので、ロケール解決済みの名称(getCategoryName)で送る。 ?>
   <script>
     (function () {
+      var d = (window.dataLayer = window.dataLayer || [])
+      var info = {
+        oc_id: <?php echo (int)$oc['id'] ?>,
+        oc_name: <?php echo json_encode((string)$oc['name'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>,
+        oc_category: <?php echo json_encode(getCategoryName((int)$oc['category']), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>
+      }
+      d.push(Object.assign({ event: 'open_jump' }, info))
       var b = document.getElementById('line-open-button')
       if (!b) return
       b.addEventListener('click', function () {
-        (window.dataLayer = window.dataLayer || []).push({
-          event: 'oc_jump',
-          oc_id: <?php echo (int)$oc['id'] ?>,
-          oc_name: <?php echo json_encode((string)$oc['name'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>,
-          oc_category: <?php echo json_encode(getCategoryName((int)$oc['category']), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>
-        })
+        d.push(Object.assign({ event: 'oc_jump' }, info))
       })
     })()
   </script>


### PR DESCRIPTION
「LINEで開く」ボタンの押下（oc_jump）は計測していましたが、その手前の「参加確認ページを開いた」段階が取れていませんでした。`open_jump` として、ページを開いた時点でも同じ値（部屋ID・部屋名・カテゴリ）を送ります。

これで open_jump → oc_jump の比で、部屋ごと・カテゴリごとのLINE遷移率（実質コンバージョン率）が出せます。言語（locale）も全イベント共通で付きます。

GTM側の設定は反映済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
