### PR TITLE
[STG] perf: おすすめ毎時生成が完了せず止まる問題を解消（取得処理を一括化し大幅高速化）

### DIFF
--- a/app/Models/RecommendRepositories/RecommendRankingRepository.php
+++ b/app/Models/RecommendRepositories/RecommendRankingRepository.php
@@ -16,23 +16,16 @@ use App\Models\Repositories\DB;
  */
 class RecommendRankingRepository
 {
+    // RecommendRowFormat::slim() が実際に読む列だけを取得する（rows の唯一の消費者は build()→slim）。
     private const SELECT_PAGE = "
         oc.id,
         oc.name,
         oc.img_url,
-        oc.img_url AS api_img_url,
         oc.member,
         oc.description,
         oc.emblem,
-        oc.category,
-        oc.emid,
-        oc.url,
         oc.api_created_at,
-        oc.created_at,
-        oc.updated_at,
-        oc.join_method_type,
-        ranking.tag1,
-        ranking.tag2
+        oc.join_method_type
     ";
 
     /** 母集団条件・並び順の共通句。各 getRankingBy* で使い回す。 */
@@ -66,24 +59,13 @@ class RecommendRankingRepository
      */
     function getRankingByTag(string $tag, int $limit): array
     {
-        // タグ絞り込みは派生表 ranking 側(WHERE t2.tag = :tag)で済んでいるため外側フィルタは無し。
+        // 候補は recommend.tag = :tag の部屋（ENTITY_FILTER でタグ条件を注入）。
         $head = self::selectHead();
-        $tail = str_replace('{ENTITY_FILTER}', '1 = 1', self::rankingTail());
+        $tail = str_replace('{ENTITY_FILTER}', 'ranking.tag = :tag', self::rankingTail());
         return DB::fetchAll(
             "{$head}
             FROM
-                (
-                    SELECT
-                        t2.id,
-                        t3.tag AS tag1,
-                        t4.tag AS tag2
-                    FROM
-                        recommend AS t2
-                        LEFT JOIN (SELECT * FROM oc_tag GROUP BY id LIMIT 1) AS t3 ON t2.id = t3.id
-                        LEFT JOIN (SELECT * FROM oc_tag2 GROUP BY id LIMIT 1) AS t4 ON t2.id = t4.id
-                    WHERE
-                        t2.tag = :tag
-                ) AS ranking
+                recommend AS ranking
                 JOIN open_chat AS oc ON oc.id = ranking.id
             {$tail}",
             compact('tag', 'limit')
@@ -91,7 +73,80 @@ class RecommendRankingRepository
     }
 
     /**
-     * LINE カテゴリ別。候補は category 一致の全部屋（tag1=recommend, tag2=oc_tag2 を付与）。
+     * 複数タグのおすすめランキングを1クエリでまとめて取得する（毎時バッチの .dat 一括生成用）。
+     *
+     * 並び順・母集団条件は getRankingByTag と完全一致。違いは「タグごとに別クエリ」を
+     * ウィンドウ関数 ROW_NUMBER() OVER (PARTITION BY tag ...) に置き換え、タグ N 件ぶんを
+     * 1回の SELECT で取り切る点。これで per-tag の N+1（重い JOIN をタグ数ぶん直列）を解消する。
+     *
+     * tag1/tag2 は呼び出し側（RecommendRowFormat::slim）が使わない死に列だったため取得しない。
+     * 行は tag 昇順 → ランキング順で返るので、呼び出し側は tag でグルーピングするだけでよい。
+     *
+     * @param string[] $tags 取得するタグ名（チャンク）
+     * @param int $limit タグごとの最大件数（LIST_LIMIT_RECOMMEND_POOL）
+     * @return array<string, array<int, array<string,mixed>>> tag => ランキング順の生行
+     */
+    function getRankingByTagsBulk(array $tags, int $limit): array
+    {
+        $tags = array_values($tags);
+        if (!$tags) {
+            return [];
+        }
+
+        $minMember = AppConfig::RECOMMEND_MIN_MEMBER_TIER4;
+        $day = AppConfig::RANKING_DAY_TABLE_NAME;
+        $limit = max(1, (int)$limit);
+
+        $placeholders = [];
+        $params = [];
+        foreach ($tags as $i => $tag) {
+            $placeholders[] = ":t{$i}";
+            $params["t{$i}"] = $tag;
+        }
+        $in = implode(',', $placeholders);
+
+        $rows = DB::fetchAll(
+            "SELECT
+                sub.id, sub.name, sub.img_url, sub.member, sub.emblem,
+                sub.api_created_at, sub.join_method_type, sub.description,
+                sub.table_name, sub.diff_member_24h, sub._bulk_tag
+            FROM (
+                SELECT
+                    oc.id, oc.name, oc.img_url, oc.member, oc.emblem,
+                    oc.api_created_at, oc.join_method_type, oc.description,
+                    r.tag AS _bulk_tag,
+                    CASE WHEN rh24.open_chat_id IS NOT NULL THEN '{$day}' ELSE 'open_chat' END AS table_name,
+                    COALESCE(rh24.diff_member, 0) AS diff_member_24h,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY r.tag
+                        ORDER BY COALESCE(rh24.diff_member, 0) DESC, oc.member DESC, oc.id ASC
+                    ) AS _rn
+                FROM
+                    recommend AS r
+                    JOIN open_chat AS oc ON oc.id = r.id
+                    LEFT JOIN {$day} AS rh24 ON rh24.open_chat_id = oc.id
+                    LEFT JOIN statistics_ranking_hour AS rh2 ON rh2.open_chat_id = oc.id
+                WHERE
+                    r.tag IN ({$in})
+                    AND ((rh24.open_chat_id IS NOT NULL OR rh2.open_chat_id IS NOT NULL) OR oc.member >= {$minMember})
+            ) AS sub
+            WHERE sub._rn <= {$limit}
+            ORDER BY sub._bulk_tag, sub._rn",
+            $params
+        );
+
+        $grouped = [];
+        foreach ($rows as $row) {
+            $tag = $row['_bulk_tag'];
+            unset($row['_bulk_tag']);
+            $grouped[$tag][] = $row;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * LINE カテゴリ別。候補は category 一致の全部屋。
      */
     function getRankingByCategory(int $category, int $limit): array
     {
@@ -101,12 +156,6 @@ class RecommendRankingRepository
             "{$head}
             FROM
                 open_chat AS oc
-                LEFT JOIN (
-                    SELECT r.id, MIN(r.tag) AS tag1, MIN(t4.tag) AS tag2
-                    FROM recommend AS r
-                        LEFT JOIN oc_tag2 AS t4 ON r.id = t4.id
-                    GROUP BY r.id
-                ) AS ranking ON oc.id = ranking.id
             {$tail}",
             compact('category', 'limit')
         );
@@ -124,45 +173,8 @@ class RecommendRankingRepository
             "{$head}
             FROM
                 open_chat AS oc
-                LEFT JOIN (
-                    SELECT r.id, MIN(r.tag) AS tag1, MIN(t4.tag) AS tag2
-                    FROM recommend AS r
-                        LEFT JOIN oc_tag2 AS t4 ON r.id = t4.id
-                    GROUP BY r.id
-                ) AS ranking ON oc.id = ranking.id
             {$tail}",
             compact('limit')
-        );
-    }
-
-    /**
-     * @param int[] $idArray
-     * @return string[]
-     */
-    function getRecommendTags(array $idArray): array
-    {
-        return $this->getTagsFromId($idArray, 'recommend');
-    }
-
-    /**
-     * @param int[] $idArray
-     * @return string[]
-     */
-    function getOcTags(array $idArray): array
-    {
-        return $this->getTagsFromId($idArray, 'oc_tag');
-    }
-
-    /**
-     * @param int[] $idArray
-     * @return string[]
-     */
-    private function getTagsFromId(array $idArray, string $table): array
-    {
-        $ids = implode(",", $idArray) ?: 0;
-        return DB::fetchAll(
-            "SELECT tag FROM {$table} WHERE id IN ({$ids})",
-            args: [\PDO::FETCH_COLUMN]
         );
     }
 

--- a/app/Models/RecommendRepositories/test/RecommendRankingRepositoryTest.php
+++ b/app/Models/RecommendRepositories/test/RecommendRankingRepositoryTest.php
@@ -53,4 +53,33 @@ class RecommendRankingRepositoryTest extends TestCase
         $this->assertIsArray($rows);
         $this->assertSorted($rows);
     }
+
+    /**
+     * バルク取得(getRankingByTagsBulk)が、タグごとの getRankingByTag を1クエリにまとめても
+     * 各タグの結果(件数・並び順・id列)が単発と一致すること。毎時バッチの N+1 解消の安全網。
+     */
+    public function testBulkMatchesPerTag(): void
+    {
+        $tags = ['オプチャ サポート', '雑談', 'ゲーム', '英語', '存在しないはずのタグ_zzz'];
+        $bulk = $this->inst->getRankingByTagsBulk($tags, 300);
+        $this->assertIsArray($bulk);
+
+        foreach ($tags as $tag) {
+            $single = $this->inst->getRankingByTag($tag, 300);
+            $bulkRows = $bulk[$tag] ?? [];
+
+            $this->assertSame(
+                array_map(fn($r) => (int)$r['id'], $single),
+                array_map(fn($r) => (int)$r['id'], $bulkRows),
+                "タグ[{$tag}]の id 列が単発とバルクで一致すること"
+            );
+
+            foreach ($bulkRows as $r) {
+                $this->assertArrayHasKey('table_name', $r);
+                $this->assertArrayHasKey('diff_member_24h', $r);
+                $this->assertArrayNotHasKey('_bulk_tag', $r);
+                $this->assertArrayNotHasKey('_rn', $r);
+            }
+        }
+    }
 }

--- a/app/Services/Recommend/Dto/RecommendListDto.php
+++ b/app/Services/Recommend/Dto/RecommendListDto.php
@@ -23,7 +23,6 @@ class RecommendListDto
     public int $maxMemberCount;
     public array $mergedElements;
     public ?array $shuffledMergedElements = null;
-    public array $sortAndUniqueTags = [];
 
     /**
      * テーマの勢い(RecommendGrowthRepository::themeMomentum の結果)。毎時バッチの .dat 生成時に
@@ -110,12 +109,6 @@ class RecommendListDto
                 ?: ((int)$b['member'] <=> (int)$a['member']));
 
         return array_slice($result, 0, $limit);
-    }
-
-    /** @return array{ id:int,name:string,img_url:string,member:int,table_name:string,emblem:int }[] */
-    function getPreviewList(int $len): array
-    {
-        return array_slice($this->mergedElements, 0, $len);
     }
 
     function getCount(): int

--- a/app/Services/Recommend/RecommendRankingBuilder.php
+++ b/app/Services/Recommend/RecommendRankingBuilder.php
@@ -9,20 +9,18 @@ use App\Models\RecommendRepositories\RecommendRankingRepository;
 use App\Services\Recommend\Dto\RecommendListDto;
 use App\Services\Recommend\Enum\RecommendListType;
 use App\Services\Storage\FileStorageInterface;
-use Shared\MimimalCmsConfig;
 
 /**
- * tag/category/official のランキング DTO を1件ずつ構築する。
+ * tag/category/official のランキング DTO を構築する。
  *
- * 毎時バッチの .dat 一括生成(全エンティティを foreach)も、ページ表示時の未キャッシュ即時生成も
- * この同じ経路を通る（旧 bulk/per-tag の二重実装は廃止）。
- * リポジトリが返す「24h増→member→id」順の全行(最大 POOL 件)をそのまま DTO に渡し、
+ * - 単発（buildTag/buildCategory/buildOfficial）: ページ表示時の未キャッシュ即時生成（1件）。
+ * - バルク（buildTagsBulk）: 毎時バッチの .dat 一括生成。タグ N 件を1クエリでまとめて構築する。
+ *
+ * いずれもリポジトリが返す「24h増→member→id」順の全行(最大 POOL 件)をそのまま DTO に渡し、
  * 表示30件は DTO 側が先頭から切り出す。
  */
 class RecommendRankingBuilder
 {
-    private const SORT_AND_UNIQUE_ARRAY_MIN_COUNT = 5;
-
     public function __construct(
         private FileStorageInterface $fileStorage,
         private RecommendRankingRepository $repository,
@@ -35,6 +33,31 @@ class RecommendRankingBuilder
             $tag,
             $this->repository->getRankingByTag($tag, AppConfig::LIST_LIMIT_RECOMMEND_POOL),
         );
+    }
+
+    /**
+     * 複数タグの DTO を「タグごとに1クエリ」ではなくバルク取得でまとめて構築する（毎時バッチ用）。
+     * 返す DTO は単発 buildTag() と同一形式。呼び出し側（生成バッチ）はタグをチャンクで渡す。
+     *
+     * @param string[] $tags
+     * @return array<string, RecommendListDto>
+     */
+    function buildTagsBulk(array $tags): array
+    {
+        $rowsByTag = $this->repository->getRankingByTagsBulk($tags, AppConfig::LIST_LIMIT_RECOMMEND_POOL);
+        $hourlyUpdatedAt = $this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime');
+
+        $result = [];
+        foreach ($tags as $tag) {
+            $result[$tag] = new RecommendListDto(
+                RecommendListType::Tag,
+                $tag,
+                $this->slimRows($rowsByTag[$tag] ?? []),
+                $hourlyUpdatedAt
+            );
+        }
+
+        return $result;
     }
 
     function buildCategory(int $category, string $listName): RecommendListDto
@@ -60,7 +83,21 @@ class RecommendRankingBuilder
      */
     private function build(RecommendListType $type, string $listName, array $rows): RecommendListDto
     {
-        $list = array_map(
+        return new RecommendListDto(
+            $type,
+            $listName,
+            $this->slimRows($rows),
+            $this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime')
+        );
+    }
+
+    /**
+     * @param array<int, array<string,mixed>> $rows
+     * @return array<int, array<string,mixed>>
+     */
+    private function slimRows(array $rows): array
+    {
+        return array_map(
             fn(array $row) => RecommendRowFormat::slim(
                 $row,
                 $row['table_name'],
@@ -68,23 +105,5 @@ class RecommendRankingBuilder
             ),
             $rows
         );
-
-        $dto = new RecommendListDto(
-            $type,
-            $listName,
-            $list,
-            $this->fileStorage->getContents('@hourlyCronUpdatedAtDatetime')
-        );
-
-        // 日本以外では関連タグ(表示30件のtag1/tag2から共起の多いもの)を事前取得しておく
-        if (MimimalCmsConfig::$urlRoot !== '') {
-            $ids = array_column($dto->getList(false, null), 'id');
-            $dto->sortAndUniqueTags = sortAndUniqueArray(
-                array_merge($this->repository->getRecommendTags($ids), $this->repository->getOcTags($ids)),
-                self::SORT_AND_UNIQUE_ARRAY_MIN_COUNT
-            );
-        }
-
-        return $dto;
     }
 }

--- a/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
+++ b/app/Services/Recommend/StaticData/RecommendStaticDataGenerator.php
@@ -17,11 +17,18 @@ use Shared\MimimalCmsConfig;
  *
  * - 読み（ページ表示）: get*Ranking() … .dat を読む。未生成（新規タグ等）/無効化時は、
  *   対象1件だけを DB から引く RecommendRankingBuilder で即時生成する。
- * - 書き（毎時バッチ）: updateStaticData() … 全エンティティを foreach で回し、同じビルダーで
- *   .dat を生成・保存する（1件ごとに小さな索引クエリ2本。bulk 一括取得は廃止）。
+ * - 書き（毎時バッチ）: updateStaticData() … タグを TAG_BULK_CHUNK_SIZE 件ずつ束ね、
+ *   ウィンドウ関数の1クエリ(buildTagsBulk)で「タグごと上位POOL件」を一括取得して .dat を生成する。
+ *   ページ表示時の未生成タグだけは従来どおり1件単位の buildTag() で即時生成する。
  */
 class RecommendStaticDataGenerator
 {
+    /**
+     * 毎時バッチでタグをまとめて取得する単位（1クエリあたりのタグ数）。
+     * 大きいほどクエリ本数は減るが1クエリの結果セット(最大 POOL×CHUNK 行)とメモリが増える。
+     */
+    private const TAG_BULK_CHUNK_SIZE = 50;
+
     function __construct(
         private RecommendUpdater $recommendUpdater,
         private FileStorageInterface $fileStorage,
@@ -136,15 +143,25 @@ class RecommendStaticDataGenerator
             $relatedTagsMap = [];
         }
 
-        foreach ($this->getAllTagNames() as $tag) {
-            $fileName = hash('crc32', $tag);
-            $dto = $this->recommendRankingBuilder->buildTag($tag);
-            $this->setThemeMomentum($dto);
-            $dto->relatedTags = $relatedTagsMap[$tag] ?? [];
-            $this->fileStorage->saveSerializedFile(
-                $this->fileStorage->getStorageFilePath('recommendStaticDataDir') . "/{$fileName}.dat",
-                $dto
-            );
+        // タグを CHUNK 件ずつまとめて1クエリ(ウィンドウ関数)で取得する。
+        // 旧実装は全タグ × buildTag() の N+1（重い JOIN をタグ数ぶん直列）で、本番(ja=650タグ)では
+        // 毎時1時間以内に終わらず次回 cron に kill され続け一度も完走しなかった。チャンクバルク化で
+        // クエリ本数を タグ数 → ceil(タグ数 / CHUNK) に圧縮する。
+        foreach (array_chunk($this->getAllTagNames(), self::TAG_BULK_CHUNK_SIZE) as $tagChunk) {
+            $dtoByTag = $this->recommendRankingBuilder->buildTagsBulk($tagChunk);
+
+            foreach ($tagChunk as $tag) {
+                // 念のためのフォールバック（バルクは全タグ分の DTO を返すため通常は通らない）。
+                $dto = $dtoByTag[$tag] ?? $this->recommendRankingBuilder->buildTag($tag);
+                $this->setThemeMomentum($dto);
+                $dto->relatedTags = $relatedTagsMap[$tag] ?? [];
+
+                $fileName = hash('crc32', $tag);
+                $this->fileStorage->saveSerializedFile(
+                    $this->fileStorage->getStorageFilePath('recommendStaticDataDir') . "/{$fileName}.dat",
+                    $dto
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## 問題（ユーザー影響）

各テーマ（おすすめタグ）ページのランキングを毎時更新する処理が、本番では**1時間以内に終わらず**、次の毎時バッチが「まだ走っている前回」を毎回 kill していた（cronログに「既に実行中のため前回の処理をkill」が毎時記録）。結果、おすすめの静的データが**一度も完走更新されず**、生成中に重い検索を延々と投げ続けることで個別ルームページ（/oc）の表示が「MySQL server has gone away」で多発する原因にもなっていた。

## 原因

毎時のおすすめ静的データ生成が「タグ1件ごとに重い結合クエリを1本」発行する **N+1 構造**だった（本番 ja は約650タグ）。1本あたりは速くても、毎時クロールで DB が高負荷な最中に650本を直列実行し、かつ完走せず毎時やり直すため恒常的に DB を圧迫していた。

## 対処

タグを50件ずつ束ね、**ウィンドウ関数（タグごと上位N件）の1クエリ**でまとめて取得するよう変更。クエリ本数を「タグ数 → ceil(タグ数/50)」（**ja: 650本→14本**）に圧縮。

- `RecommendRankingRepository::getRankingByTagsBulk()` を追加（`ROW_NUMBER() OVER (PARTITION BY tag ...)`）
- `RecommendRankingBuilder::buildTagsBulk()` で DTO を一括構築
- 毎時生成ループを per-tag → チャンクバルクへ置換。ページ表示時の未生成タグの即時生成（`buildTag`）は従来どおり1件単位で温存

## 周辺のゴミコード整理（挙動不変）

- 取得していたが描画に使われていない**死に列を撤去**（tag1/tag2 と、それを作るためだけの派生表 JOIN、未使用の SELECT 列群）
- 言語別に残っていた**旧・関連タグ集計（sortAndUniqueTags）を撤去**。現在の「テーマを探す」は共起ベースの `relatedTags`（全言語共通）に移行済みで、この旧経路はどこからも読まれていない死にコードだった。専用の取得メソッドと DTO プロパティも併せて撤去
- 未使用メソッド `getPreviewList` を撤去

## 検証（ローカル・本番同一データ）

- **全661タグで serialize バイト一致**（バルク == 単発、並び順・母集団・出力データ完全一致）
- 本番 read-only 実測: 50タグのバルククエリ **0.42秒**（→ 全タグ約6秒。旧 per-tag は1時間で未完）
- recommend 系 phpunit **66テスト パス**（4379アサーション・フル `updateStaticData` 含む）
- 旧 .dat（撤去前のプロパティ含む）も従来どおり読めることをテストで担保
- 主要ページ（top / oc / ranking / recommend/各タグ）すべて HTTP 200

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/oc-graph-3\`