### PR TITLE
[STG] skip-ci: 本番デプロイがSQLite初期化で失敗する問題を修正（oc_page_cacheはMySQL移行済）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,12 +142,7 @@ jobs:
 
       - name: Initialize SQLite databases
         run: |
-          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do for name in statistics_ohlc ranking_position_ohlc oc_page_cache; do db="storage/$lang/SQLite/$name/$name.db"; if [ ! -f "$db" ]; then sqlite3 "$db" < "setup/schema/sqlite/$name.sql" && echo "Created: $db"; fi; done; done'
-
-      # 既存DBへの追加カラム反映（MySQLの加算スキーマ同期と同じ思想・冪等。カラムが既にあれば何もしない）
-      - name: Sync SQLite schema (additive, idempotent)
-        run: |
-          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do db="storage/$lang/SQLite/oc_page_cache/oc_page_cache.db"; if [ -f "$db" ]; then sqlite3 "$db" "ALTER TABLE oc_page_cache ADD COLUMN narrative_data TEXT" 2>/dev/null && echo "Added narrative_data: $db" || true; fi; done'
+          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do for name in statistics_ohlc ranking_position_ohlc; do db="storage/$lang/SQLite/$name/$name.db"; if [ ! -f "$db" ]; then sqlite3 "$db" < "setup/schema/sqlite/$name.sql" && echo "Created: $db"; fi; done; done'
 
       # setup/schema/mysql/*.sql を source of truth に、全DBグループ(ocreview/ranking/comment/userlog)へ
       # 不足テーブル・カラム・索引を「加算のみ」で冪等反映する (MySQL/MariaDB 両対応)。


### PR DESCRIPTION
ルーム分析文キャッシュ(oc_page_cache)を SQLite から MySQL へ移した際、`setup/schema/sqlite/oc_page_cache.sql` を削除したが、`deploy.yml` の「Initialize SQLite databases」がまだ oc_page_cache を初期化対象に含めていた。サーバに該当 SQLite DB が無いと削除済みの SQL ファイルを参照し、デプロイ全体が exit 1 で失敗する（[失敗ログ](https://github.com/Open-Chat-Graph/Open-Chat-Graph/actions/runs/27489781164)）。直前の oc_page_cache MySQL 移行 PR の後始末漏れ。

## 対処

- 初期化リストから `oc_page_cache` を除外（`statistics_ohlc` / `ranking_position_ohlc` はSQLiteのまま）
- oc_page_cache 専用だった「Sync SQLite schema（narrative_data 追加）」ステップを削除（MySQL移行済で不要）

deploy.yml のみの変更で PHP 非変更・mock クローリングと無関係のため skip-ci。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/Open-Chat-Graph\`