### PR TITLE
[PROD] 横長広告をフッター直前へ移動し標準サイズに整理、不要な内部通知を停止

### DIFF
--- a/app/Services/Cron/OcreviewApiCommentDataImporter.php
+++ b/app/Services/Cron/OcreviewApiCommentDataImporter.php
@@ -605,22 +605,8 @@ class OcreviewApiCommentDataImporter
             return;
         }
 
-        // レコード数を取得（ログ用）
-        $sourceCount = $this->sourceCommentPdo->query("SELECT COUNT(*) FROM {$sourceTable}")->fetchColumn();
-        $targetCount = $this->targetPdo->query("SELECT COUNT(*) FROM {$targetTable}")->fetchColumn();
-
-        AdminTool::sendDiscordNotify(sprintf(
-            '【%s】不足レコード検出: %d 件のソースレコードがターゲットに存在しません (ソース: %d, ターゲット: %d)',
-            $targetTable,
-            count($missingIds),
-            $sourceCount,
-            $targetCount
-        ));
-
         // 不足しているレコードを100件ずつチャンクで取得・挿入
         $this->insertMissingRecords($sourceTable, $targetTable, $sourceIdColumn, $missingIds, $transformCallback);
-
-        AdminTool::sendDiscordNotify(sprintf('【%s】不足レコード挿入完了: %d 件', $targetTable, count($missingIds)));
     }
 
     /**

--- a/app/Services/Cron/OcreviewApiDataImporter.php
+++ b/app/Services/Cron/OcreviewApiDataImporter.php
@@ -1049,19 +1049,6 @@ class OcreviewApiDataImporter
             return;
         }
 
-        // レコード数を取得（ログ用）
-        $sourceCountQuery = "SELECT COUNT(*) FROM {$sourceTable}" . ($sourceWhereClause ? " WHERE {$sourceWhereClause}" : "");
-        $sourceCount = $sourcePdo->query($sourceCountQuery)->fetchColumn();
-        $targetCount = $targetPdo->query("SELECT COUNT(*) FROM {$targetTable}")->fetchColumn();
-
-        AdminTool::sendDiscordNotify(sprintf(
-            '【%s】不足レコード検出: %d 件のソースレコードがターゲットに存在しません (ソース: %d, ターゲット: %d)',
-            $targetTable,
-            count($missingIds),
-            $sourceCount,
-            $targetCount
-        ));
-
         // 不足しているレコードを100件ずつチャンクで取得・挿入
         $this->insertMissingRecords(
             $sourcePdo,
@@ -1072,8 +1059,6 @@ class OcreviewApiDataImporter
             $missingIds,
             $transformCallback
         );
-
-        AdminTool::sendDiscordNotify(sprintf('【%s】不足レコード挿入完了: %d 件', $targetTable, count($missingIds)));
     }
 
     /**

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -35,10 +35,9 @@
                 </div>
             </div>
 
-            <?php // CTA直後にOC横長1枠（固定）。
-                  // SEO 流入の初見読者に Offerwall を出さないよう、blog では Offerwall のみタグ側で抑制する ?>
+            <?php // SEO 流入の初見読者に Offerwall を出さないよう、blog では Offerwall のみタグ側で抑制する
+                  // （広告枠 ocTopHorizontal はフッター直前に出力する） ?>
             <?php \App\Views\Ads\GoogleAdsense::gTag(suppressOfferwall: true) ?>
-            <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
 
             <?php if (!empty($_faqHtml)): ?>
                 <div class="blog-faq"><?php echo $_faqHtml ?></div>
@@ -57,6 +56,8 @@
             <?php endif ?>
         </article>
     </main>
+    <?php // フッター直前にOC横長1枠（固定）。adblock検出の維持も兼ねる ?>
+    <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
     <?php \App\Views\Ads\GoogleAdsense::loadAdsTag() ?>
     <?php viewComponent('footer_inner') ?>
     <?php echo $_breadcrumbsShema ?>

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -211,12 +211,6 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
     <?php // 関連ルーム(類似サイズ/おすすめ)は recommend 静的キャッシュ(.dat)から都度組み立て（MySQL不使用） ?>
     <?php viewComponent('oc_recommend_aside', ['similarSize' => $_similarSize, 'recommend' => $_recommend, 'oc' => $oc]) ?>
 
-    <?php if ($enableAdsense): ?>
-      <?php // 関連ルームの下にOC横長1枠（固定。高さ確保済みでCLSなし。回遊導線は遮らない）。
-            // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-      <?php GAd::output('ocTopHorizontal') ?>
-    <?php endif ?>
-
 
     <?php if (MimimalCmsConfig::$urlRoot === ''): // TODO:日本以外ではコメントが無効
     ?>
@@ -238,6 +232,12 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
         </script>
         <div id="comment-root"></div>
       </section>
+    <?php endif ?>
+
+    <?php if ($enableAdsense): ?>
+      <?php // コメントの下・フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。
+            // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
+      <?php GAd::output('ocTopHorizontal') ?>
     <?php endif ?>
     <?php viewComponent('footer_inner') ?>
 

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -96,14 +96,14 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
 
     </section>
 
-    <?php if ($enableAdsense && isset($recommend)): ?>
-      <?php // ランキングリスト直下にOC横長1枠（固定。リストは分断しない。高さ確保済みでCLSなし）。
-            // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-      <?php GAd::output('ocTopHorizontal') ?>
-    <?php endif ?>
-
     <?php if (isset($_discovery) && !$_discovery->isEmpty()) : ?>
       <?php viewComponent('theme_discovery', ['discovery' => $_discovery]) ?>
+    <?php endif ?>
+
+    <?php if ($enableAdsense && isset($recommend)): ?>
+      <?php // フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。
+            // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
+      <?php GAd::output('ocTopHorizontal') ?>
     <?php endif ?>
 
     <?php viewComponent('footer_inner') ?>

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -91,12 +91,6 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
         <?php viewComponent('top_ranking_comment_list_hour', compact('dto')) ?>
         <?php viewComponent('top_ranking_comment_list_hour24', compact('dto')) ?>
 
-        <?php if ($enableAdsense): ?>
-            <?php // 最近のコメントの上にOC横長1枠（固定。高さ確保済みでCLSなし）。
-                  // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-            <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
-        <?php endif ?>
-
         <?php if (MimimalCmsConfig::$urlRoot === ''): ?>
             <?php viewComponent('top_ranking_recent_comments') ?>
         <?php endif ?>
@@ -107,6 +101,12 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
         <?php viewComponent('recommend_list2', ['recommend' => $officialDto, 'id' => 0]) ?>
         <?php viewComponent('recommend_list2', ['recommend' => $officialDto2, 'id' => 0]) ?>
+
+        <?php if ($enableAdsense): ?>
+            <?php // フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。
+                  // security.js の広告ブロック検出はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
+            <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
+        <?php endif ?>
 
         <?php viewComponent('footer_inner') ?>
         <div class="refresh-time" style="width: fit-content; margin: auto; padding-bottom: 0.5rem; margin-top: -9px;">

--- a/public/style/components/site_header.css
+++ b/public/style/components/site_header.css
@@ -681,10 +681,30 @@ html.is-ios .site_header_outer.header-hidden {
   aspect-ratio: 1;
 }
 
+/* 横長広告: 画面幅ごとに標準的なバナーサイズへ。
+   モバイル 320x100（大モバイルバナー）/ タブレット 468x60 / PC 728x90（リーダーボード）。
+   固定サイズなので CLS が出ず、配信枠とクリエイティブのサイズが一致して
+   左右の白い余白が出ない（中央寄せ・両脇はページ背景になじむ）。 */
 .horizontal-ads {
-  width: auto;
+  display: block;
+  width: 320px;
   height: 100px;
-  max-height: 100px;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+@media screen and (min-width: 500px) {
+  .horizontal-ads {
+    width: 468px;
+    height: 60px;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .horizontal-ads {
+    width: 728px;
+    height: 90px;
+  }
 }
 
 .rectangle-ads-parent,
@@ -725,6 +745,17 @@ html.is-ios .site_header_outer.header-hidden {
   display: block;
   background: var(--c-bg-sub);
 }
+
+/* 自動広告がフィード内に自動挿入する枠の地色をページ背景になじませる
+   （ダークモード時に枠まわりが白く浮くのを防ぐ）。クリエイティブ(iframe)の
+   中身は Google 配信なので変えられないが、枠の余白はこちらで暗色化できる。 */
+.google-auto-placed {
+  background: var(--c-bg);
+}
+
+/* アンカー広告（最下部の固定バー）の暗色化はCSSでは不可・未対応。
+   Google が ins 背景を inライン !important で当てる（外部CSSは負ける）うえ、
+   「∨」閉じタブは closed shadow 内に描画され adoptedStyleSheets も届かないため。 */
 
 .rectangle2-ads {
   width: auto;

--- a/public/style/react/SiteHeader.css
+++ b/public/style/react/SiteHeader.css
@@ -200,6 +200,12 @@ ins.adsbygoogle[data-anchor-status='dismissed'] {
   display: none !important;
 }
 
+/* 自動広告がフィード内に自動挿入する枠の地色をページ背景になじませる
+   （ダークモード時に枠まわりが白く浮くのを防ぐ）。 */
+.google-auto-placed {
+  background: var(--c-bg);
+}
+
 ins.adsbygoogle[data-ad-status='unfilled'] {
   background: var(--c-bg-sub);
   position: relative;


### PR DESCRIPTION
stg の以下の変更を本番へ昇格します。

主要ページの横長広告（広告ブロック検出も兼ねる1枠）をフッター直前へ移動。
本文中に出ていた自動広告と重なって表示が崩れるのを避け、回遊導線も遮らない。
ルームはコメントの下、おすすめは「テーマを探す」の下に配置。ブログ一覧は元から
カード一覧の末尾＝フッター直前のため変更なし。

横長広告を画面幅ごとの標準バナーサイズに調整（モバイル320x100／タブレット468x60／
PC728x90）。固定サイズでCLSは出ず、配信枠とクリエイティブのサイズが一致して
左右の白い余白が出ない。

ダークモード時、自動広告枠の地色をページ背景になじませて白浮きを抑制。

レコード補完処理（openchat_master・コメント）の「不足レコード検出／挿入完了」
Discord通知を停止（不要なノイズのため）。補完ロジックは維持。

効かないアンカー広告用CSS（Googleのインライン!importantとclosed shadowに阻まれ無効）を撤去。

検証: php -l / PHPStan ともにクリーン。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
