### PR TITLE
[PROD] perf: おすすめ「テーマの勢い」のフォールバック集計を廃止して毎時バッチを軽量化

### DIFF
--- a/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
+++ b/app/Models/Repositories/Recommend/RecommendGrowthRepository.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace App\Models\Repositories\Recommend;
 
 use App\Models\SQLite\SQLiteRankingPosition;
-use App\Models\SQLite\SQLiteStatistics;
 
 /**
  * /recommend テーマページの「勢いグラフ」用データ取得(集計のみ・副作用なし)。
  *
- * 2 系統の指標を返す:
- *   1. rank   … LINE 公式「ランキング」(category=0=全体)での掲載部屋の最高(=最小)順位の日次推移【ヒーロー】
- *   2. member … 同一部屋コホートの合計メンバー数(規模の伸び・rank が無いテーマのフォールバック)
+ * 指標は1つ: rank … LINE 公式「ランキング」(category=0=全体)での掲載部屋の最高(=最小)順位の日次推移。
+ * ランキング掲載が無い(2点未満の)テーマは「勢い」を出さない(空配列を返す)。旧 member フォールバック
+ * (同一部屋コホートの合計メンバー数)は、表示が rank 優先で大半のテーマで計算しても捨てられていたため廃止。
  *
  * ヒーローを「最高順位」にした理由:
  *   LINE 公式「ランキング」は人数だけでなく活動量を反映する(人数との Spearman ≒ 0.26。14人の部屋が
@@ -20,15 +19,9 @@ use App\Models\SQLite\SQLiteStatistics;
  *   ~3部屋(0のことも多い)と疎すぎてカウントには向かない。そこで掲載部屋の「最も良い順位
  *   (= MIN(position))」を採る。順位は小さいほど良い=活発。
  *
- * バイアス対策(member):「同一部屋コホート」で集計する。
- *   期間の開始日と終了日の両方に記録がある掲載部屋だけを対象にし、その合計人数を日次で返す。
- *   こうすることで「途中で現れた部屋による段差」「期間中に消えた部屋による下振れ」「記録欠損を
- *   0 として合算する過大評価」を排除し、"今と過去で存在する同じ部屋同士" の比較に揃える。
- *
  * 注意(残るバイアス・呼び出し側/キャプションで明示すること):
  *   - 対象は「掲載中の上位部屋」であり、タグ全体ではない(掲載は人気上位に限られる選抜バイアス)。
- *   - rank は ranking_position.db(ロケール別)、member は statistics.db(ロケール別)から集計。
- *     いずれも ja/tw/th 全ロケール対応。ocgraph_sqlapi は使用しない。
+ *   - rank は ranking_position.db(ロケール別)から集計。ja/tw/th 全ロケール対応。ocgraph_sqlapi は使用しない。
  */
 class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
 {
@@ -47,60 +40,33 @@ class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
      * @param int $days 遡る日数
      * @return array{
      *   spanDays: int,
-     *   rank: array{points: array{date:string, value:int}[], current:int, first:int, leaderId:int},
-     *   member: array{points: array{date:string, value:int}[], increase:int, rooms:int}
-     * }|array{} データ不足時は空配列
+     *   rank: array{points: array{date:string, value:int}[], current:int, first:int, leaderId:int}
+     * }|array{} 掲載が無い(2点未満)等のデータ不足時は空配列
      *
-     * rank   = 全体ランキングでの掲載部屋の最高(=最小)順位の日次推移(value=その日の MIN(position))【ヒーロー】。
-     *          leaderId = 最新日にその最高順位を持っていた部屋の open_chat_id(どの部屋の話か示すため)。
-     * member = 同一部屋コホートの合計人数(規模・rank が無いテーマのフォールバック)。
+     * rank = 全体ランキングでの掲載部屋の最高(=最小)順位の日次推移(value=その日の MIN(position))。
+     *        leaderId = 最新日にその最高順位を持っていた部屋の open_chat_id(どの部屋の話か示すため)。
      */
     public function themeMomentum(array $openChatIds, \DateTime $anchorDate, int $days = 7): array
     {
-        $rank   = $this->bestRankPositionDaily($openChatIds, $anchorDate, $days);
-        // rank は ranking_position.db(ロケール別)、member は statistics.db(ロケール別)から集計。
-        // いずれも ja/tw/th 全ロケール対応。
-        $member = $this->themeGrowth($openChatIds, $anchorDate, $days);
+        // rank は ranking_position.db(ロケール別・ja/tw/th 全ロケール対応)から集計。
+        $rank = $this->bestRankPositionDaily($openChatIds, $anchorDate, $days);
 
-        // ヒーロー(rank)が 2 点未満 かつ member も空ならグラフ・数値を出す意味が無いので空配列。
-        if (count($rank['points']) < 2 && !$member['points']) {
+        // ランキング掲載が無い(2点未満の)テーマはグラフを描けないので「勢い」を出さない。
+        if (count($rank['points']) < 2) {
             return [];
         }
 
-        // spanDays は rank(ヒーロー)系列優先・無ければ member 系列。
-        $spanSource = $rank['points'] ?: $member['points'];
-        $spanDays = 0;
-        if (count($spanSource) >= 2) {
-            $spanDays = (new \DateTime($spanSource[count($spanSource) - 1]['date']))
-                ->diff(new \DateTime($spanSource[0]['date']))->days;
-        }
-
-        $rankCurrent = 0;
-        $rankFirst = 0;
-        if ($rank['points']) {
-            $rkp = $rank['points'];
-            $rankFirst = $rkp[0]['value'];
-            $rankCurrent = $rkp[count($rkp) - 1]['value'];
-        }
-
-        $memberIncrease = 0;
-        if ($member['points']) {
-            $mp = $member['points'];
-            $memberIncrease = $mp[count($mp) - 1]['value'] - $mp[0]['value'];
-        }
+        $rkp = $rank['points'];
+        $spanDays = (int)(new \DateTime($rkp[count($rkp) - 1]['date']))
+            ->diff(new \DateTime($rkp[0]['date']))->days;
 
         return [
             'spanDays' => $spanDays,
             'rank' => [
-                'points'   => $rank['points'],
-                'current'  => $rankCurrent,
-                'first'    => $rankFirst,
+                'points'   => $rkp,
+                'current'  => $rkp[count($rkp) - 1]['value'],
+                'first'    => $rkp[0]['value'],
                 'leaderId' => $rank['leaderId'] ?? 0,
-            ],
-            'member' => [
-                'points'   => $member['points'],
-                'increase' => $memberIncrease,
-                'rooms'    => $member['rooms'],
             ],
         ];
     }
@@ -168,67 +134,6 @@ class RecommendGrowthRepository implements RecommendGrowthRepositoryInterface
                 $rows ?: []
             ),
             'leaderId' => $leaderId,
-        ];
-    }
-
-    /**
-     * 同一部屋コホートの合計メンバー数を日次で返す。
-     *
-     * @param int[] $openChatIds 掲載部屋の ID 群
-     * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
-     * @param int $days 遡る日数
-     * @return array{points: array{date:string, value:int}[], rooms:int}
-     *         points: 日付昇順の合計 / rooms: コホートに含まれる部屋数
-     */
-    public function themeGrowth(array $openChatIds, \DateTime $anchorDate, int $days = 21): array
-    {
-        $empty = ['points' => [], 'rooms' => 0];
-
-        $ids = $this->sanitizeIds($openChatIds);
-        if (count($ids) < 3) {
-            return $empty;
-        }
-
-        $in = implode(',', $ids);
-        // DateTime 由来の Y-m-d 固定書式なのでインライン化(注入リスクなし)。
-        $since = (clone $anchorDate)->modify("-{$days} days")->format('Y-m-d');
-
-        SQLiteStatistics::connect(SQLiteStatistics::WEB_READER);
-
-        $rows = SQLiteStatistics::fetchAll(
-            "WITH bounds AS (
-                SELECT MIN(date) AS mn, MAX(date) AS mx
-                FROM statistics
-                WHERE open_chat_id IN ($in) AND date >= '$since'
-             ),
-             cohort AS (
-                SELECT s.open_chat_id
-                FROM statistics s, bounds b
-                WHERE s.open_chat_id IN ($in)
-                  AND s.date IN (b.mn, b.mx)
-                GROUP BY s.open_chat_id
-                HAVING COUNT(DISTINCT s.date) = 2
-             )
-             SELECT date,
-                    SUM(member) AS value,
-                    (SELECT COUNT(*) FROM cohort) AS rooms
-             FROM statistics
-             WHERE open_chat_id IN (SELECT open_chat_id FROM cohort)
-               AND date >= '$since'
-             GROUP BY date
-             ORDER BY date ASC"
-        );
-
-        if (!$rows) {
-            return $empty;
-        }
-
-        return [
-            'points' => array_map(
-                static fn($r) => ['date' => (string)$r['date'], 'value' => (int)$r['value']],
-                $rows
-            ),
-            'rooms' => (int)($rows[0]['rooms'] ?? 0),
         ];
     }
 

--- a/app/Models/Repositories/Recommend/RecommendGrowthRepositoryInterface.php
+++ b/app/Models/Repositories/Recommend/RecommendGrowthRepositoryInterface.php
@@ -13,26 +13,16 @@ namespace App\Models\Repositories\Recommend;
 interface RecommendGrowthRepositoryInterface
 {
     /**
-     * テーマの勢いを 1 つの配列にまとめて返す(ja/tw/th 全ロケール対応)。
+     * テーマの勢い(掲載部屋の全体ランキング最高順位の日次推移)を返す(ja/tw/th 全ロケール対応)。
+     * ランキング掲載が無い(2点未満の)テーマは空配列を返す。
      *
      * @param int[] $openChatIds 掲載部屋の ID 群
      * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
      * @param int $days 遡る日数
      * @return array{
      *   spanDays: int,
-     *   rank: array{points: array{date:string, value:int}[], current:int, first:int, leaderId:int},
-     *   member: array{points: array{date:string, value:int}[], increase:int, rooms:int}
+     *   rank: array{points: array{date:string, value:int}[], current:int, first:int, leaderId:int}
      * }|array{} データ不足時は空配列
      */
     public function themeMomentum(array $openChatIds, \DateTime $anchorDate, int $days = 7): array;
-
-    /**
-     * 同一部屋コホートの合計メンバー数を日次で返す。
-     *
-     * @param int[] $openChatIds 掲載部屋の ID 群
-     * @param \DateTime $anchorDate 「直近 N 日」の起点(最終 cron 時刻)
-     * @param int $days 遡る日数
-     * @return array{points: array{date:string, value:int}[], rooms:int}
-     */
-    public function themeGrowth(array $openChatIds, \DateTime $anchorDate, int $days = 21): array;
 }

--- a/app/Models/Repositories/Recommend/test/RecommendGrowthRepositoryTest.php
+++ b/app/Models/Repositories/Recommend/test/RecommendGrowthRepositoryTest.php
@@ -7,18 +7,16 @@
  * docker compose exec app vendor/bin/phpunit app/Models/Repositories/Recommend/test/RecommendGrowthRepositoryTest.php
  *
  * テスト方針:
- * - SQLite(ranking_position.db / statistics.db) を読み取り専用で参照(書き込み禁止)。
+ * - SQLite(ranking_position.db) を読み取り専用で参照(書き込み禁止)。
  * - 実数値は日々変わるため exact 値ではなく「不変条件」をアサート。
- * - 空配列 / 無効ID / ID不足 → empty / 空shape が返ること。
- * - themeMomentum の返り値が docブロック通りのキー・型を持つこと。
+ * - 空配列 / 無効ID / 掲載なし → empty が返ること。
+ * - themeMomentum の返り値が docブロック通りのキー・型を持つこと(member フォールバックは廃止)。
  * - rank.points が日付昇順であること。
  * - rank.leaderId が int で、>0 なら入力 ID 集合に含まれること。
- * - member.points の各 value が int であること。
- * - themeGrowth は 3ID 未満で空配列を返すこと。
  *
- * 使用する実在 ID: ranking_position.db / statistics.db(statistics テーブル)双方にデータがある
- * 小さい ID を使う。実データ環境ではこれらは必ず存在する想定。
- * ID がDBに存在しない場合でも、テストは「空配列・shape の不変条件」で壊れない設計にする。
+ * 使用する実在 ID: ranking_position.db にデータがある小さい ID を使う。実データ環境では
+ * これらは必ず存在する想定。ID がDBに存在しない場合でも、テストは「空配列・shape の不変条件」で
+ * 壊れない設計にする。
  */
 
 declare(strict_types=1);
@@ -72,7 +70,7 @@ class RecommendGrowthRepositoryTest extends TestCase
 
     public function test_themeMomentum_returns_empty_array_for_single_id(): void
     {
-        // 1件のみ → rank も member も成立しない可能性が高い → 空
+        // 1件のみ → rank の点が揃わない可能性が高い → 空
         // (空ではない場合も shape チェックだけ行う)
         $result = $this->repo->themeMomentum([3], $this->anchor);
         $this->assertIsArray($result);
@@ -93,9 +91,11 @@ class RecommendGrowthRepositoryTest extends TestCase
             $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
         }
 
-        foreach (['spanDays', 'rank', 'member'] as $key) {
+        foreach (['spanDays', 'rank'] as $key) {
             $this->assertArrayHasKey($key, $result, "トップレベルキー '{$key}' が存在すること");
         }
+        // member フォールバックは廃止: キー自体が無いこと。
+        $this->assertArrayNotHasKey('member', $result, 'member フォールバックは廃止されたこと');
     }
 
     public function test_themeMomentum_rank_has_correct_keys(): void
@@ -108,19 +108,6 @@ class RecommendGrowthRepositoryTest extends TestCase
         $rank = $result['rank'];
         foreach (['points', 'current', 'first', 'leaderId'] as $key) {
             $this->assertArrayHasKey($key, $rank, "rank.{$key} が存在すること");
-        }
-    }
-
-    public function test_themeMomentum_member_has_correct_keys(): void
-    {
-        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
-        if (empty($result)) {
-            $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
-        }
-
-        $member = $result['member'];
-        foreach (['points', 'increase', 'rooms'] as $key) {
-            $this->assertArrayHasKey($key, $member, "member.{$key} が存在すること");
         }
     }
 
@@ -160,18 +147,6 @@ class RecommendGrowthRepositoryTest extends TestCase
         $this->assertIsInt($result['rank']['leaderId']);
     }
 
-    public function test_themeMomentum_member_increase_and_rooms_are_ints(): void
-    {
-        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 7);
-        if (empty($result)) {
-            $this->markTestSkipped('安定IDのデータが取得できなかったためスキップ');
-        }
-
-        $this->assertIsInt($result['member']['increase']);
-        $this->assertIsInt($result['member']['rooms']);
-        $this->assertGreaterThanOrEqual(0, $result['member']['rooms']);
-    }
-
     // ===================================================
     // themeMomentum: points の詳細不変条件
     // ===================================================
@@ -207,36 +182,6 @@ class RecommendGrowthRepositoryTest extends TestCase
             // date は YYYY-MM-DD 形式
             $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $point['date']);
         }
-    }
-
-    public function test_themeMomentum_member_points_have_correct_shape(): void
-    {
-        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 21);
-        if (empty($result) || empty($result['member']['points'])) {
-            $this->markTestSkipped('member.points が空のためスキップ');
-        }
-
-        foreach ($result['member']['points'] as $point) {
-            $this->assertArrayHasKey('date', $point);
-            $this->assertArrayHasKey('value', $point);
-            $this->assertIsString($point['date']);
-            $this->assertIsInt($point['value']);
-            $this->assertGreaterThanOrEqual(0, $point['value'], 'member.value は 0 以上のメンバー数であること');
-            $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $point['date']);
-        }
-    }
-
-    public function test_themeMomentum_member_points_are_date_ascending(): void
-    {
-        $result = $this->repo->themeMomentum(self::STABLE_IDS, $this->anchor, 21);
-        if (empty($result) || empty($result['member']['points'])) {
-            $this->markTestSkipped('member.points が空のためスキップ');
-        }
-
-        $dates = array_column($result['member']['points'], 'date');
-        $sorted = $dates;
-        sort($sorted);
-        $this->assertSame($sorted, $dates, 'member.points の date が昇順であること');
     }
 
     // ===================================================
@@ -282,118 +227,5 @@ class RecommendGrowthRepositoryTest extends TestCase
         if (count($result['rank']['points']) >= 2) {
             $this->assertGreaterThan(0, $result['spanDays'], 'rank.points が 2 点以上なら spanDays > 0');
         }
-    }
-
-    // ===================================================
-    // themeGrowth: 3ID 未満は空
-    // ===================================================
-
-    public function test_themeGrowth_returns_empty_for_zero_ids(): void
-    {
-        $result = $this->repo->themeGrowth([], $this->anchor);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('points', $result);
-        $this->assertArrayHasKey('rooms', $result);
-        $this->assertEmpty($result['points']);
-        $this->assertSame(0, $result['rooms']);
-    }
-
-    public function test_themeGrowth_returns_empty_for_one_id(): void
-    {
-        $result = $this->repo->themeGrowth([3], $this->anchor);
-        $this->assertEmpty($result['points']);
-        $this->assertSame(0, $result['rooms']);
-    }
-
-    public function test_themeGrowth_returns_empty_for_two_ids(): void
-    {
-        $result = $this->repo->themeGrowth([3, 17], $this->anchor);
-        $this->assertEmpty($result['points']);
-        $this->assertSame(0, $result['rooms']);
-    }
-
-    public function test_themeGrowth_returns_data_for_five_ids(): void
-    {
-        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
-        // データがある場合は shape を確認(データがなければ empty shape も正常)
-        $this->assertArrayHasKey('points', $result);
-        $this->assertArrayHasKey('rooms', $result);
-        $this->assertIsArray($result['points']);
-        $this->assertIsInt($result['rooms']);
-        $this->assertGreaterThanOrEqual(0, $result['rooms']);
-    }
-
-    public function test_themeGrowth_rooms_matches_cohort_count(): void
-    {
-        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
-        if (empty($result['points'])) {
-            $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
-        }
-
-        // rooms は入力 ID 数以下のコホート
-        $this->assertLessThanOrEqual(count(self::STABLE_IDS), $result['rooms']);
-        // rooms >= 1 (points があれば最低 1 部屋)
-        $this->assertGreaterThanOrEqual(1, $result['rooms']);
-    }
-
-    public function test_themeGrowth_nonexistent_ids_return_empty(): void
-    {
-        $result = $this->repo->themeGrowth([PHP_INT_MAX - 1, PHP_INT_MAX - 2, PHP_INT_MAX - 3], $this->anchor, 21);
-        $this->assertEmpty($result['points']);
-        $this->assertSame(0, $result['rooms']);
-    }
-
-    // ===================================================
-    // themeGrowth: points の不変条件
-    // ===================================================
-
-    public function test_themeGrowth_points_are_date_ascending(): void
-    {
-        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
-        if (empty($result['points'])) {
-            $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
-        }
-
-        $dates = array_column($result['points'], 'date');
-        $sorted = $dates;
-        sort($sorted);
-        $this->assertSame($sorted, $dates, 'points の date が昇順であること');
-    }
-
-    public function test_themeGrowth_points_values_are_ints(): void
-    {
-        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
-        if (empty($result['points'])) {
-            $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
-        }
-
-        foreach ($result['points'] as $point) {
-            $this->assertIsInt($point['value'], "value は int であること");
-            $this->assertGreaterThanOrEqual(0, $point['value']);
-        }
-    }
-
-    public function test_themeGrowth_points_dates_match_expected_format(): void
-    {
-        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, 21);
-        if (empty($result['points'])) {
-            $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
-        }
-
-        foreach ($result['points'] as $point) {
-            $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $point['date']);
-        }
-    }
-
-    public function test_themeGrowth_points_count_does_not_exceed_days(): void
-    {
-        $days = 14;
-        $result = $this->repo->themeGrowth(self::STABLE_IDS, $this->anchor, $days);
-        if (empty($result['points'])) {
-            $this->markTestSkipped('themeGrowth のデータが空のためスキップ');
-        }
-
-        // days + 1 日分以下(境界の扱いで ±1 の余裕を持たせる)
-        $this->assertLessThanOrEqual($days + 1, count($result['points']), 'points 数は days 以下であること');
     }
 }

--- a/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
+++ b/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
@@ -151,7 +151,7 @@ class RecommendStaticDataGenerator
     /**
      * テーマの勢い(themeMomentum)を事前計算して DTO に同梱する。
      *
-     * /recommend/{tag} がアクセスごとに ranking_position.db / statistics.db を集計していたのを、
+     * /recommend/{tag} がアクセスごとに ranking_position.db を集計していたのを、
      * 毎時の .dat 生成時の1回に寄せる。対象はタグ .dat のみ（勢いを表示するのはタグページだけ）。
      * 集計窓の起点・対象IDはページ側のライブ計算と同一
      * (RecommendOpenChatPageController::index と揃えること)。

--- a/app/Views/components/recommend_growth_chart.php
+++ b/app/Views/components/recommend_growth_chart.php
@@ -9,9 +9,9 @@ use App\Services\Recommend\ThemeGrowthChartSvg;
  *
  * 順位は小さいほど良いので、スパークラインは値を反転して「順位が上がる=上に伸びる」向きに描く。
  * 改善(順位UP)=緑 / 悪化(順位DOWN)=赤橙 / 横ばい=灰。動きは平滑化せず誠実に表示する。
- * rank が無いテーマは合計メンバー数にフォールバック。
+ * ランキング掲載が無いテーマはカード自体を出さない(member フォールバックは廃止)。
  *
- * @var array  $growth     spanDays / rank{points:{date,value}[],current,first} / member{points,increase,rooms}
+ * @var array  $growth     spanDays / rank{points:{date,value}[],current,first,leaderId}
  * @var string $extractTag テーマ名(親 view でエスケープ済み)
  *
  * 制約: サーバー側でインライン SVG を生成。JS/Webフォント無し・高さ固定/img は width&height 明示で CLS ゼロ。
@@ -19,7 +19,7 @@ use App\Services\Recommend\ThemeGrowthChartSvg;
  */
 
 $growth = isset($growth) && is_array($growth) ? $growth : [];
-if (!$growth || empty($growth['rank']) && empty($growth['member'])) {
+if (!$growth || empty($growth['rank'])) {
   return;
 }
 
@@ -27,14 +27,15 @@ if (!$growth || empty($growth['rank']) && empty($growth['member'])) {
 $displayTag = RecommendUtility::extractTag($extractTag);
 
 $rank   = $growth['rank']   ?? null;
-$member = $growth['member'] ?? null;
 $spanDays    = (int)($growth['spanDays'] ?? 0);
 $rankCurrent = $rank !== null ? (int)($rank['current'] ?? 0) : 0;
 $rankFirst   = $rank !== null ? (int)($rank['first'] ?? 0) : 0;
 $rankPoints  = ($rank !== null && !empty($rank['points'])) ? $rank['points'] : [];
-$memberInc   = $member !== null ? (int)($member['increase'] ?? 0) : 0;
 
-$useRank = $rankCurrent > 0;
+// 掲載が無い(順位が取れない)テーマはカードを出さない(フォールバックは廃止)。
+if ($rankCurrent <= 0) {
+  return;
+}
 
 /** 日数を人に伝わる丸めた期間表現に(例: 29→「1ヶ月」)。窓の長さに対応。 */
 $periodLabel = static function (int $d): string {
@@ -47,58 +48,44 @@ $periodLabel = static function (int $d): string {
 };
 $period = $periodLabel($spanDays);
 
-if ($useRank) {
-  $label = t('公式ランキングでの順位（活発なルーム）');
-  $improve = $rankFirst - $rankCurrent; // 正 = 順位が小さくなった = 改善
-  $chartPoints = $rankPoints;
+$label = t('公式ランキングでの順位（活発なルーム）');
+$improve = $rankFirst - $rankCurrent; // 正 = 順位が小さくなった = 改善
+$chartPoints = $rankPoints;
 
-  // 順位を反転(値を負)して描く → 順位が良く(小さく)なるほど上に伸びる。
-  $chart = ThemeGrowthChartSvg::build(array_map(
-    static fn($p) => ['date' => $p['date'], 'value' => -(int)$p['value']],
-    $rankPoints
-  ));
+// 順位を反転(値を負)して描く → 順位が良く(小さく)なるほど上に伸びる。
+$chart = ThemeGrowthChartSvg::build(array_map(
+  static fn($p) => ['date' => $p['date'], 'value' => -(int)$p['value']],
+  $rankPoints
+));
 
-  // 活発さティア(全体ランキング最高順位の絶対値で。/oc ナラティブ準拠)。
-  // 色は「下降の赤」「横ばいのくすんだ灰」をやめ、安心できる緑系で統一(上位すぎて張り付く=最高クラス
-  // なので肯定的に)。低位のときだけ落ち着いた灰。方向は文章で誠実に伝える。
-  // 全体ランキングに入っている時点で「活発なルーム」なので、基本は安心できる緑。順位帯で文言だけ強める。
-  $b = $rankCurrent;
-  if ($b <= 10)      $tierWord = t('オープンチャット全体を代表する規模の');
-  elseif ($b <= 50)  $tierWord = t('全体でも上位クラスの大規模な');
-  elseif ($b <= 300) $tierWord = t('全体ランキング上位の活発な');
-  else               $tierWord = t('全体ランキングに入る活発な');
-  $color = 'var(--c-brand)';
+// 活発さティア(全体ランキング最高順位の絶対値で。/oc ナラティブ準拠)。
+// 色は「下降の赤」「横ばいのくすんだ灰」をやめ、安心できる緑系で統一(上位すぎて張り付く=最高クラス
+// なので肯定的に)。低位のときだけ落ち着いた灰。方向は文章で誠実に伝える。
+// 全体ランキングに入っている時点で「活発なルーム」なので、基本は安心できる緑。順位帯で文言だけ強める。
+$b = $rankCurrent;
+if ($b <= 10)      $tierWord = t('オープンチャット全体を代表する規模の');
+elseif ($b <= 50)  $tierWord = t('全体でも上位クラスの大規模な');
+elseif ($b <= 300) $tierWord = t('全体ランキング上位の活発な');
+else               $tierWord = t('全体ランキングに入る活発な');
+$color = 'var(--c-brand)';
 
-  // 多言語対応: 語順が言語で異なるため位置指定子(%1$s..)のテンプレートにして翻訳側で並べ替え可能にする。
-  $trend = $improve > 0
-    ? sprintfT('この%1$sで全体%2$s位→%3$s位に上昇', $period, number_format($rankFirst), number_format($rankCurrent))
-    : ($improve < 0
-      ? sprintfT('この%1$sで全体%2$s位→%3$s位', $period, number_format($rankFirst), number_format($rankCurrent))
-      : sprintfT('この%1$sは全体%2$s位前後で安定', $period, number_format($rankCurrent)));
+// 多言語対応: 語順が言語で異なるため位置指定子(%1$s..)のテンプレートにして翻訳側で並べ替え可能にする。
+$trend = $improve > 0
+  ? sprintfT('この%1$sで全体%2$s位→%3$s位に上昇', $period, number_format($rankFirst), number_format($rankCurrent))
+  : ($improve < 0
+    ? sprintfT('この%1$sで全体%2$s位→%3$s位', $period, number_format($rankFirst), number_format($rankCurrent))
+    : sprintfT('この%1$sは全体%2$s位前後で安定', $period, number_format($rankCurrent)));
 
-  $line = $tierWord !== ''
-    ? sprintfT('「%1$s」には%2$sルームがあります（%3$s）。', $displayTag, $tierWord, $trend)
-    : sprintfT('「%1$s」の掲載部屋の最高順位は全体%2$s位（%3$s）。', $displayTag, number_format($rankCurrent), $trend);
-} else {
-  // フォールバック: 合計メンバー数。色は安心できる緑/灰(赤は使わない)。
-  $label = t('メンバー数（掲載部屋の合計）');
-  $improve = $memberInc;
-  $color = $improve >= 0 ? 'var(--c-brand)' : 'var(--c-text-steel)';
-  $chartPoints = ($member !== null && !empty($member['points'])) ? $member['points'] : [];
-  $chart = ThemeGrowthChartSvg::build($chartPoints);
-
-  // 多言語対応: 増減/横ばいの語句と文全体を t()/sprintfT() でローカライズ(語順は翻訳側で並べ替え)。
-  $word = $improve > 0 ? sprintfT('約%s人増えました', number_format(abs($improve)))
-    : ($improve < 0 ? sprintfT('約%s人減りました', number_format(abs($improve))) : t('ほぼ横ばいでした'));
-  $line = sprintfT('「%1$s」の掲載部屋の合計メンバーは、この%2$sで%3$s。', $displayTag, $period, $word);
-}
+$line = $tierWord !== ''
+  ? sprintfT('「%1$s」には%2$sルームがあります（%3$s）。', $displayTag, $tierWord, $trend)
+  : sprintfT('「%1$s」の掲載部屋の最高順位は全体%2$s位（%3$s）。', $displayTag, number_format($rankCurrent), $trend);
 
 // 「どの部屋の話か」を具体化: 最高順位を持つ部屋をリストから引き、サムネ+名前+順位+人数の
 // 小さなリンクを出す。$recommend は view() の sanitizeObject で既にエスケープ済み。
 // open_chat_list_recommend と同じく getList の値はエスケープ済みをそのまま echo する(ここで追加エスケープしないこと)。
 $leader = null;
 $leaderHref = '';
-if ($useRank && isset($recommend) && $recommend !== null) {
+if (isset($recommend) && $recommend !== null) {
   $leaderId = (int)($rank['leaderId'] ?? 0);
   if ($leaderId > 0) {
     foreach ($recommend->getList(false, null) as $row) {
@@ -122,7 +109,7 @@ if (!empty($chartPoints)) {
 }
 
 // SVG の defs id は1ページ内ユニークに。
-$gid = 'ocg-grad-' . substr(md5($extractTag . '|' . ($useRank ? 'rank' : 'member') . '|' . $spanDays), 0, 8);
+$gid = 'ocg-grad-' . substr(md5($extractTag . '|rank|' . $spanDays), 0, 8);
 
 // ブランドアイコン(96x96・web最適化済み)。width/height 明示で CLS ゼロ。
 $lineIcon = fileUrl('assets/line_app_icon.png', urlRoot: '');


### PR DESCRIPTION
タグページの「テーマの勢い」カードは、公式ランキングでの最高順位の推移(rank)を
主役に表示し、合計メンバー数(member)はランキング掲載が無いテーマ用のフォールバック
だった。しかし生成側は rank の有無に関わらず member も常に計算しており、表示が rank
優先のため大半のタグでは「計算しても捨てる」状態になっていた。

この member 集計は statistics(約8700万行)に対する3パスのコホートCTEで、毎時×全タグ
ぶん走るため、おすすめ静的データ生成ループ中の重い処理になっていた。重いSQLite集計の
間ずっとMySQL接続がアイドルになり、ループ全体が伸びて接続が wait_timeout で切られる
窓を広げ、「MySQL server has gone away」の一因になっていた。

要件上フォールバックは不要(ランキング掲載が無いテーマは勢いカード自体を出さなくてよい)
と整理し、member フォールバックを全廃:

- RecommendGrowthRepository::themeGrowth() と member 系の集計・返却を削除。
  themeMomentum() は rank のみを返し、2点未満(掲載なし)なら空配列を返す。
- インターフェイスから themeGrowth() を除去。SQLiteStatistics 依存も解消。
- ビュー recommend_growth_chart.php の member フォールバック分岐を削除。
- 関連テストを rank 専用に整理(member/themeGrowth のテストを削除)。

これにより掲載のあるタグでも重いCTEが消え、毎時バッチのループ短縮＝MySQLアイドル窓の
縮小につながる。表示は従来どおり(member は元々フォールバック時しか出ていない)。

🤖 Generated with Claude Code (claude-opus-4-8[1m])
Committed from: vm:~/Open-Chat-Graph