### PR TITLE
[PROD] skip-ci: おすすめタグの全レコード再適用を既定で待機にして暴走を防止

### DIFF
--- a/app/Controllers/Pages/AdminPageController.php
+++ b/app/Controllers/Pages/AdminPageController.php
@@ -98,7 +98,8 @@ class AdminPageController
      */
     function tagupdate()
     {
-        $this->batchScriptLauncher->launchInBackground(BatchScript::tagUpdate);
+        // admin からの手動実行は実行中の前ランを kill して後発で再実行する（--cancel-previous）。
+        $this->batchScriptLauncher->launchInBackground(BatchScript::tagUpdate, '--cancel-previous');
 
         return view('admin/admin_message_page', ['title' => 'exec', 'message' => BatchScript::tagUpdate->absolutePath() . ' を実行しました。']);
     }

--- a/app/Controllers/Pages/AdminRecommendTagController.php
+++ b/app/Controllers/Pages/AdminRecommendTagController.php
@@ -139,7 +139,9 @@ class AdminRecommendTagController
     public function rebuild()
     {
         // urlRoot を渡してロケール別に再構築（'' なら ja）。バックグラウンドで起動。
-        $this->batchScriptLauncher->launchInBackground(BatchScript::tagUpdate, (string)MimimalCmsConfig::$urlRoot);
+        // admin/編集画面からの手動反映は最新の編集を確実に反映したいので、実行中の前ランを
+        // kill して後発で再実行する（--cancel-previous）。
+        $this->batchScriptLauncher->launchInBackground(BatchScript::tagUpdate, (string)MimimalCmsConfig::$urlRoot, '--cancel-previous');
         return response(['ok' => true]);
     }
 

--- a/app/Services/Recommend/RebuildAllRecommendTagsService.php
+++ b/app/Services/Recommend/RebuildAllRecommendTagsService.php
@@ -17,7 +17,7 @@ use Shared\MimimalCmsConfig;
  * おすすめタグの全レコード再適用ジョブ（batch/exec/tag_update.php のエントリから起動）。
  *
  * GUI からの「全レコードに即時反映」で使われ、タグ再構築から静的データ生成・CDN purge までを
- * 一気通貫で実行する。二重実行時は実行中の前プロセスを kill して後発で再実行する（最新の定義を優先）。
+ * 一気通貫で実行する。二重実行時の挙動は $cancelPrevious で切り替える（既定は待機）。
  */
 class RebuildAllRecommendTagsService
 {
@@ -27,17 +27,33 @@ class RebuildAllRecommendTagsService
         private BatchScriptLauncher $launcher,
     ) {}
 
-    function handle(): void
+    /**
+     * @param bool $cancelPrevious 既に実行中だった場合の挙動。
+     *   false（既定）: 実行中ならスキップして待機する（前のランの完走を優先）。
+     *                  毎時処理など定期トリガでは、反映がトリガ間隔より長くかかっても
+     *                  後発が前を kill し続けて永遠に完走しない事態を避けるためこちらを使う。
+     *   true: 実行中の前プロセスを kill して後発で再実行する（最新の定義を優先）。
+     *         GUI/admin からの手動実行のように、最新の編集を確実に反映したいときに使う。
+     */
+    function handle(bool $cancelPrevious = false): void
     {
         $now = date('Y-m-d H:i:s');
 
         try {
-            // 二重実行時は後発優先: 実行中の前プロセスを kill して引き継ぐ。
-            // タグ反映は時間がかかるため、古い定義のまま走る先行ランをスキップで待つと
-            // 最新の編集が黙って取りこぼされる。最新で上書きするため前ランを止めて再実行する。
-            // shadow-swap の build テーブルは毎回 DROP→作り直し、RENAME は原子的なので、
-            // 先行ランを途中 kill しても live は不整合にならない（本ランが全件作り直す）。
             if ($this->state->getBool(StateType::isRecommendTagRebuildActive)) {
+                if (!$cancelPrevious) {
+                    // 既定（待機）: 実行中なら何もせず終了し、前のランを完走させる。
+                    $message = 'rebuildAllViaShadowSwap: 既に実行中のためスキップ at ' . $now;
+                    CronUtility::addCronLog($message);
+                    AdminTool::sendDiscordNotify($message);
+                    return;
+                }
+
+                // 後発優先: 実行中の前プロセスを kill して引き継ぐ。
+                // タグ反映は時間がかかるため、古い定義のまま走る先行ランをスキップで待つと
+                // 最新の編集が黙って取りこぼされる。最新で上書きするため前ランを止めて再実行する。
+                // shadow-swap の build テーブルは毎回 DROP→作り直し、RENAME は原子的なので、
+                // 先行ランを途中 kill しても live は不整合にならない（本ランが全件作り直す）。
                 $message = 'rebuildAllViaShadowSwap: 既に実行中のため前回の処理をkillして再実行 at ' . $now;
                 CronUtility::addCronLog($message);
                 AdminTool::sendDiscordNotify($message);

--- a/app/Services/Recommend/test/RebuildAllRecommendTagsServiceTest.php
+++ b/app/Services/Recommend/test/RebuildAllRecommendTagsServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Config\SecretsConfig;
+use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
+use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\Cron\Utility\BatchScriptLauncher;
+use App\Services\Recommend\RebuildAllRecommendTagsService;
+use App\Services\Recommend\RecommendUpdater;
+use PHPUnit\Framework\TestCase;
+use Shared\MimimalCmsConfig;
+
+// docker compose exec app vendor/bin/phpunit app/Services/Recommend/test/RebuildAllRecommendTagsServiceTest.php
+//
+// handle() の二重実行時の分岐だけを、依存を全てモックして検証する。
+// 実DB再構築・CDN purge は走らせない（updater/launcher をモックして無効化）。
+// Discord 通知も飛ばさない（webhook URL を空にして curl を no-op 化）。
+class RebuildAllRecommendTagsServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        MimimalCmsConfig::$urlRoot = '';      // ja 経路（rebuildAllViaShadowSwap）
+        SecretsConfig::$discordWebhookUrl = ''; // 通知を外に飛ばさない
+    }
+
+    /** 既定（待機）: 実行中なら kill も再構築もせず即 return する */
+    public function test_default_waits_when_active(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->with(StateType::isRecommendTagRebuildActive)->willReturn(true);
+
+        $updater = $this->createMock(RecommendUpdater::class);
+        $launcher = $this->createMock(BatchScriptLauncher::class);
+
+        // スキップ＝前ランを kill しない・再構築しない・静的データ生成へ連鎖しない
+        $launcher->expects($this->never())->method('killOtherInstances');
+        $updater->expects($this->never())->method('rebuildAllViaShadowSwap');
+        $launcher->expects($this->never())->method('launchSync');
+        // 待機なので実行中フラグを立てない（前ランの所有を奪わない）
+        $state->expects($this->never())->method('setTrue');
+
+        (new RebuildAllRecommendTagsService($state, $updater, $launcher))->handle(false);
+    }
+
+    /** cancelPrevious=true: 実行中なら前ランを kill して再構築→静的データ生成へ連鎖する */
+    public function test_cancel_previous_kills_and_reruns_when_active(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->with(StateType::isRecommendTagRebuildActive)->willReturn(true);
+
+        $updater = $this->createMock(RecommendUpdater::class);
+        $launcher = $this->createMock(BatchScriptLauncher::class);
+
+        $launcher->expects($this->once())->method('killOtherInstances')->willReturn('killed');
+        $updater->expects($this->once())->method('rebuildAllViaShadowSwap');
+        $launcher->expects($this->once())->method('launchSync'); // 静的データ生成へ連鎖
+
+        (new RebuildAllRecommendTagsService($state, $updater, $launcher))->handle(true);
+    }
+
+    /** 実行中でなければ、引数に関わらず通常どおり再構築する（kill は呼ばない） */
+    public function test_runs_normally_when_not_active(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->with(StateType::isRecommendTagRebuildActive)->willReturn(false);
+
+        $updater = $this->createMock(RecommendUpdater::class);
+        $launcher = $this->createMock(BatchScriptLauncher::class);
+
+        $launcher->expects($this->never())->method('killOtherInstances');
+        $updater->expects($this->once())->method('rebuildAllViaShadowSwap');
+        $launcher->expects($this->once())->method('launchSync');
+
+        (new RebuildAllRecommendTagsService($state, $updater, $launcher))->handle(false);
+    }
+}

--- a/batch/exec/tag_update.php
+++ b/batch/exec/tag_update.php
@@ -9,8 +9,16 @@ use Shared\MimimalCmsConfig;
 
 set_time_limit(3600 * 10);
 
-if (isset($argv[1]) && $argv[1]) {
-    MimimalCmsConfig::$urlRoot = $argv[1];
+// 引数: 位置引数 = urlRoot（ロケール, '' なら ja）/ フラグ --cancel-previous。
+// --cancel-previous を付けたときだけ、実行中の前プロセスを kill して再実行する。
+// 付けない既定では実行中ならスキップして待機する（定期トリガで永遠に kill され続けないように）。
+$cancelPrevious = false;
+foreach (array_slice($argv, 1) as $arg) {
+    if ($arg === '--cancel-previous') {
+        $cancelPrevious = true;
+    } elseif ($arg !== '') {
+        MimimalCmsConfig::$urlRoot = $arg;
+    }
 }
 
 try {
@@ -18,7 +26,7 @@ try {
      * @var RebuildAllRecommendTagsService $service
      */
     $service = app(RebuildAllRecommendTagsService::class);
-    $service->handle();
+    $service->handle($cancelPrevious);
 } catch (\Throwable $e) {
     // サービス解決自体の失敗（デプロイ中のクラス入れ替わり等）に備えた最終防衛のみ
     CronUtility::addCronLog($e->__toString());


### PR DESCRIPTION
stg を main へ反映するリリースPR。

## 内容

おすすめタグの「全レコードに即時反映」の二重実行時の挙動を引数で切り替え可能にし、**既定を「実行中ならスキップして待機」に戻した**（前のランの完走を優先）。データ増加で 1 回の反映がトリガ間隔より長くかかったとき、後発が前を kill し続けて永遠に完走しなくなる事態を防ぐ。

admin / 編集画面からの手動実行（「全レコードに即時反映」・「タグ更新」）だけは、最新の編集を確実に反映するため常に前のランを kill して再実行する（`--cancel-previous`）。

二重実行時の3分岐（既定=待機 / cancel=前ランkill / 非実行中=通常）を依存モックで検証するテストも追加。ローカルで全パス確認済み。

詳細は #489。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-mock`
