### PR TITLE
[PROD] skip-ci: 本番デプロイがSQLite初期化で失敗する問題を修正（oc_page_cacheはMySQL移行済）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,12 +142,7 @@ jobs:
 
       - name: Initialize SQLite databases
         run: |
-          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do for name in statistics_ohlc ranking_position_ohlc oc_page_cache; do db="storage/$lang/SQLite/$name/$name.db"; if [ ! -f "$db" ]; then sqlite3 "$db" < "setup/schema/sqlite/$name.sql" && echo "Created: $db"; fi; done; done'
-
-      # 既存DBへの追加カラム反映（MySQLの加算スキーマ同期と同じ思想・冪等。カラムが既にあれば何もしない）
-      - name: Sync SQLite schema (additive, idempotent)
-        run: |
-          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do db="storage/$lang/SQLite/oc_page_cache/oc_page_cache.db"; if [ -f "$db" ]; then sqlite3 "$db" "ALTER TABLE oc_page_cache ADD COLUMN narrative_data TEXT" 2>/dev/null && echo "Added narrative_data: $db" || true; fi; done'
+          ssh -p ${{ steps.config.outputs.ssh_port }} ${{ steps.config.outputs.ssh_user }}@${{ steps.config.outputs.ssh_host }} 'cd ${{ steps.config.outputs.ssh_path }} && for lang in ja tw th; do for name in statistics_ohlc ranking_position_ohlc; do db="storage/$lang/SQLite/$name/$name.db"; if [ ! -f "$db" ]; then sqlite3 "$db" < "setup/schema/sqlite/$name.sql" && echo "Created: $db"; fi; done; done'
 
       # setup/schema/mysql/*.sql を source of truth に、全DBグループ(ocreview/ranking/comment/userlog)へ
       # 不足テーブル・カラム・索引を「加算のみ」で冪等反映する (MySQL/MariaDB 両対応)。


### PR DESCRIPTION
stg の #472 を main へ昇格。

oc_page_cache を SQLite から MySQL へ移行した際の後始末漏れで、`deploy.yml` の「Initialize SQLite databases」が削除済みの `oc_page_cache.sql` を参照して本番デプロイ全体が失敗していた。初期化リストから oc_page_cache を外し、不要になった SQLite カラム追加ステップを削除。

詳細: https://github.com/Open-Chat-Graph/Open-Chat-Graph/pull/472

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/Open-Chat-Graph\`