### PR TITLE
[PROD] perf: コメント一覧の取得を高速化（いいね集計を表示分だけに限定し約15%短縮）

### DIFF
--- a/app/Models/CommentRepositories/CommentListRepository.php
+++ b/app/Models/CommentRepositories/CommentListRepository.php
@@ -11,8 +11,9 @@ class CommentListRepository implements CommentListRepositoryInterface
 {
     function findComments(CommentListApiArgs $args): array
     {
+        // 1. ページぶんのコメントを確定（comment + log のみ。index駆動で軽い）
         $query =
-        "SELECT
+            "SELECT
                 c.id,
                 c.comment_id AS commentId,
                 CASE
@@ -33,44 +34,11 @@ class CommentListRepository implements CommentListRepositoryInterface
                     WHEN c.user_id = :user_id THEN 0
                     ELSE c.flag
                 END AS flag,
-                IFNULL(l.empathy, 0) AS empathyCount,
-                IFNULL(l.insights, 0) AS insightsCount,
-                IFNULL(l.negative, 0) AS negativeCount,
-                IFNULL(l.voted, '') AS voted,
                 lg.ip AS logIp,
                 lg.ua AS logUa
             FROM
                 comment AS c
                 LEFT JOIN log AS lg ON lg.entity_id = c.comment_id AND lg.type = 'AddComment'
-                LEFT JOIN (
-                    SELECT
-                        comment_id,
-                        COUNT(
-                            CASE
-                                WHEN type = 'empathy' THEN 1
-                            END
-                        ) AS empathy,
-                        COUNT(
-                            CASE
-                                WHEN type = 'insights' THEN 1
-                            END
-                        ) AS insights,
-                        COUNT(
-                            CASE
-                                WHEN type = 'negative' THEN 1
-                            END
-                        ) AS negative,
-                        GROUP_CONCAT(
-                            CASE
-                                WHEN user_id = :user_id THEN type
-                                ELSE NULL
-                            END
-                        ) AS voted
-                    FROM
-                        `like`
-                    GROUP BY
-                        comment_id
-                ) AS l ON l.comment_id = c.comment_id
             WHERE
                 c.open_chat_id = :open_chat_id
                 AND (c.flag != 1 OR c.user_id = :user_id)
@@ -79,12 +47,73 @@ class CommentListRepository implements CommentListRepositoryInterface
             LIMIT
                 :offset, :limit";
 
-        return CommentDB::fetchAll($query, [
+        /** @var CommentListApi[] $comments */
+        $comments = CommentDB::fetchAll($query, [
             'user_id' => $args->user_id,
             'open_chat_id' => $args->open_chat_id,
             'offset' => $args->page * $args->limit,
             'limit' => $args->limit,
         ], [\PDO::FETCH_CLASS, CommentListApi::class]);
+
+        if (!$comments) {
+            return [];
+        }
+
+        // 2. いいね集計はページ内コメントだけにスコープして取得し、マージ
+        $commentIds = array_map(fn(CommentListApi $c) => $c->commentId, $comments);
+        $likeMap = $this->fetchLikeCounts($commentIds, $args->user_id);
+
+        foreach ($comments as $c) {
+            $like = $likeMap[$c->commentId] ?? null;
+            if ($like !== null) {
+                $c->empathyCount = (int)$like['empathy'];
+                $c->insightsCount = (int)$like['insights'];
+                $c->negativeCount = (int)$like['negative'];
+                $c->voted = $like['voted'] ?? '';
+            }
+        }
+
+        return $comments;
+    }
+
+    /**
+     * 指定コメントIDぶんのいいね集計を comment_id => 集計行 のマップで返す
+     *
+     * @param int[] $commentIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchLikeCounts(array $commentIds, string $user_id): array
+    {
+        $params = ['user_id' => $user_id];
+        $placeholders = [];
+        foreach (array_values($commentIds) as $i => $id) {
+            $key = "cid_{$i}";
+            $placeholders[] = ":{$key}";
+            $params[$key] = $id;
+        }
+        $in = implode(',', $placeholders);
+
+        $query =
+            "SELECT
+                comment_id,
+                COUNT(CASE WHEN type = 'empathy' THEN 1 END) AS empathy,
+                COUNT(CASE WHEN type = 'insights' THEN 1 END) AS insights,
+                COUNT(CASE WHEN type = 'negative' THEN 1 END) AS negative,
+                GROUP_CONCAT(CASE WHEN user_id = :user_id THEN type END) AS voted
+            FROM
+                `like`
+            WHERE
+                comment_id IN ({$in})
+            GROUP BY
+                comment_id";
+
+        $rows = CommentDB::fetchAll($query, $params);
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[(int)$row['comment_id']] = $row;
+        }
+        return $map;
     }
 
     function findCommentById(int $comment_id): array|false

--- a/app/Models/CommentRepositories/Dto/CommentListApi.php
+++ b/app/Models/CommentRepositories/Dto/CommentListApi.php
@@ -15,10 +15,10 @@ class CommentListApi
     public string $time;
     public string $userId;
     public int $flag;
-    public int $empathyCount;
-    public int $insightsCount;
-    public int $negativeCount;
-    public string $voted;
+    public int $empathyCount = 0;
+    public int $insightsCount = 0;
+    public int $negativeCount = 0;
+    public string $voted = '';
     public ?string $logIp = null;
     public ?string $logUa = null;
 

--- a/app/Models/CommentRepositories/test/CommentListRepositoryTest.php
+++ b/app/Models/CommentRepositories/test/CommentListRepositoryTest.php
@@ -19,12 +19,12 @@ class CommentListRepositoryTest extends TestCase
     {
         $this->inst = app(CommentListRepository::class);
 
-        $args = new CommentListApiArgs;
-
-        $args->open_chat_id = 1234;
-        $args->user_id = 'test';
-        $args->limit = 2;
-        $args->page = 1;
+        $args = new CommentListApiArgs(
+            page: 1,
+            limit: 2,
+            open_chat_id: 1234,
+            user_id: 'test',
+        );
 
         $r = $this->inst->findComments($args);
         debug($r);


### PR DESCRIPTION
stg の #480 を本番(main)へ昇格。

コメント一覧の取得処理で、いいね集計を表示するコメントぶんだけに限定して約15%短縮。詳細は #480 を参照。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
