### PR TITLE
[STG] fix: おすすめタグの「全レコードに即時反映」を続けて押すと最新の編集が反映されない問題を修正

### DIFF
--- a/app/Services/Recommend/RebuildAllRecommendTagsService.php
+++ b/app/Services/Recommend/RebuildAllRecommendTagsService.php
@@ -17,7 +17,7 @@ use Shared\MimimalCmsConfig;
  * おすすめタグの全レコード再適用ジョブ（batch/exec/tag_update.php のエントリから起動）。
  *
  * GUI からの「全レコードに即時反映」で使われ、タグ再構築から静的データ生成・CDN purge までを
- * 一気通貫で実行する。実行中フラグによる二重実行防止と通知を含む。
+ * 一気通貫で実行する。二重実行時は実行中の前プロセスを kill して後発で再実行する（最新の定義を優先）。
  */
 class RebuildAllRecommendTagsService
 {
@@ -32,12 +32,21 @@ class RebuildAllRecommendTagsService
         $now = date('Y-m-d H:i:s');
 
         try {
-            // 二重実行防止: 既に実行中なら何もせず終了
+            // 二重実行時は後発優先: 実行中の前プロセスを kill して引き継ぐ。
+            // タグ反映は時間がかかるため、古い定義のまま走る先行ランをスキップで待つと
+            // 最新の編集が黙って取りこぼされる。最新で上書きするため前ランを止めて再実行する。
+            // shadow-swap の build テーブルは毎回 DROP→作り直し、RENAME は原子的なので、
+            // 先行ランを途中 kill しても live は不整合にならない（本ランが全件作り直す）。
             if ($this->state->getBool(StateType::isRecommendTagRebuildActive)) {
-                $message = 'rebuildAllViaShadowSwap: 既に実行中のためスキップ at ' . $now;
+                $message = 'rebuildAllViaShadowSwap: 既に実行中のため前回の処理をkillして再実行 at ' . $now;
                 CronUtility::addCronLog($message);
                 AdminTool::sendDiscordNotify($message);
-                return;
+
+                // 自分以外の tag_update.php をkill（killされた側は finally が走らずフラグを
+                // 下ろせないため、この後こちらで立て直して所有する）
+                CronUtility::addCronLog('kill結果: ' . $this->launcher->killOtherInstances(BatchScript::tagUpdate));
+                $this->state->setFalse(StateType::isRecommendTagRebuildActive);
+                sleep(5); // プロセス終了を待つ
             }
 
             $this->state->setTrue(StateType::isRecommendTagRebuildActive);

--- a/app/Services/Recommend/TagDefinition/data/ja.json
+++ b/app/Services/Recommend/TagDefinition/data/ja.json
@@ -2685,7 +2685,9 @@
             },
             {
                 "tag": "DISH／／",
-                "keywords": ["DISH//"]
+                "keywords": [
+                    "DISH//"
+                ]
             },
             {
                 "tag": "HIPHOP"
@@ -3038,6 +3040,12 @@
         ]
     },
     "nameStrong": [
+        {
+            "tag": "声劇",
+            "keywords": [
+                "声劇"
+            ]
+        },
         {
             "tag": "ガチャガチャ",
             "keywords": [


### PR DESCRIPTION
おすすめタグの定義を編集して「全レコードに即時反映」を押し、反映が終わる前にもう一度編集して押し直すと、後から押した方が無視されていた。先に走っている処理は編集前の古い定義で動いているので、最新の編集が反映されないまま終わる。反映には時間がかかるため起きやすい。

## 対処

後から来た実行が、走っている前の処理を止めてから最新の定義で実行し直すように変更した。既存のおすすめ静的データ生成ジョブ（[`UpdateRecommendStaticDataService`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Services/Recommend/StaticData/UpdateRecommendStaticDataService.php#L36-L47)）と同じ「前プロセスを kill して引き継ぐ」方式に揃えた。

変更前: 実行中フラグが立っていたら何もせず終了（最新の編集を取りこぼす）
変更後: 走っている `tag_update.php` を kill → フラグを立て直して最新の定義でフル再構築

## データ破損しないか

[`applyViaShadowSwap`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Models/RecommendRepositories/RecommendTagRepository.php#L89-L129) は作業用テーブルを毎回作り直し、表示用テーブルへの入れ替え（RENAME）は原子的。前の処理を途中で止めても表示用データは壊れない。作業用テーブル（`_build`/`_old`）は再実行の冒頭 `DROP IF EXISTS` で消え、一時テーブルは接続切断で自動破棄されるので残らない。

## その他

あわせて ja.json に「声劇」タグ（nameStrong）を追加。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/Open-Chat-Graph\`