### PR TITLE
[STG] fix: おすすめのテーマ分け更新が途中で止まり新しい分類が反映されなくなる不具合を修正

### DIFF
--- a/app/Services/Cron/Enum/SyncOpenChatStateType.php
+++ b/app/Services/Cron/Enum/SyncOpenChatStateType.php
@@ -14,6 +14,7 @@ enum SyncOpenChatStateType: string
     case isUpdateRecommendStaticDataActive = 'isUpdateRecommendStaticDataActive';
     case isUpdateOcPageCacheActive = 'isUpdateOcPageCacheActive';
     case isRecommendTagRebuildActive = 'isRecommendTagRebuildActive';
+    case recommendTagRebuildStartedAt = 'recommendTagRebuildStartedAt';
     case recommendTagsJsonHash = 'recommendTagsJsonHash';
     case rankingPersistenceBackground = 'rankingPersistenceBackground';
     case ocreviewApiDataImportBackground = 'ocreviewApiDataImportBackground';

--- a/app/Services/Cron/Utility/BatchScriptLauncher.php
+++ b/app/Services/Cron/Utility/BatchScriptLauncher.php
@@ -47,6 +47,27 @@ class BatchScriptLauncher
         return implode(' ', $output) . " (return code: {$returnCode})";
     }
 
+    /**
+     * 自分以外に同名スクリプトのプロセスが動いているかを返す（プロセス死活判定用）。
+     *
+     * killOtherInstances と同じ条件（同名スクリプト・自PID除外）で対象を数えるだけの読み取り版。
+     * ロックの所有プロセスが本当に生きているかの確認に使う。
+     */
+    public function isAnyInstanceRunning(BatchScript $script): bool
+    {
+        $myPid = getmypid();
+        $cmd = "ps aux | grep {$script->basename()} | grep -v grep | grep -v '{$myPid}' | awk '{print \$2}'";
+        exec($cmd, $output);
+
+        foreach ($output as $line) {
+            if (trim($line) !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function buildCommand(BatchScript $script, array $args): string
     {
         $phpBinary = PHP_SAPI === 'cli' ? PHP_BINARY : AppConfig::$phpBinary;

--- a/app/Services/Recommend/RebuildAllRecommendTagsService.php
+++ b/app/Services/Recommend/RebuildAllRecommendTagsService.php
@@ -25,6 +25,7 @@ class RebuildAllRecommendTagsService
         private SyncOpenChatStateRepositoryInterface $state,
         private RecommendUpdater $recommendUpdater,
         private BatchScriptLauncher $launcher,
+        private RecommendTagRebuildLock $rebuildLock,
     ) {}
 
     /**
@@ -40,7 +41,7 @@ class RebuildAllRecommendTagsService
         $now = date('Y-m-d H:i:s');
 
         try {
-            if ($this->state->getBool(StateType::isRecommendTagRebuildActive)) {
+            if ($this->rebuildLock->isHeldByLiveProcess()) {
                 if (!$cancelPrevious) {
                     // 既定（待機）: 実行中なら何もせず終了し、前のランを完走させる。
                     $message = 'rebuildAllViaShadowSwap: 既に実行中のためスキップ at ' . $now;
@@ -61,11 +62,11 @@ class RebuildAllRecommendTagsService
                 // 自分以外の tag_update.php をkill（killされた側は finally が走らずフラグを
                 // 下ろせないため、この後こちらで立て直して所有する）
                 CronUtility::addCronLog('kill結果: ' . $this->launcher->killOtherInstances(BatchScript::tagUpdate));
-                $this->state->setFalse(StateType::isRecommendTagRebuildActive);
+                $this->rebuildLock->release();
                 sleep(5); // プロセス終了を待つ
             }
 
-            $this->state->setTrue(StateType::isRecommendTagRebuildActive);
+            $this->rebuildLock->acquire();
 
             try {
                 AdminTool::sendDiscordNotify('rebuildAllViaShadowSwap start at ' . $now);
@@ -86,7 +87,7 @@ class RebuildAllRecommendTagsService
                 AdminTool::sendDiscordNotify('rebuildAllViaShadowSwap done at ' . $now);
             } finally {
                 // 成否に関わらず必ずフラグを下ろす
-                $this->state->setFalse(StateType::isRecommendTagRebuildActive);
+                $this->rebuildLock->release();
             }
 
             // ──────────────────────────────────────────────

--- a/app/Services/Recommend/RecommendTagRebuildLock.php
+++ b/app/Services/Recommend/RecommendTagRebuildLock.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Recommend;
+
+use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
+use App\Services\Admin\AdminTool;
+use App\Services\Cron\Enum\BatchScript;
+use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\Cron\Utility\BatchScriptLauncher;
+use App\Services\Cron\Utility\CronUtility;
+
+/**
+ * おすすめタグの全レコード再適用（rebuildAllViaShadowSwap / updateRecommendTables(false)）の
+ * クロススクリプト排他ロック。
+ *
+ * 排他したいのは毎時CRON（update_recommend_static_data.php）とGUI再適用（tag_update.php）の
+ * 2経路が同時に全件再構築（同じ shadow テーブル）を走らせないこと。
+ *
+ * 単純な真偽フラグ（isRecommendTagRebuildActive）だけだと、ロック保持プロセスが多重起動解消の
+ * kill などで SIGKILL されたとき finally が走らずフラグが永久に立ち残り、以後の全再適用が恒久的に
+ * スキップされる（= 定義を変えても古い部屋が付け直されない）。実際に本番でこの状態に陥った。
+ *
+ * そこで「フラグが立っていても所有プロセスが生存していなければ漏れたロックとみなして回収する」
+ * というプロセス死活ベースの自己修復を行う。ps 誤検知に備えて、規定時間を超えて保持され続けた
+ * ロックも保険として強制回収する。
+ */
+class RecommendTagRebuildLock
+{
+    /**
+     * 所有プロセスの生存判定が誤検知（defunct 等）でも、これを超えて立ち続けるロックは
+     * 漏れたものとみなして強制回収する保険値（秒）。実再構築は分オーダーで終わるため十分大きく取る。
+     */
+    private const MAX_HELD_SECONDS = 7200;
+
+    public function __construct(
+        private SyncOpenChatStateRepositoryInterface $state,
+        private BatchScriptLauncher $launcher,
+    ) {}
+
+    /**
+     * 全再適用が「実際に生きているプロセスに」保持されているか。
+     *
+     * フラグが立っていても、所有プロセス（tag_update.php / update_recommend_static_data.php）が
+     * 居ない、または規定時間を超過している場合は、漏れたロックとみなしてその場で回収（フラグを
+     * 下ろす）し、false を返す。これにより呼び出し側は新たに再適用を握れる。
+     */
+    public function isHeldByLiveProcess(): bool
+    {
+        if (!$this->state->getBool(StateType::isRecommendTagRebuildActive)) {
+            return false;
+        }
+
+        if ($this->hasLiveOwnerProcess() && !$this->hasExceededMaxHeldTime()) {
+            return true;
+        }
+
+        $startedAt = $this->state->getString(StateType::recommendTagRebuildStartedAt);
+        $message = '漏れたタグ全再適用ロックを検知したため回収します'
+            . '（所有プロセス不在 または 規定時間超過, startedAt=' . ($startedAt !== '' ? $startedAt : 'unknown') . '）';
+        CronUtility::addCronLog($message);
+        AdminTool::sendDiscordNotify($message);
+        $this->release();
+
+        return false;
+    }
+
+    /** ロックを取得する（フラグを立て、取得時刻を記録する）。 */
+    public function acquire(): void
+    {
+        $this->state->setString(StateType::recommendTagRebuildStartedAt, date('Y-m-d H:i:s'));
+        $this->state->setTrue(StateType::isRecommendTagRebuildActive);
+    }
+
+    /** ロックを解放する（フラグを下ろす）。 */
+    public function release(): void
+    {
+        $this->state->setFalse(StateType::isRecommendTagRebuildActive);
+    }
+
+    private function hasLiveOwnerProcess(): bool
+    {
+        return $this->launcher->isAnyInstanceRunning(BatchScript::updateRecommendStaticData)
+            || $this->launcher->isAnyInstanceRunning(BatchScript::tagUpdate);
+    }
+
+    private function hasExceededMaxHeldTime(): bool
+    {
+        $startedAt = $this->state->getString(StateType::recommendTagRebuildStartedAt);
+        if ($startedAt === '') {
+            return true; // 取得時刻が無い＝旧形式や記録漏れ → 回収対象とみなす
+        }
+
+        $startedTs = strtotime($startedAt);
+        if ($startedTs === false) {
+            return true;
+        }
+
+        return (time() - $startedTs) > self::MAX_HELD_SECONDS;
+    }
+}

--- a/app/Services/Recommend/StaticData/UpdateRecommendStaticDataService.php
+++ b/app/Services/Recommend/StaticData/UpdateRecommendStaticDataService.php
@@ -10,6 +10,7 @@ use App\Services\Cron\Enum\BatchScript;
 use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
 use App\Services\Cron\Utility\BatchScriptLauncher;
 use App\Services\Cron\Utility\CronUtility;
+use App\Services\Recommend\RecommendTagRebuildLock;
 use App\Services\Recommend\RecommendUpdater;
 use App\Services\Recommend\TagDefinition\TagMetadata;
 use ExceptionHandler\ExceptionHandler;
@@ -28,6 +29,7 @@ class UpdateRecommendStaticDataService
         private RecommendUpdater $recommendUpdater,
         private RecommendStaticDataGenerator $recommendStaticDataGenerator,
         private BatchScriptLauncher $launcher,
+        private RecommendTagRebuildLock $rebuildLock,
     ) {}
 
     function handle(): void
@@ -61,10 +63,10 @@ class UpdateRecommendStaticDataService
                 $currentHash = is_file($tagJsonPath) ? hash('sha256', (string)file_get_contents($tagJsonPath)) : '';
                 $storedHash = $this->state->getString(StateType::recommendTagsJsonHash);
                 if ($currentHash !== '' && $currentHash !== $storedHash) {
-                    if ($this->state->getBool(StateType::isRecommendTagRebuildActive)) {
+                    if ($this->rebuildLock->isHeldByLiveProcess()) {
                         CronUtility::addCronLog('タグ定義変更を検知したが再適用が実行中のためスキップ（次回CRONで再試行）');
                     } else {
-                        $this->state->setTrue(StateType::isRecommendTagRebuildActive);
+                        $this->rebuildLock->acquire();
                         try {
                             CronUtility::addCronLog('タグ定義の変更を検知 → 全レコード再適用開始 (urlRoot=' . MimimalCmsConfig::$urlRoot . ')');
                             if (MimimalCmsConfig::$urlRoot === '') {
@@ -77,7 +79,7 @@ class UpdateRecommendStaticDataService
                             $didRebuild = true;
                             CronUtility::addCronLog('全レコード再適用 完了');
                         } finally {
-                            $this->state->setFalse(StateType::isRecommendTagRebuildActive);
+                            $this->rebuildLock->release();
                         }
                     }
                 }

--- a/app/Services/Recommend/test/RebuildAllRecommendTagsServiceTest.php
+++ b/app/Services/Recommend/test/RebuildAllRecommendTagsServiceTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 use App\Config\SecretsConfig;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
-use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
 use App\Services\Cron\Utility\BatchScriptLauncher;
 use App\Services\Recommend\RebuildAllRecommendTagsService;
+use App\Services\Recommend\RecommendTagRebuildLock;
 use App\Services\Recommend\RecommendUpdater;
 use PHPUnit\Framework\TestCase;
 use Shared\MimimalCmsConfig;
@@ -14,8 +14,9 @@ use Shared\MimimalCmsConfig;
 // docker compose exec app vendor/bin/phpunit app/Services/Recommend/test/RebuildAllRecommendTagsServiceTest.php
 //
 // handle() の二重実行時の分岐だけを、依存を全てモックして検証する。
+// 「実行中か」の判定は RecommendTagRebuildLock::isHeldByLiveProcess() に委譲しているため、
+// ロックをモックして true/false を与え、分岐（待機 / kill再実行 / 通常実行）を確認する。
 // 実DB再構築・CDN purge は走らせない（updater/launcher をモックして無効化）。
-// Discord 通知も飛ばさない（webhook URL を空にして curl を no-op 化）。
 class RebuildAllRecommendTagsServiceTest extends TestCase
 {
     protected function setUp(): void
@@ -27,51 +28,56 @@ class RebuildAllRecommendTagsServiceTest extends TestCase
     /** 既定（待機）: 実行中なら kill も再構築もせず即 return する */
     public function test_default_waits_when_active(): void
     {
-        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
-        $state->method('getBool')->with(StateType::isRecommendTagRebuildActive)->willReturn(true);
-
+        $state = $this->createStub(SyncOpenChatStateRepositoryInterface::class);
         $updater = $this->createMock(RecommendUpdater::class);
         $launcher = $this->createMock(BatchScriptLauncher::class);
+        $lock = $this->createMock(RecommendTagRebuildLock::class);
 
-        // スキップ＝前ランを kill しない・再構築しない・静的データ生成へ連鎖しない
+        // 生きたプロセスに本当に保持されている（漏れロックではない）
+        $lock->method('isHeldByLiveProcess')->willReturn(true);
+
+        // スキップ＝前ランを kill しない・再構築しない・連鎖しない・ロックを奪わない
         $launcher->expects($this->never())->method('killOtherInstances');
         $updater->expects($this->never())->method('rebuildAllViaShadowSwap');
         $launcher->expects($this->never())->method('launchSync');
-        // 待機なので実行中フラグを立てない（前ランの所有を奪わない）
-        $state->expects($this->never())->method('setTrue');
+        $lock->expects($this->never())->method('acquire');
 
-        (new RebuildAllRecommendTagsService($state, $updater, $launcher))->handle(false);
+        (new RebuildAllRecommendTagsService($state, $updater, $launcher, $lock))->handle(false);
     }
 
     /** cancelPrevious=true: 実行中なら前ランを kill して再構築→静的データ生成へ連鎖する */
     public function test_cancel_previous_kills_and_reruns_when_active(): void
     {
-        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
-        $state->method('getBool')->with(StateType::isRecommendTagRebuildActive)->willReturn(true);
-
+        $state = $this->createStub(SyncOpenChatStateRepositoryInterface::class);
         $updater = $this->createMock(RecommendUpdater::class);
         $launcher = $this->createMock(BatchScriptLauncher::class);
+        $lock = $this->createMock(RecommendTagRebuildLock::class);
+
+        $lock->method('isHeldByLiveProcess')->willReturn(true);
 
         $launcher->expects($this->once())->method('killOtherInstances')->willReturn('killed');
+        $lock->expects($this->once())->method('acquire');
         $updater->expects($this->once())->method('rebuildAllViaShadowSwap');
         $launcher->expects($this->once())->method('launchSync'); // 静的データ生成へ連鎖
 
-        (new RebuildAllRecommendTagsService($state, $updater, $launcher))->handle(true);
+        (new RebuildAllRecommendTagsService($state, $updater, $launcher, $lock))->handle(true);
     }
 
-    /** 実行中でなければ、引数に関わらず通常どおり再構築する（kill は呼ばない） */
+    /** 実行中でなければ（漏れロックの自動回収後含む）、通常どおり再構築する（kill は呼ばない） */
     public function test_runs_normally_when_not_active(): void
     {
-        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
-        $state->method('getBool')->with(StateType::isRecommendTagRebuildActive)->willReturn(false);
-
+        $state = $this->createStub(SyncOpenChatStateRepositoryInterface::class);
         $updater = $this->createMock(RecommendUpdater::class);
         $launcher = $this->createMock(BatchScriptLauncher::class);
+        $lock = $this->createMock(RecommendTagRebuildLock::class);
+
+        $lock->method('isHeldByLiveProcess')->willReturn(false);
 
         $launcher->expects($this->never())->method('killOtherInstances');
+        $lock->expects($this->once())->method('acquire');
         $updater->expects($this->once())->method('rebuildAllViaShadowSwap');
         $launcher->expects($this->once())->method('launchSync');
 
-        (new RebuildAllRecommendTagsService($state, $updater, $launcher))->handle(false);
+        (new RebuildAllRecommendTagsService($state, $updater, $launcher, $lock))->handle(false);
     }
 }

--- a/app/Services/Recommend/test/RecommendTagRebuildLockTest.php
+++ b/app/Services/Recommend/test/RecommendTagRebuildLockTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Config\SecretsConfig;
+use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
+use App\Services\Cron\Utility\BatchScriptLauncher;
+use App\Services\Cron\Enum\SyncOpenChatStateType as StateType;
+use App\Services\Recommend\RecommendTagRebuildLock;
+use PHPUnit\Framework\TestCase;
+
+// docker compose exec app vendor/bin/phpunit app/Services/Recommend/test/RecommendTagRebuildLockTest.php
+//
+// 全再適用ロックの自己修復（漏れたロックの回収）を、状態リポジトリとランチャーを
+// モック/スタブして検証する。kill された保持プロセスがフラグを下ろせず立ち残った状況を、
+// 所有プロセスの死活と保持時間から検知して回収できることを確認する。
+class RecommendTagRebuildLockTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SecretsConfig::$discordWebhookUrl = ''; // 回収時の通知を外に飛ばさない
+    }
+
+    /** フラグが立っていなければ保持されておらず、回収（setFalse）も死活確認もしない */
+    public function test_not_held_when_flag_is_down(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->with(StateType::isRecommendTagRebuildActive)->willReturn(false);
+        $state->expects($this->never())->method('setFalse');
+
+        // フラグが下りていればプロセス死活すら確認しない（短絡）
+        $launcher = $this->createMock(BatchScriptLauncher::class);
+        $launcher->expects($this->never())->method('isAnyInstanceRunning');
+
+        $this->assertFalse((new RecommendTagRebuildLock($state, $launcher))->isHeldByLiveProcess());
+    }
+
+    /** フラグが立ち・所有プロセス生存・取得時刻が新しい → 本当に実行中（回収しない） */
+    public function test_held_when_process_alive_and_recent(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->willReturn(true);
+        $state->method('getString')->willReturn(date('Y-m-d H:i:s')); // たった今取得
+        $state->expects($this->never())->method('setFalse');
+
+        $launcher = $this->createStub(BatchScriptLauncher::class);
+        $launcher->method('isAnyInstanceRunning')->willReturn(true);
+
+        $this->assertTrue((new RecommendTagRebuildLock($state, $launcher))->isHeldByLiveProcess());
+    }
+
+    /** フラグは立つが所有プロセスが居ない（= kill 等で漏れたロック）→ 回収して false */
+    public function test_reclaims_leaked_lock_when_no_owner_process(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->willReturn(true);
+        $state->method('getString')->willReturn(date('Y-m-d H:i:s'));
+        $state->expects($this->once())->method('setFalse')->with(StateType::isRecommendTagRebuildActive);
+
+        $launcher = $this->createStub(BatchScriptLauncher::class);
+        $launcher->method('isAnyInstanceRunning')->willReturn(false); // どのスクリプトも生存していない
+
+        $this->assertFalse((new RecommendTagRebuildLock($state, $launcher))->isHeldByLiveProcess());
+    }
+
+    /** 所有プロセスが生存と見えても、規定時間を大幅超過していれば保険で回収する */
+    public function test_reclaims_when_held_too_long_even_if_process_seems_alive(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->willReturn(true);
+        $state->method('getString')->willReturn(date('Y-m-d H:i:s', time() - 60 * 60 * 3)); // 3時間前
+        $state->expects($this->once())->method('setFalse')->with(StateType::isRecommendTagRebuildActive);
+
+        $launcher = $this->createStub(BatchScriptLauncher::class);
+        $launcher->method('isAnyInstanceRunning')->willReturn(true);
+
+        $this->assertFalse((new RecommendTagRebuildLock($state, $launcher))->isHeldByLiveProcess());
+    }
+
+    /** 取得時刻が記録されていない（旧形式/記録漏れ）も回収対象 */
+    public function test_reclaims_when_started_at_missing(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->method('getBool')->willReturn(true);
+        $state->method('getString')->willReturn('');
+        $state->expects($this->once())->method('setFalse')->with(StateType::isRecommendTagRebuildActive);
+
+        $launcher = $this->createStub(BatchScriptLauncher::class);
+        $launcher->method('isAnyInstanceRunning')->willReturn(true);
+
+        $this->assertFalse((new RecommendTagRebuildLock($state, $launcher))->isHeldByLiveProcess());
+    }
+
+    /** acquire は取得時刻を記録しフラグを立てる */
+    public function test_acquire_records_started_at_and_raises_flag(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->expects($this->once())->method('setString')
+            ->with(StateType::recommendTagRebuildStartedAt, $this->callback('is_string'));
+        $state->expects($this->once())->method('setTrue')
+            ->with(StateType::isRecommendTagRebuildActive);
+
+        $launcher = $this->createStub(BatchScriptLauncher::class);
+
+        (new RecommendTagRebuildLock($state, $launcher))->acquire();
+    }
+
+    /** release はフラグを下ろす */
+    public function test_release_lowers_flag(): void
+    {
+        $state = $this->createMock(SyncOpenChatStateRepositoryInterface::class);
+        $state->expects($this->once())->method('setFalse')
+            ->with(StateType::isRecommendTagRebuildActive);
+
+        $launcher = $this->createStub(BatchScriptLauncher::class);
+
+        (new RecommendTagRebuildLock($state, $launcher))->release();
+    }
+}


### PR DESCRIPTION
## 問題の概要

おすすめのタグ定義（テーマ分け）を更新しても、**既存の部屋が新しい分類に付け直されず、古い分類のまま残り続ける**ことがある。

実例: 「フォートナイトブレインロット」へ振り分けられるはずの約 **636室** が「ブレインロット」に残り続けていた（[/recommend/ブレインロット](https://openchat-review.me/recommend/%E3%83%96%E3%83%AC%E3%82%A4%E3%83%B3%E3%83%AD%E3%83%83%E3%83%88)）。デプロイは成功し定義ファイルも本番に反映済みなのに、表示だけが古いままになる。

## 原因

おすすめタグの「全レコード再適用」（定義が変わったら全部の部屋を付け直す処理）は、毎時CRONとGUI再適用が同時に走らないよう真偽フラグ `isRecommendTagRebuildActive` で排他している。

このフラグは `try…finally` で必ず下ろす作りだが、**再適用中のプロセスが多重起動解消の `kill` などで SIGKILL されると `finally` が実行されず、フラグが永久に立ち残る**。以後の毎時処理は「再適用が実行中」と誤認してスキップし続け（[`UpdateRecommendStaticDataService`](../blob/stg/app/Services/Recommend/StaticData/UpdateRecommendStaticDataService.php) の検知→スキップ分岐）、定義を変えても既存の部屋が付け直されなくなる。新着の差分更新だけは動くため「更新は完走しているのに古い分類のまま」という分かりにくい状態になる。

GUI再適用（[`RebuildAllRecommendTagsService`](../blob/stg/app/Services/Recommend/RebuildAllRecommendTagsService.php)）は kill 後に自分でフラグを下ろす自己回復を持っていたが、**毎時CRON側には同じ手当てが無く**、漏れたフラグを誰も回収できなかった。

## 対処

- ロックを**プロセス死活ベースで自己修復**する [`RecommendTagRebuildLock`](../blob/fix/recommend-rebuild-lock-leak/app/Services/Recommend/RecommendTagRebuildLock.php) を追加。フラグが立っていても所有プロセス（`tag_update.php` / `update_recommend_static_data.php`）が生存していなければ「漏れたロック」とみなして回収し、再適用を握れるようにする。
- `ps` の誤検知に備え、規定時間（2時間）を超えて保持され続けたロックも保険として強制回収する（実際の全再構築は約21分で完了するため十分なマージン）。
- 毎時CRON / GUI再適用の両経路をこのロック経由に統一。
- 死活判定の読み取り版 `BatchScriptLauncher::isAnyInstanceRunning()` を追加。
- ロックの自己修復と両サービスの分岐に対するユニットテストを追加（10 tests / 30 assertions green）。

## 本番の応急処置（このPRとは別に実施済み）

立ち残っていたフラグを手動で解除済み。次の毎時CRONで全再適用が走り、636室が正しく振り分けられる見込み（確認中）。本PRはこの状態に二度と陥らないための恒久対策。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/oc-graph-3\`