### PR TITLE
[PROD] feat: 利用者の主要操作をアクセス解析で計測（検索・LINE遷移・グラフ・ランキング操作）

### DIFF
--- a/app/Views/components/oc_jump_page.php
+++ b/app/Views/components/oc_jump_page.php
@@ -113,19 +113,22 @@ $_css[] = 'pages/oc-jump';
   <?php GAd::loadAdsTag() ?>
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
   <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
-  <?php // 「LINEで開く」クリックを GA4(GTM dataLayer経由)で計測。LINEへ遷移直前でも beacon で飛ぶ。
+  <?php // 参加確認ページを GA4(GTM dataLayer経由)で計測。開いた時点=open_jump、「LINEで開く」押下=oc_jump。
+        // 両者の比でLINE遷移率(コンバージョン)が出せる。LINEへ遷移直前のクリックでも beacon で飛ぶ。
         // カテゴリはIDがロケールごとに別物なので、ロケール解決済みの名称(getCategoryName)で送る。 ?>
   <script>
     (function () {
+      var d = (window.dataLayer = window.dataLayer || [])
+      var info = {
+        oc_id: <?php echo (int)$oc['id'] ?>,
+        oc_name: <?php echo json_encode((string)$oc['name'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>,
+        oc_category: <?php echo json_encode(getCategoryName((int)$oc['category']), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>
+      }
+      d.push(Object.assign({ event: 'open_jump' }, info))
       var b = document.getElementById('line-open-button')
       if (!b) return
       b.addEventListener('click', function () {
-        (window.dataLayer = window.dataLayer || []).push({
-          event: 'oc_jump',
-          oc_id: <?php echo (int)$oc['id'] ?>,
-          oc_name: <?php echo json_encode((string)$oc['name'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>,
-          oc_category: <?php echo json_encode(getCategoryName((int)$oc['category']), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>
-        })
+        d.push(Object.assign({ event: 'oc_jump' }, info))
       })
     })()
   </script>

--- a/app/Views/components/oc_jump_page.php
+++ b/app/Views/components/oc_jump_page.php
@@ -113,6 +113,22 @@ $_css[] = 'pages/oc-jump';
   <?php GAd::loadAdsTag() ?>
   <script src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
   <script defer src="<?php echo fileurl("/js/security.js", urlRoot: '') ?>"></script>
+  <?php // 「LINEで開く」クリックを GA4(GTM dataLayer経由)で計測。LINEへ遷移直前でも beacon で飛ぶ。
+        // カテゴリはIDがロケールごとに別物なので、ロケール解決済みの名称(getCategoryName)で送る。 ?>
+  <script>
+    (function () {
+      var b = document.getElementById('line-open-button')
+      if (!b) return
+      b.addEventListener('click', function () {
+        (window.dataLayer = window.dataLayer || []).push({
+          event: 'oc_jump',
+          oc_id: <?php echo (int)$oc['id'] ?>,
+          oc_name: <?php echo json_encode((string)$oc['name'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>,
+          oc_category: <?php echo json_encode(getCategoryName((int)$oc['category']), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>
+        })
+      })
+    })()
+  </script>
 </body>
 
 </html>

--- a/frontend/oc-app/src/comments/components/Button/LikeButton.tsx
+++ b/frontend/oc-app/src/comments/components/Button/LikeButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import LikeButtonUi from './LikeButtonUi'
 import { fetchApi } from '../../utils/utils'
+import { trackEvent } from '../../../util/track'
 
 export type LikeBtnState = LikeBtnApi & { commentId: number }
 
@@ -15,13 +16,21 @@ export default function LikeButton(props: LikeBtnState) {
       if (sendingRef.current) return
       sendingRef.current = true
 
+      // 未投票なら付与(POST)、投票済みなら取り消し(DELETE)
+      const isAdding = state.voted === ''
+
       try {
         const res = await fetchApi<LikeBtnApi>(
           `${window.location.origin}/comment_reaction/${state.commentId}`,
-          state.voted === '' ? 'POST' : 'DELETE',
+          isAdding ? 'POST' : 'DELETE',
           { type }
         )
         setState({ ...res, commentId: state.commentId })
+
+        // 付与時のみ計測。empathy=いいね！/negative=うーん…
+        if (isAdding) {
+          trackEvent('comment_vote', { vote_type: type === 'negative' ? 'dislike' : 'like' })
+        }
       } finally {
         sendingRef.current = false
       }

--- a/frontend/oc-app/src/comments/components/CommentForm.tsx
+++ b/frontend/oc-app/src/comments/components/CommentForm.tsx
@@ -11,6 +11,7 @@ import { inputNameState } from '../state/inputNameState'
 import { appInitTagDto } from '../config/appInitTagDto'
 import { errorDialogState } from '../state/errorDialogState'
 import { imageFilesState } from '../state/imageFilesState'
+import { trackEvent } from '../../util/track'
 
 export default function CommentForm() {
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -70,6 +71,7 @@ export default function CommentForm() {
         setName('')
         setText('')
         setImageFiles([])
+        trackEvent('comment_submit', { has_image: currentImages.length > 0 })
       } catch (error) {
         console.error(error)
         let message: string

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -235,10 +235,22 @@ export function handleChangeLimit(limit: ChartLimit | 25) {
   }
 
   setUrlParamsFromChartStates()
+  trackChartChange('period')
+}
 
-  // limit値→期間: 25=最新24時間 / 8=1週間 / 31=1ヶ月 / 0=全期間
+// グラフ操作はどれでも chart_change を送り、period/mode/rank_type/category の全状態と、
+// 今回変えた項目(changed)を毎回含める。これで「ローソク足×1ヶ月」等の組み合わせを集計できる。
+// (URLはreplaceStateで書くだけでGA4は遷移後を拾えないため、状態はイベントに載せる)
+function trackChartChange(changed: 'period' | 'mode' | 'rank' | 'category') {
+  const limit = graphStore.get(limitAtom)
   const period = limit === 25 ? '24h' : limit === 8 ? '1week' : limit === 31 ? '1month' : 'all'
-  trackEvent('chart_period', { period })
+  trackEvent('chart_change', {
+    changed,
+    period,
+    mode: graphStore.get(chartModeAtom),
+    rank_type: graphStore.get(rankingRisingAtom),
+    category: graphStore.get(categoryAtom),
+  })
 }
 
 export function handleChangeCategory(alignment: urlParamsValue<'category'> | null) {
@@ -246,6 +258,7 @@ export function handleChangeCategory(alignment: urlParamsValue<'category'> | nul
   graphStore.set(categoryAtom, alignment)
   fetchChart(false)
   setUrlParamsFromChartStates()
+  trackChartChange('category')
 }
 
 export function handleChangeRankingRising(alignment: ToggleChart) {
@@ -262,9 +275,7 @@ export function handleChangeRankingRising(alignment: ToggleChart) {
 
   fetchChart(false)
   setUrlParamsFromChartStates()
-
-  // 順位グラフ種別: ranking=ランキング / rising=急上昇 / none=表示なし
-  trackEvent('chart_rank', { rank_type: alignment })
+  trackChartChange('rank')
 }
 
 export function handleChangeEnableZoom(value: boolean) {
@@ -360,7 +371,5 @@ export function handleChangeChartMode(mode: ChartMode) {
 
   fetchChart(true)
   setUrlParamsFromChartStates()
-
-  // グラフ種別: candlestick=ローソク足 / line=折れ線
-  trackEvent('chart_mode', { mode })
+  trackChartChange('mode')
 }

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -3,6 +3,7 @@ import { graphStore } from './store'
 import { chartMeta, chatArgDto, fetchChart } from '../util/fetchRenderer'
 import OpenChatChart from '../classes/OpenChatChart'
 import { getCurrentUrlParams, getStoregeFixedLimitSetting, setUrlParams } from '../util/urlParam'
+import { trackEvent } from '../../util/track'
 
 export const chart = new OpenChatChart()
 export const loadingAtom = atom(false)
@@ -234,6 +235,10 @@ export function handleChangeLimit(limit: ChartLimit | 25) {
   }
 
   setUrlParamsFromChartStates()
+
+  // limit値→期間: 25=最新24時間 / 8=1週間 / 31=1ヶ月 / 0=全期間
+  const period = limit === 25 ? '24h' : limit === 8 ? '1week' : limit === 31 ? '1month' : 'all'
+  trackEvent('chart_period', { period })
 }
 
 export function handleChangeCategory(alignment: urlParamsValue<'category'> | null) {

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -262,6 +262,9 @@ export function handleChangeRankingRising(alignment: ToggleChart) {
 
   fetchChart(false)
   setUrlParamsFromChartStates()
+
+  // 順位グラフ種別: ranking=ランキング / rising=急上昇 / none=表示なし
+  trackEvent('chart_rank', { rank_type: alignment })
 }
 
 export function handleChangeEnableZoom(value: boolean) {
@@ -357,4 +360,7 @@ export function handleChangeChartMode(mode: ChartMode) {
 
   fetchChart(true)
   setUrlParamsFromChartStates()
+
+  // グラフ種別: candlestick=ローソク足 / line=折れ線
+  trackEvent('chart_mode', { mode })
 }

--- a/frontend/oc-app/src/util/track.ts
+++ b/frontend/oc-app/src/util/track.ts
@@ -1,0 +1,10 @@
+// dataLayer 経由で GTM にカスタムイベントを送る。測定先(本番/STG)の出し分けは GTM 側(hostName ルックアップ)で行うので、ここではホスト判定しない。
+export function trackEvent(name: string, params?: Record<string, unknown>): void {
+  try {
+    const w = window as unknown as { dataLayer?: Record<string, unknown>[] }
+    w.dataLayer = w.dataLayer || []
+    w.dataLayer.push({ event: name, ...(params || {}) })
+  } catch {
+    /* noop */
+  }
+}

--- a/frontend/ranking/src/components/KeywordSearchTracker.tsx
+++ b/frontend/ranking/src/components/KeywordSearchTracker.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+import { useAtomValue } from 'jotai'
+import { keywordState } from '../store/atom'
+import { trackEvent } from '../utils/track'
+
+// キーワード検索が実行されたとき(keywordが空→非空、または値が変化)に1回だけ計測する。
+// トップフォームからのGET着地・URL直アクセス・アプリ内検索の全経路を網羅し、
+// カテゴリ/並び替え変更(keyword不変)やクリア(空)では撃たない。検索語は search_term に入れる。
+export default function KeywordSearchTracker() {
+  const keyword = useAtomValue(keywordState)
+  const prevRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (keyword && keyword !== prevRef.current) {
+      trackEvent('keyword_search', { search_term: keyword })
+    }
+    prevRef.current = keyword
+  }, [keyword])
+
+  return null
+}

--- a/frontend/ranking/src/components/ListToggleChips.tsx
+++ b/frontend/ranking/src/components/ListToggleChips.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react'
 import { Chip, Stack } from '@mui/material'
 import { useSetListParams } from '../hooks/ListParamsHooks'
 import { t } from '../config/translation'
+import { trackEvent } from '../utils/track'
 
 type ToggleButtons = [ListParams['list'], string][]
 
@@ -22,6 +23,7 @@ const ListToggleChips = memo(function ListToggleButton({
   const setParams = useSetListParams()
   const handleChange = (newList: ListParams['list']) => {
     if (newList) {
+      trackEvent('ranking_action', { action: `period:${newList}` })
       setParams((params) => ({ ...params, list: newList, order: '', sort: '' }))
     }
   }

--- a/frontend/ranking/src/components/OCListSortMenu.tsx
+++ b/frontend/ranking/src/components/OCListSortMenu.tsx
@@ -4,6 +4,7 @@ import SortIcon from '@mui/icons-material/Sort'
 import { isSP } from '../utils/utils'
 import { useSetListParams } from '../hooks/ListParamsHooks'
 import { t } from '../config/translation'
+import { trackEvent } from '../utils/track'
 
 export const rankingOptions2: SortOptions = [
   /* [['ランキング順', t('並び順')], 'asc', 'rank'], */
@@ -44,6 +45,7 @@ export const OCListSortMenu = memo(function OCListSortMenu({
   }
 
   const handleMenuItemClick = (e: ClickEvent, i: number) => {
+    trackEvent('ranking_action', { action: `sort:${options[i][2]}_${options[i][1]}` })
     setParams((params) => ({ ...params, order: options[i][1], sort: options[i][2] }))
     setAnchorEl(null)
   }

--- a/frontend/ranking/src/components/OcListMainTabs.tsx
+++ b/frontend/ranking/src/components/OcListMainTabs.tsx
@@ -20,6 +20,7 @@ import SiteHeader from './SiteHeader'
 import { useInView } from 'react-intersection-observer'
 import { t } from '../config/translation'
 import RecommendThemeShelf from './RecommendThemeShelf'
+import { trackEvent } from '../utils/track'
 
 function LinkTab(props: { label?: string; href?: string }) {
   return (
@@ -75,6 +76,8 @@ function OcListSwiper({
   const onSlideChange = useCallback((swiper: SwiperCore) => {
     const newValue = swiper.activeIndex
     if (currentIndex.current === newValue) return
+
+    trackEvent('ranking_action', { action: `category:${OPEN_CHAT_CATEGORY[newValue][1]}` })
 
     setParams((params) => {
       const category = OPEN_CHAT_CATEGORY[newValue][1]

--- a/frontend/ranking/src/components/OcListMainTabsVertical.tsx
+++ b/frontend/ranking/src/components/OcListMainTabsVertical.tsx
@@ -11,6 +11,7 @@ import SiteHeaderVertical from './SiteHeaderVertical'
 import SiteHeaderVerticalSearch from './SiteHeaderVerticalSearch'
 import { t } from '../config/translation'
 import RecommendThemeShelf from './RecommendThemeShelf'
+import { trackEvent } from '../utils/track'
 
 function TabPanel({ children, value, index }: TabPanelProps) {
   return <div hidden={value !== index}>{value === index && children}</div>
@@ -36,6 +37,8 @@ export default function OcListMainTabsVertical({ cateIndex }: { cateIndex: numbe
 
   const handleChange = (e: React.SyntheticEvent, newValue: number) => {
     if (e.type === 'click' && !samePageLinkNavi(e as LinkEvent)) return
+
+    trackEvent('ranking_action', { action: `category:${OPEN_CHAT_CATEGORY[newValue][1]}` })
 
     const category = OPEN_CHAT_CATEGORY[newValue][1]
     const url = updateURLSearchParams({ ...params, sub_category: '' })

--- a/frontend/ranking/src/components/SubCategoryChips.tsx
+++ b/frontend/ranking/src/components/SubCategoryChips.tsx
@@ -10,6 +10,7 @@ import { rankingArgDto } from '../config/config'
 import { useAtom } from 'jotai'
 import { subCategoryChipsStackScrollLeft } from '../store/atom'
 import { t } from '../config/translation'
+import { trackEvent } from '../utils/track'
 
 const Chips = memo(function Chips({
   sub_category,
@@ -22,6 +23,9 @@ const Chips = memo(function Chips({
   const existsProp = category && Object.hasOwn(rankingArgDto.subCategories, category)
 
   const handleChange = (newValue: ListParams['sub_category']) => {
+    if (newValue) {
+      trackEvent('ranking_action', { action: `subcategory:${newValue}` })
+    }
     setStackScrollLeft(stackParentRef.current?.scrollLeft || 0)
     setParams((params) => ({ ...params, sub_category: newValue }))
   }

--- a/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
+++ b/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
@@ -5,7 +5,6 @@ import { useSetListParams } from './ListParamsHooks'
 import { useAtomValue } from 'jotai'
 import { keywordState } from '../store/atom'
 import { langCode } from '../config/config'
-import { trackEvent } from '../utils/track'
 
 export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => void) | undefined) {
   const [open, setOpen] = useState(false)
@@ -87,8 +86,6 @@ export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => v
       if (keyword.length > maxLength) {
         keyword = keyword.substring(0, maxLength)
       }
-
-      trackEvent('search', { search_term: keyword })
 
       if (siperSlideTo) {
         setParams((params) => {

--- a/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
+++ b/frontend/ranking/src/hooks/useSiteHeaderSearch.ts
@@ -5,6 +5,7 @@ import { useSetListParams } from './ListParamsHooks'
 import { useAtomValue } from 'jotai'
 import { keywordState } from '../store/atom'
 import { langCode } from '../config/config'
+import { trackEvent } from '../utils/track'
 
 export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => void) | undefined) {
   const [open, setOpen] = useState(false)
@@ -86,6 +87,8 @@ export default function useSiteHeaderSearch(siperSlideTo?: ((index: number) => v
       if (keyword.length > maxLength) {
         keyword = keyword.substring(0, maxLength)
       }
+
+      trackEvent('search', { search_term: keyword })
 
       if (siperSlideTo) {
         setParams((params) => {

--- a/frontend/ranking/src/pages/OCListPage.tsx
+++ b/frontend/ranking/src/pages/OCListPage.tsx
@@ -7,6 +7,7 @@ import { getValidListParams } from '../hooks/ListParamsHooks'
 import { listParamsState, keywordState } from '../store/atom'
 import { useMediaQuery } from '@mui/material'
 import OcListMainTabsVertical from '../components/OcListMainTabsVertical'
+import KeywordSearchTracker from '../components/KeywordSearchTracker'
 
 export default function OCListPage() {
   const { category } = useParams()
@@ -33,6 +34,7 @@ export default function OCListPage() {
 
   return (
     <Provider store={store}>
+      <KeywordSearchTracker />
       {matches ? (
         <OcListMainTabsVertical cateIndex={cateIndex} />
       ) : (

--- a/frontend/ranking/src/utils/track.ts
+++ b/frontend/ranking/src/utils/track.ts
@@ -1,0 +1,10 @@
+// dataLayer 経由で GTM にカスタムイベントを送る。測定先(本番/STG)の出し分けは GTM 側(hostName ルックアップ)で行うので、ここではホスト判定しない。
+export function trackEvent(name: string, params?: Record<string, unknown>): void {
+  try {
+    const w = window as unknown as { dataLayer?: Record<string, unknown>[] }
+    w.dataLayer = w.dataLayer || []
+    w.dataLayer.push({ event: name, ...(params || {}) })
+  } catch {
+    /* noop */
+  }
+}

--- a/public/style/react/OpenChat.css
+++ b/public/style/react/OpenChat.css
@@ -17,12 +17,12 @@
 
 .super-icon.official {
   width: 20px;
-  background-image: url(https://openchat-review.me/assets/line_svg_sprite.svg);
+  background-image: url(/../assets/line_svg_sprite.svg);
   background-position: -62px -76px;
 }
 
 .super-icon.sp {
-  background-image: url(https://openchat-review.me/assets/line_svg_sprite.svg);
+  background-image: url(/../assets/line_svg_sprite.svg);
   background-position: -33px -76px;
 }
 


### PR DESCRIPTION
利用者の主要操作をGoogleアナリティクスで計測できるようにする一連の変更を本番へ反映します。これまでページ表示数しか取れておらず、検索・コメント・LINE遷移・グラフ操作などが集計できませんでした。

含まれるstg PR:
- #460 検索・コメント投稿・いいね・グラフ期間切替を計測
- #461 キーワード検索を全経路で確実に（keyword_search）
- #462 「LINEで開く」遷移とグラフ操作の詳細
- #463 グラフ操作を1イベントに統合（表示状態の組み合わせ）
- #464 ランキングのボタン操作＋全イベントに言語(locale)
- #465 参加確認ページを開いた段階も計測（open_jump・LINE遷移率）

本番GA4プロパティ側のカスタムディメンション登録とGTM設定は反映済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
