### PR TITLE
[STG] perf: ルーム統計グラフのローソク足表示で不要なデータ取得をなくす（DBアクセス削減・取得データ軽量化）

### DIFF
--- a/app/Services/Chart/OpenChatChartApiService.php
+++ b/app/Services/Chart/OpenChatChartApiService.php
@@ -86,10 +86,11 @@ class OpenChatChartApiService
         // withMeta が要求されたら従来の全期間+メタ動作を優先し、範囲は無視する。
         $useRange = !$withMeta && $from !== null && $to !== null;
 
-        // 日次系列はローソク足・日次ビューの描画に必要（純粋なhourビューでは取得しない）。
+        // 日次統計は日次ビュー(折れ線)の描画とメタの空フォールバックに使う。
+        // ローソク足は OHLC 専用軸(ohlcDate)だけで描くので日次統計は引かない（無駄な統計DBアクセスを避ける）。
         // メタは ChartMetaBuilder（ライブ）で別途組むため、ここでは可用性を計算しない。
         $statsDto = null;
-        if ($mode === 'candlestick' || $span === 'day' || $withMeta) {
+        if ($mode !== 'candlestick' && ($span === 'day' || $withMeta)) {
             $statsDto = $this->statisticsChartArrayService->buildStatisticsChartArray(
                 $open_chat_id,
                 $category > 0 ? $category : null,
@@ -102,7 +103,7 @@ class OpenChatChartApiService
         }
 
         if ($mode === 'candlestick') {
-            $response = $this->buildCandlestickSeries($open_chat_id, $positionCategory, $sort, $type, $statsDto, $useRange ? $from : null, $useRange ? $to : null);
+            $response = $this->buildCandlestickSeries($open_chat_id, $positionCategory, $sort, $type, $useRange ? $from : null, $useRange ? $to : null);
         } elseif ($span === 'hour') {
             // hour系列(最新24時間固定・MariaDB)は範囲化対象外。from/to は無視する。
             $response = $this->buildHourSeries($open_chat_id, $positionCategory, $sort, $type);
@@ -120,13 +121,15 @@ class OpenChatChartApiService
     }
 
     /**
-     * series 指定時の層単位レスポンスを組み立てる。
+     * series 指定時の層単位レスポンスを組み立てる。要求された層だけを載せて返す（メタは付けない）。
      *
-     * 共通の date 軸（member 統計の from/to もしくは全期間から生成。順位層もこの軸に整合させる）に、
-     * 要求された層だけを載せて返す。メタは付けない。
+     * - member / position（折れ線）は共通の日次 date 軸に揃える。どちらかを要求されたときだけ
+     *   `date` を1本載せ、統計(buildStatisticsChartArray)も取得する。
+     * - OHLC（ローソク足）は OHLC 専用の `ohlcDate` 軸で返す（appendOhlcLayers）。日次 date とは別系列。
+     *   OHLC だけの要求なら統計取得も `date` も無し（無駄な統計DBアクセスと date/ohlcDate の二重を避ける）。
      *
      * @param array<string, true> $layers resolveSeries の結果（要求された層の集合）
-     * @return array{date: string[], member?: (int|null)[], time?: array, position?: array, totalCount?: array, ohlcDate?: string[], memberOhlc?: array, positionOhlc?: array}
+     * @return array{date?: string[], member?: (int|null)[], time?: array, position?: array, totalCount?: array, ohlcDate?: string[], memberOhlc?: array, positionOhlc?: array}
      */
     private function buildSeriesResponse(
         int $open_chat_id,
@@ -137,59 +140,35 @@ class OpenChatChartApiService
         ?string $from,
         ?string $to,
     ): array {
-        // date 軸は全層で共通。member 統計の範囲（from/to もしくは実データ全期間）から生成する。
-        // 統計レコードが無ければ空（date 空・各層空）で返す。
-        $statsDto = $this->statisticsChartArrayService->buildStatisticsChartArray(
-            $open_chat_id,
-            null,
-            $from,
-            $to,
-        );
+        $response = [];
 
-        if ($statsDto === false) {
-            $response = ['date' => []];
-            if (isset($layers[self::SERIES_MEMBER])) {
-                $response['member'] = [];
+        // member / position（折れ線）を要求されたときだけ、共通の日次 date 軸＋統計を取得する。
+        $wantMember = isset($layers[self::SERIES_MEMBER]);
+        $wantPosition = isset($layers[self::SERIES_POSITION]);
+        if ($wantMember || $wantPosition) {
+            $statsDto = $this->statisticsChartArrayService->buildStatisticsChartArray($open_chat_id, null, $from, $to);
+
+            $response['date'] = $statsDto === false ? [] : $statsDto->date;
+
+            if ($wantMember) {
+                $response['member'] = $statsDto === false ? [] : $statsDto->member;
             }
-            if (isset($layers[self::SERIES_POSITION])) {
-                // time は急上昇(rising)のみ。ランキングは終日時刻を持たない（null配列）ので配列ごと省く。
+
+            if ($wantPosition) {
+                // 順位層は member と同じ date 軸（statsDto.start/end）で生成し、from/to を DB 絞り込みに渡す。
+                $position = $statsDto === false
+                    ? ['time' => [], 'position' => [], 'totalCount' => []]
+                    : $this->buildPositionLayer($open_chat_id, $positionCategory, $sort, $type, $statsDto, $from, $to);
+                // time は急上昇(rising)のみ返す（ランキングは終日時刻なし＝null配列になるので省く）。
                 if ($type === RankingType::Rising) {
-                    $response['time'] = [];
+                    $response['time'] = $position['time'];
                 }
-                $response['position'] = [];
-                $response['totalCount'] = [];
+                $response['position'] = $position['position'];
+                $response['totalCount'] = $position['totalCount'];
             }
-            $this->appendOhlcLayers(
-                $response,
-                $open_chat_id,
-                $positionCategory,
-                $sort,
-                $type,
-                isset($layers[self::SERIES_MEMBER_OHLC]),
-                isset($layers[self::SERIES_POSITION_OHLC]),
-                $from,
-                $to,
-            );
-            return $response;
         }
 
-        $response = ['date' => $statsDto->date];
-
-        if (isset($layers[self::SERIES_MEMBER])) {
-            $response['member'] = $statsDto->member;
-        }
-
-        if (isset($layers[self::SERIES_POSITION])) {
-            // 順位層は member と同じ date 軸（statsDto.start/end）で生成し、from/to を DB 絞り込みに渡す。
-            $position = $this->buildPositionLayer($open_chat_id, $positionCategory, $sort, $type, $statsDto, $from, $to);
-            // time は急上昇(rising)のみ返す（ランキングは終日時刻なし＝null配列になるので省く）。
-            if ($type === RankingType::Rising) {
-                $response['time'] = $position['time'];
-            }
-            $response['position'] = $position['position'];
-            $response['totalCount'] = $position['totalCount'];
-        }
-
+        // OHLC（ローソク足）は ohlcDate 軸で別途載せる（日次 date とは独立）。
         $this->appendOhlcLayers(
             $response,
             $open_chat_id,
@@ -316,20 +295,13 @@ class OpenChatChartApiService
         int $positionCategory,
         string $sort,
         RankingType $type,
-        StatisticsChartDto $statsDto,
         ?string $from = null,
         ?string $to = null,
     ): array {
-        // ローソク足は時刻ラベル付き折れ線tooltipを使わないので time を持たない。
-        // 折れ線用の position/totalCount もローソク足では描画しないため省く
-        // （member は折れ線と層キャッシュを共有するため返す）。
-        $response = [
-            'date' => $statsDto->date,
-            'member' => $statsDto->member,
-        ];
-
+        // ローソク足は OHLC 専用の ohlcDate 軸だけで描く。日次の date / member 折れ線は使わないので返さない
+        // （member を引くための統計DBアクセスと、date と ohlcDate の二重を避ける）。
+        $response = [];
         $this->appendOhlcLayers($response, $open_chat_id, $positionCategory, $sort, $type, true, $sort !== 'none', $from, $to);
-
         return $response;
     }
 

--- a/app/Services/Chart/test/OpenChatChartApiServiceTest.php
+++ b/app/Services/Chart/test/OpenChatChartApiServiceTest.php
@@ -52,7 +52,11 @@ class OpenChatChartApiServiceTest extends TestCase
     {
         $result = $this->instance->buildChartResponse(192, 8, 'day', 'ranking', 'all', 'candlestick', false);
 
-        $this->assertSame(count($result['date']), count($result['member']));
+        // ローソク足は OHLC 専用軸(ohlcDate)だけで返す。日次の date / member 折れ線は持たない
+        // （member を引くための統計DBアクセスと、date と ohlcDate の二重を避ける）
+        $this->assertArrayNotHasKey('date', $result);
+        $this->assertArrayNotHasKey('member', $result);
+        $this->assertArrayNotHasKey('time', $result);
 
         // OHLC は共通の ohlcDate 軸＋date抜きの値配列で返る（memberOhlc/positionOhlc は ohlcDate と同長）
         $this->assertArrayHasKey('ohlcDate', $result);
@@ -60,9 +64,6 @@ class OpenChatChartApiServiceTest extends TestCase
         $this->assertArrayHasKey('positionOhlc', $result);
         $this->assertSame(count($result['ohlcDate']), count($result['memberOhlc']));
         $this->assertSame(count($result['ohlcDate']), count($result['positionOhlc']));
-
-        // ローソク足は時刻ラベル折れ線tooltipを使わないので time は持たない
-        $this->assertArrayNotHasKey('time', $result);
 
         // 各 OHLC 要素は date を持たない（ohlcDate と重複させない）
         if ($result['memberOhlc']) {
@@ -144,7 +145,8 @@ class OpenChatChartApiServiceTest extends TestCase
     {
         $result = $this->instance->buildChartResponse(192, 8, 'day', 'ranking', 'all', 'candlestick', false, null, null, 'memberOhlc');
 
-        $this->assertArrayHasKey('date', $result);
+        // OHLC だけの要求は ohlcDate 軸のみ。日次 date は付けない（統計DBも引かない・date二重も無し）
+        $this->assertArrayNotHasKey('date', $result);
         $this->assertArrayHasKey('ohlcDate', $result);
         $this->assertArrayHasKey('memberOhlc', $result);
         $this->assertSame(count($result['ohlcDate']), count($result['memberOhlc']));
@@ -158,7 +160,7 @@ class OpenChatChartApiServiceTest extends TestCase
     {
         $result = $this->instance->buildChartResponse(192, 8, 'day', 'ranking', 'all', 'candlestick', false, null, null, 'positionOhlc');
 
-        $this->assertArrayHasKey('date', $result);
+        $this->assertArrayNotHasKey('date', $result);
         $this->assertArrayHasKey('ohlcDate', $result);
         $this->assertArrayHasKey('positionOhlc', $result);
         $this->assertSame(count($result['ohlcDate']), count($result['positionOhlc']));

--- a/frontend/oc-app/README.md
+++ b/frontend/oc-app/README.md
@@ -58,11 +58,14 @@
 | 折れ線・人数のみ | `member` | `?span=day&sort=none&scope=all&category={cat}&mode=line&series=member&from={from}&to={to}` |
 | 折れ線・ランキング | `member,position` | `?span=day&sort=ranking&scope=in&category={cat}&mode=line&series=member,position&from={from}&to={to}` |
 | 折れ線・急上昇 | `member,position` | `?span=day&sort=rising&scope=all&category={cat}&mode=line&series=member,position&from={from}&to={to}` |
-| ローソク・人数のみ | `member,memberOhlc` | `?span=day&sort=none&scope=all&category={cat}&mode=candlestick&series=member,memberOhlc&from={from}&to={to}` |
-| ローソク・ランキング | `member,memberOhlc,positionOhlc` | `?span=day&sort=ranking&scope=in&category={cat}&mode=candlestick&series=member,memberOhlc,positionOhlc&from={from}&to={to}` |
-| ローソク・急上昇 | `member,memberOhlc,positionOhlc` | `?span=day&sort=rising&scope=all&category={cat}&mode=candlestick&series=member,memberOhlc,positionOhlc&from={from}&to={to}` |
+| ローソク・人数のみ | `memberOhlc` | `?span=day&sort=none&scope=all&category={cat}&mode=candlestick&series=memberOhlc&from={from}&to={to}` |
+| ローソク・ランキング | `memberOhlc,positionOhlc` | `?span=day&sort=ranking&scope=in&category={cat}&mode=candlestick&series=memberOhlc,positionOhlc&from={from}&to={to}` |
+| ローソク・急上昇 | `memberOhlc,positionOhlc` | `?span=day&sort=rising&scope=all&category={cat}&mode=candlestick&series=memberOhlc,positionOhlc&from={from}&to={to}` |
 | 最新24時間（折れ線） | （series無し・全24h） | `?span=hour&sort=ranking&scope=in&category={cat}&mode=line` |
 | 初回ロード（埋め込みメタ無し） | （series無し・全期間） | `?span=day&sort=ranking&scope=in&category={cat}&mode=line&meta=1` |
+
+ローソク足は OHLC 層だけを取る（`member` 折れ線は引かない＝統計DBアクセスを発生させない）。
+ローソク足は常に全期間取得し、期間タブの本数はクライアント側でスライスする。
 
 ---
 
@@ -70,16 +73,17 @@
 
 ```ts
 interface ChartResponse {
-  date: string[]                 // 全系列共通の日付（hour は時刻ラベル）軸
-  member: (number | null)[]      // date と同順・同長のメンバー数
+  // 折れ線(line)用。ローソク足では付かない
+  date?: string[]                // 日次の日付（hour は時刻ラベル）軸
+  member?: (number | null)[]     // date と同順・同長のメンバー数
 
   // 順位（折れ線の重ね描き。sort≠none のときだけ付く）
   position?: (number | null)[]   // date と同順・同長（圏外は0、未取得日は null）
   totalCount?: (number | null)[] // 同上（その日の総件数）
   time?: (string | null)[]       // 急上昇(rising)のときだけ。順位を記録した時刻(HH:MM)
 
-  // ローソク足（mode=candlestick のときだけ付く）
-  ohlcDate?: string[]            // OHLC専用の日付軸（date の部分集合）。下2つはこれと index 整合
+  // ローソク足(candlestick)用。ohlcDate が OHLC 専用の日付軸（折れ線の date とは別系列）
+  ohlcDate?: string[]            // OHLC のある日付（昇順）。下2つはこれと index 整合
   memberOhlc?: MemberOhlc[]      // ohlcDate と同順・同長
   positionOhlc?: (RankingPositionOhlc | null)[] // ohlcDate と同順・同長。null=その日は圏外
 
@@ -108,21 +112,23 @@ interface RankingPositionOhlc {
 
 | フィールド | 付く条件 |
 | --- | --- |
-| `date` / `member` | 常に |
-| `position` / `totalCount` | sort≠none（折れ線の順位） |
-| `time` | sort=rising のときだけ |
-| `ohlcDate` / `memberOhlc` | mode=candlestick |
-| `positionOhlc` | mode=candlestick かつ sort≠none |
+| `date` / `member` | 折れ線(line)のみ（ローソク足では付かない） |
+| `position` / `totalCount` | 折れ線 かつ sort≠none |
+| `time` | 折れ線 かつ sort=rising のときだけ |
+| `ohlcDate` / `memberOhlc` | ローソク足(candlestick) |
+| `positionOhlc` | ローソク足 かつ sort≠none |
 | `meta` | 初回ロード（meta=1）のときだけ |
 
 ---
 
 ## 約束ごと（壊さないこと）
 
-- `date` は全系列で共通の1本の軸。`member`・`position`・`totalCount`・`time` はこれと index 整合。
+- 折れ線は `date` が共通軸で、`member`・`position`・`totalCount`・`time` はこれと index 整合。
+- ローソク足は `ohlcDate` が唯一の軸で、`memberOhlc`・`positionOhlc` はこれと同順・同長
+  （各要素に date を持たせない＝二重・三重にしない）。`positionOhlc` の `null` はその日が圏外
+  （順位OHLCなし）で、描画では0（圏外）として埋める。
+- ローソク足は折れ線の `date` / `member` を返さない・取得しない（OHLC は別系列で、日次 member 折れ線は
+  描かないため。統計DBへの無駄なアクセスと date/ohlcDate の二重を避ける）。
 - `time` は急上昇(rising)のときだけ返す。ランキング・人数のみ・24時間・ローソク足では付かない
   （時刻を持たない／x軸が時刻のため）。フロントは「`time` が無い＝時刻表示なし」として扱う。
-- OHLC は `ohlcDate` という別の日付軸を1本だけ持ち、`memberOhlc` と `positionOhlc` はどちらも
-  これと同順・同長で揃える（各要素に date を持たせて二重・三重にしない）。`positionOhlc` の `null`
-  はその日が圏外（順位OHLCなし）で、描画では0（圏外）として埋める。
 - `meta` は初回ロード時のみ。操作後の層別フェッチには含めない。

--- a/frontend/oc-app/src/graph/classes/ModelFactory.ts
+++ b/frontend/oc-app/src/graph/classes/ModelFactory.ts
@@ -6,7 +6,6 @@ export default class ModelFactory {
       graph2: [],
       time: [],
       totalCount: [],
-      rankingOhlc: [],
     }
   }
 

--- a/frontend/oc-app/src/graph/classes/OpenChatChart.ts
+++ b/frontend/oc-app/src/graph/classes/OpenChatChart.ts
@@ -38,9 +38,11 @@ export default class OpenChatChart implements ChartFactory {
   onZooming = false
   onPaning = false
   enableZoom = false
-  /** OHLC専用の日付軸（memberOhlcApiData / initData.rankingOhlc と index 整合）。日次 date 軸の部分集合 */
+  /** OHLC専用の日付軸（memberOhlcApiData / positionOhlcApiData と index 整合・昇順） */
   ohlcDate: string[] = []
   memberOhlcApiData: MemberOhlc[] = []
+  /** 順位OHLC（ohlcDate と index 整合。null=その日は圏外）。順位OFF時は空配列 */
+  positionOhlcApiData: (RankingPositionOhlc | null)[] = []
   ohlcData: { x: number; o: number; h: number; l: number; c: number }[] = []
   ohlcRankingData: { x: number; o: number; h: number; l: number; c: number }[] = []
   ohlcRankingNullLow: Set<number> = new Set()
@@ -240,16 +242,14 @@ export default class OpenChatChart implements ChartFactory {
 
   private buildCandlestickData() {
     const limit = this.limit
-    const dailyDates = this.initData.date // 日次 date 軸（期間タブの窓計算に使う）
-    const ohlcDate = this.ohlcDate // OHLC日付軸（dailyDates の部分集合・昇順）
+    const ohlcDate = this.ohlcDate // OHLC日付軸（昇順）
     const member = this.memberOhlcApiData // ohlcDate と index 整合
-    const rankingOhlc = this.initData.rankingOhlc // ohlcDate と index 整合（null=圏外）
-    const hasRanking = !!rankingOhlc?.length
+    const ranking = this.positionOhlcApiData // ohlcDate と index 整合（null=圏外）。順位OFF時は空
+    const hasRanking = !!ranking.length
+    const len = ohlcDate.length
 
-    // 期間タブの窓は従来どおり「日次 date 軸の末尾 limit 日」。その開始日以降の OHLC だけ描く。
-    // （OHLC本数ではなく日次日数で窓を決めることで updateCandleTabVisibility のタブ表示判定と一致させる）
-    const startIdx = limit ? Math.max(0, dailyDates.length - limit) : 0
-    const windowStart = dailyDates[startIdx] ?? ''
+    // 期間タブは末尾 limit 本のローソクを表示する（OHLCは日次なので「直近 limit 日」と一致）。0=全期間。
+    const startIdx = limit ? Math.max(0, len - limit) : 0
 
     const ohlcData: { x: number; o: number; h: number; l: number; c: number }[] = []
     const allValues: number[] = []
@@ -258,18 +258,17 @@ export default class OpenChatChart implements ChartFactory {
     const ohlcRankingData: { x: number; o: number; h: number; l: number; c: number }[] = []
     const ohlcRankingNullLow = new Set<number>()
 
-    for (let k = 0; k < ohlcDate.length; k++) {
-      if (ohlcDate[k] < windowStart) continue // 窓より前の OHLC は描かない
-      const m = member[k]
+    for (let i = startIdx; i < len; i++) {
+      const m = member[i]
       if (!m) continue // member OHLC は ohlcDate と1:1（防御的にスキップ）
 
       const x = ohlcData.length
-      ohlcDates.push(ohlcDate[k])
+      ohlcDates.push(ohlcDate[i])
       ohlcData.push({ x, o: m.open_member, h: m.high_member, l: m.low_member, c: m.close_member })
       allValues.push(m.open_member, m.high_member, m.low_member, m.close_member)
 
       if (hasRanking) {
-        const r = rankingOhlc![k]
+        const r = ranking[i]
         if (r) {
           if (r.low_position === null) ohlcRankingNullLow.add(x)
           ohlcRankingData.push({

--- a/frontend/oc-app/src/graph/state/chartState.ts
+++ b/frontend/oc-app/src/graph/state/chartState.ts
@@ -326,15 +326,11 @@ export function updateTabVisibility(dataLength: number) {
  * - OHLCデータは記録期間が限られるため（例: 過去のみに存在する部屋）、
  *   より短いタブで全て表示しきれる冗長な長いタブも非表示にする
  */
-export function updateCandleTabVisibility(ohlcDate: string[], dates: string[]) {
-  const ohlcDateSet = new Set(ohlcDate)
-  const countInWindow = (limit: number) => {
-    let count = 0
-    for (let i = limit ? Math.max(0, dates.length - limit) : 0; i < dates.length; i++) {
-      if (ohlcDateSet.has(dates[i])) count++
-    }
-    return count
-  }
+export function updateCandleTabVisibility(ohlcDate: string[]) {
+  // OHLCは日次連続なので「直近 limit 本」を各タブの表示本数とみなす（0=全期間）。
+  // 過去で記録が途切れた部屋など recency は ohlcAvailability(hasOhlcDataForLimit) 側でゲートする。
+  const total = ohlcDate.length
+  const countInWindow = (limit: number) => (limit ? Math.min(limit, total) : total)
 
   const weekCount = countInWindow(8)
   const monthCount = countInWindow(31)

--- a/frontend/oc-app/src/graph/types/api.d.ts
+++ b/frontend/oc-app/src/graph/types/api.d.ts
@@ -52,17 +52,19 @@ interface ErrorResponse {
 }
 
 /**
- * /oc/{id}/chart のレスポンス。表示ビュー（span×sort×scope×mode）の描画に必要な系列を一括返却する
+ * /oc/{id}/chart のレスポンス。表示ビュー（span×sort×scope×mode）の描画に必要な系列だけを返す。
  *
- * - date/member: hour は時刻ラベル+毎時メンバー数、day は日付+日次メンバー数（date は全系列共通の軸）
- * - position/totalCount: sort が none 以外のときの順位系列。time は急上昇(rising)のときだけ付く
- *   （ランキングは終日時刻を持たないため省略。フロントは time が無い＝時刻表示なしとして扱う）
- * - ohlcDate/memberOhlc/positionOhlc: mode=candlestick のときのみ。ohlcDate は OHLC 専用の日付軸で、
- *   memberOhlc・positionOhlc はこれと同順・同長（positionOhlc の null はその日が圏外＝順位OHLCなし）
+ * - 折れ線(line): date（hourは時刻ラベル）＋ member。順位ON時は position/totalCount。
+ *   time は急上昇(rising)のときだけ付く（ランキングは終日時刻を持たないため省略。無い＝時刻表示なし）。
+ * - ローソク足(candlestick): ohlcDate ＋ memberOhlc（順位ON時は positionOhlc）だけを返す。
+ *   日次の date / member 折れ線は使わないので付かない（ohlcDate が OHLC 専用の日付軸）。
+ *   memberOhlc・positionOhlc は ohlcDate と同順・同長（positionOhlc の null はその日が圏外＝順位OHLCなし）。
+ *
+ * 各フィールドは要求した層のときだけ付く（layer別の差分フェッチと共通形）。
  */
 interface ChartResponse {
-  date: string[]
-  member: (number | null)[]
+  date?: string[]
+  member?: (number | null)[]
   time?: (string | null)[]
   position?: (number | null)[]
   totalCount?: (number | null)[]

--- a/frontend/oc-app/src/graph/types/chart.d.ts
+++ b/frontend/oc-app/src/graph/types/chart.d.ts
@@ -8,8 +8,6 @@ type ChartArgs = {
   graph2: (number | null)[]
   time: (string | null)[]
   totalCount: (number | null)[]
-  /** 順位OHLC。ohlcDate と index 整合（null=その日は圏外） */
-  rankingOhlc?: (RankingPositionOhlc | null)[]
 }
 
 type ChartData = {

--- a/frontend/oc-app/src/graph/util/fetchRenderer.ts
+++ b/frontend/oc-app/src/graph/util/fetchRenderer.ts
@@ -143,21 +143,20 @@ function layerKey(name: LayerName): string {
 
 /**
  * 現在の表示ビューで必要な層を返す。
- *  - member: 常に必要
- *  - position: 折れ線 かつ 順位ON（sort≠none）
- *  - memberOhlc: ローソク足
- *  - positionOhlc: ローソク足 かつ 順位ON
+ *  - 折れ線: member（常に）＋ position（順位ON時）
+ *  - ローソク足: memberOhlc（常に）＋ positionOhlc（順位ON時）。日次 member 折れ線は描かないので取得しない
+ *    （member 層＝統計DBアクセスを発生させない。OHLC は ohlcDate 軸で独立して持つ）
  */
 function requiredLayers(): LayerName[] {
   const mode = graphStore.get(chartModeAtom)
   const sort = graphStore.get(rankingRisingAtom)
-  const list: LayerName[] = ['member']
   if (mode === 'candlestick') {
-    list.push('memberOhlc')
+    const list: LayerName[] = ['memberOhlc']
     if (sort !== 'none') list.push('positionOhlc')
-  } else if (sort !== 'none') {
-    list.push('position')
+    return list
   }
+  const list: LayerName[] = ['member']
+  if (sort !== 'none') list.push('position')
   return list
 }
 
@@ -196,13 +195,8 @@ function windowFromForLimit(limit: ChartLimit): string {
 /**
  * 現在ビューで「描画・取得に使う窓の開始日」を返す。
  *
- * ローソク足は全期間で取得する（＝開始日は startDate 固定）。
- * 理由: ローソク足のタブ表示判定 updateCandleTabVisibility は「長いタブが短いタブより本数が
- * 多いか」を表示中 data の日付配列で数えて決めるため、窓だけ持つと（週タブ表示中は week 窓ぶんの
- * 日付しか無く）月/全タブの本数を過小カウントしてタブが誤って消える。可用性メタ(ohlcAvailability)は
- * 閾値booleanのみでこの本数比較を再現できないため、ローソク足は全期間取得で従来の判定を厳密に維持する。
- * （member 層は line と共有。candlestick で member 行は描画しないが date 軸を全期間に保つため全期間で持つ）
- *
+ * ローソク足は全期間で取得する（＝開始日は startDate 固定）。タブ表示判定・本数スライスとも
+ * OHLC全件が手元にある前提で行うため（窓だけ持つと長いタブの本数を過小カウントする）。
  * 折れ線は従来どおり limit の窓開始日（縮小はクライアントスライス、拡大は古い差分だけ取得）。
  */
 function neededFromForView(limit: ChartLimit): string {
@@ -249,13 +243,17 @@ async function fetchLayers(names: LayerName[], from: string, to: string): Promis
   const data = await fetcher<ChartResponse>(
     `${chatArgDto.baseUrl}/oc/${chatArgDto.id}/chart?${getChartViewQuery()}&series=${series}&from=${from}&to=${to}`
   )
-  mergeLayers(names, data)
+  mergeLayers(names, data, from)
 }
 
-/** 取得レスポンス(共通date軸)を、要求した各層の byDate に prepend マージし loadedFrom を更新する */
-function mergeLayers(names: LayerName[], data: ChartResponse): void {
+/**
+ * 取得レスポンスを、要求した各層の byDate にマージし loadedFrom を更新する。
+ * 折れ線層(member/position)は date 軸、ローソク足層(OHLC)は ohlcDate 軸と zip する。
+ * loadedFrom は「取得した窓の開始日(from)」で更新する（OHLC応答に date が無くても遡れた範囲を記録できる）。
+ */
+function mergeLayers(names: LayerName[], data: ChartResponse, from: string): void {
   const date = data.date ?? []
-  const from = date[0]
+  const ohlcDate = data.ohlcDate ?? []
 
   for (const name of names) {
     const key = layerKey(name)
@@ -263,7 +261,6 @@ function mergeLayers(names: LayerName[], data: ChartResponse): void {
       case 'member': {
         const entry = ensureMemberEntry(key)
         date.forEach((d, i) => entry.byDate.set(d, data.member?.[i] ?? null))
-        if (from !== undefined && from < entry.loadedFrom) entry.loadedFrom = from
         break
       }
       case 'position': {
@@ -275,31 +272,27 @@ function mergeLayers(names: LayerName[], data: ChartResponse): void {
             totalCount: data.totalCount?.[i] ?? null,
           })
         )
-        if (from !== undefined && from < entry.loadedFrom) entry.loadedFrom = from
         break
       }
       case 'memberOhlc': {
-        // OHLC は共通 ohlcDate 軸と index 整合。ohlcDate と zip して日付キーの byDate に積む。
         const entry = ensureMemberOhlcEntry(key)
-        const ohlcDate = data.ohlcDate ?? []
         ohlcDate.forEach((d, i) => {
           const v = data.memberOhlc?.[i]
           if (v) entry.byDate.set(d, v)
         })
-        if (from !== undefined && from < entry.loadedFrom) entry.loadedFrom = from
         break
       }
       case 'positionOhlc': {
         const entry = ensurePositionOhlcEntry(key)
-        const ohlcDate = data.ohlcDate ?? []
         ohlcDate.forEach((d, i) => {
           const v = data.positionOhlc?.[i]
           if (v) entry.byDate.set(d, v) // null（圏外）は積まない＝assemble 時に欠落=圏外として復元
         })
-        if (from !== undefined && from < entry.loadedFrom) entry.loadedFrom = from
         break
       }
     }
+    const entry = layers.get(key)!
+    if (from < entry.loadedFrom) entry.loadedFrom = from
   }
 }
 
@@ -378,16 +371,32 @@ async function ensureLayersForWindow(neededFrom: string): Promise<void> {
  * chart 側が limit で末尾スライスするため、ここでは窓全体（蓄積が広くてもよい）を渡す。
  */
 function assembleResponse(limit: ChartLimit): ChartResponse {
-  const from = neededFromForView(limit)
-  const date = buildDateAxis(from)
   const needs = new Set(requiredLayers())
 
-  const response: ChartResponse = {
-    date,
-    member: [],
-    position: [],
-    totalCount: [],
+  // ローソク足: OHLC 専用軸(ohlcDate)だけで組み立てる（日次 date / member は使わない）。
+  // ローソク足は全期間取得なので、キャッシュ済み OHLC の日付を昇順に並べたものが ohlcDate になる。
+  if (needs.has('memberOhlc')) {
+    const entry = layers.get(MEMBER_OHLC_KEY) as
+      | { loadedFrom: string; byDate: Map<string, MemberOhlc> }
+      | undefined
+    const ohlcDate = entry ? [...entry.byDate.keys()].sort() : []
+    const response: ChartResponse = {
+      ohlcDate,
+      memberOhlc: ohlcDate.map((d) => entry!.byDate.get(d)!),
+    }
+    // positionOhlc（順位ON時のみ）も同じ ohlcDate に整合（順位OHLCの無い日は null＝圏外）
+    if (needs.has('positionOhlc')) {
+      const pentry = layers.get(positionKey('positionOhlc')) as
+        | { loadedFrom: string; byDate: Map<string, RankingPositionOhlc> }
+        | undefined
+      response.positionOhlc = ohlcDate.map((d) => pentry?.byDate.get(d) ?? null)
+    }
+    return response
   }
+
+  // 折れ線: 日次 date 軸で組み立てる
+  const date = buildDateAxis(neededFromForView(limit))
+  const response: ChartResponse = { date, member: [], position: [], totalCount: [] }
 
   // member（常に必要）
   const memberEntry = layers.get(MEMBER_KEY) as
@@ -395,7 +404,7 @@ function assembleResponse(limit: ChartLimit): ChartResponse {
     | undefined
   response.member = date.map((d) => memberEntry?.byDate.get(d) ?? null)
 
-  // position（折れ線・順位ON時のみ。それ以外は空配列で従来同様）
+  // position（順位ON時のみ。それ以外は空配列で従来同様）
   if (needs.has('position')) {
     const entry = layers.get(positionKey('position')) as
       | { loadedFrom: string; byDate: Map<string, PositionPoint> }
@@ -405,24 +414,6 @@ function assembleResponse(limit: ChartLimit): ChartResponse {
     // time は急上昇(rising)のみ。ランキングは時刻を持たないので time キー自体を付けない。
     if (graphStore.get(rankingRisingAtom) === 'rising') {
       response.time = date.map((d) => entry?.byDate.get(d)?.time ?? null)
-    }
-  }
-
-  // memberOhlc（ローソク足時のみ）: window 内で OHLC を持つ日を ohlcDate にし、値配列を index 整合させる
-  if (needs.has('memberOhlc')) {
-    const entry = layers.get(MEMBER_OHLC_KEY) as
-      | { loadedFrom: string; byDate: Map<string, MemberOhlc> }
-      | undefined
-    const ohlcDate = date.filter((d) => entry?.byDate.has(d))
-    response.ohlcDate = ohlcDate
-    response.memberOhlc = ohlcDate.map((d) => entry!.byDate.get(d)!)
-
-    // positionOhlc（順位ON時のみ）も同じ ohlcDate に整合（順位OHLCの無い日は null＝圏外）
-    if (needs.has('positionOhlc')) {
-      const pentry = layers.get(positionKey('positionOhlc')) as
-        | { loadedFrom: string; byDate: Map<string, RankingPositionOhlc> }
-        | undefined
-      response.positionOhlc = ohlcDate.map((d) => pentry?.byDate.get(d) ?? null)
     }
   }
 
@@ -472,20 +463,18 @@ export async function fetchChartData(withMeta = false): Promise<ChartResponse> {
  * （取り込む層は現在ビューが返した系列ぶん。order は date 昇順前提）
  */
 function importFullResponseToLayers(data: ChartResponse): void {
-  const from = data.date?.[0]
-  if (from === undefined) return
+  // meta=1 は全期間取得なので、窓開始日＝startDate（ローソク足は date を持たないため chartMeta から取る）。
+  const from = chartMeta?.startDate
+  if (!from) return
 
-  // member は常に入っている
-  mergeLayers(['member'], data)
-
-  // 現在ビューに応じて返ってきた層も取り込む（空配列なら実質ノーオペ）
   const sort = graphStore.get(rankingRisingAtom)
   const mode = graphStore.get(chartModeAtom)
   if (mode === 'candlestick') {
-    mergeLayers(['memberOhlc'], data)
-    if (sort !== 'none') mergeLayers(['positionOhlc'], data)
-  } else if (sort !== 'none') {
-    mergeLayers(['position'], data)
+    mergeLayers(['memberOhlc'], data, from)
+    if (sort !== 'none') mergeLayers(['positionOhlc'], data, from)
+  } else {
+    mergeLayers(['member'], data, from)
+    if (sort !== 'none') mergeLayers(['position'], data, from)
   }
 }
 
@@ -494,8 +483,8 @@ const renderPositionChart = (data: ChartResponse, animation: boolean, limit: Cha
 
   chart.render(
     {
-      date: data.date,
-      graph1: data.member,
+      date: data.date ?? [],
+      graph1: data.member ?? [],
       graph2: data.position ?? [],
       // time は rising のみ。ランキング等で無い場合は空配列として扱う（時刻tooltip非表示）
       time: data.time ?? [],
@@ -515,8 +504,8 @@ const renderPositionChart = (data: ChartResponse, animation: boolean, limit: Cha
 const renderMemberChart = (data: ChartResponse, animation: boolean, limit: ChartLimit) => {
   chart.render(
     {
-      date: data.date,
-      graph1: data.member,
+      date: data.date ?? [],
+      graph1: data.member ?? [],
       graph2: [],
       time: [],
       totalCount: [],
@@ -531,21 +520,17 @@ const renderMemberChart = (data: ChartResponse, animation: boolean, limit: Chart
   )
 }
 
-const renderCandlestickChart = (data: ChartResponse, animation: boolean, limit: ChartLimit) => {
-  const isRising = graphStore.get(rankingRisingAtom) === 'rising'
+const renderCandlestickChart = (animation: boolean, limit: ChartLimit) => {
+  const sort = graphStore.get(rankingRisingAtom)
+  const isRising = sort === 'rising'
 
+  // ローソク足は OHLC をチャートのプロパティ(ohlcDate/memberOhlcApiData/positionOhlcApiData)で持つので、
+  // 折れ線用の ChartArgs(date/graph1/...) は空でよい。
   chart.render(
-    {
-      date: data.date,
-      graph1: data.member,
-      graph2: [],
-      time: [],
-      totalCount: [],
-      rankingOhlc: data.positionOhlc,
-    },
+    { date: [], graph1: [], graph2: [], time: [], totalCount: [] },
     {
       label1: t('メンバー数'),
-      label2: isRising ? t('急上昇') : t('ランキング'),
+      label2: sort === 'none' ? '' : isRising ? t('急上昇') : t('ランキング'),
       category: graphStore.get(categoryAtom) === 'all' ? t('すべて') : chatArgDto.categoryName,
       isRising,
     },
@@ -565,18 +550,14 @@ export function renderChartData(data: ChartResponse, animation: boolean) {
   const sort = graphStore.get(rankingRisingAtom)
 
   if (graphStore.get(chartModeAtom) === 'candlestick') {
-    // OHLC は ohlcDate（OHLC専用の日付軸）＋ index 整合の値配列で受け取る
+    // OHLC は ohlcDate（OHLC専用の日付軸）＋ index 整合の値配列で受け取る（日次 date/member は持たない）
     chart.ohlcDate = data.ohlcDate ?? []
     chart.memberOhlcApiData = data.memberOhlc ?? []
+    chart.positionOhlcApiData = data.positionOhlc ?? []
 
-    // 期間タブ毎のローソク足本数に基づいてタブ表示を更新（OHLCのある日付集合＝ohlcDate）
-    updateCandleTabVisibility(chart.ohlcDate, data.date)
-
-    if (sort === 'none') {
-      renderMemberChart(data, animation, limit)
-    } else {
-      renderCandlestickChart(data, animation, limit)
-    }
+    // 期間タブ表示は OHLC 本数で判定（順位ON/OFFどちらも renderCandlestickChart が描く）
+    updateCandleTabVisibility(chart.ohlcDate)
+    renderCandlestickChart(animation, limit)
     return
   }
 


### PR DESCRIPTION
ルーム個別ページのグラフを「ローソク足」で表示するとき、描画に使わない日次メンバー数を毎回取得し、さらにレスポンスに同じ日付配列が二重に乗っていた。これを整理し、ローソク足は OHLC のデータだけを取得・返すようにした。

## これまでの問題

- ローソク足でも日次メンバー数（member）を取得していた。ローソク足では描画に使わないのに、表示のたび統計DBへアクセスしていた。
- レスポンスに日次の日付 `date` と OHLC 用の日付 `ohlcDate` が両方乗り、中身が同じで二重だった（指摘いただいた点）。

## 対処

- ローソク足は OHLC 専用の日付軸 `ohlcDate` だけで描くようにし、`date` / `member` を取得も返却もしない。
  - API（`app/Services/Chart/OpenChatChartApiService.php`）: ローソク足や OHLC だけの取得要求では統計テーブルを引かず、`ohlcDate` + `memberOhlc`（順位ONなら `positionOhlc`）だけ返す。
  - フロント（`frontend/oc-app/src/graph/util/fetchRenderer.ts`）: ローソク足は member 層を取得しない（順位ONでも `positionOhlc` だけ取得）。折れ線へ切り替えたとき初めて member を遅延取得する。
- 期間タブ（週/月/全期間）の本数判定も OHLC 本数で行うよう揃えた。
- `frontend/oc-app/README.md`（表示状態ごとのAPIとデータ型）も更新。

差分は純減（9ファイル・+160/-205）で、ローソク足まわりのコードがシンプルになった。

## 確認

- PHPStan / 該当 PHPUnit（OpenChatChartApiServiceTest 10件）/ tsc 通過。
- 折れ線・ローソク足 × ランキング・急上昇・なし × 期間タブの全ビュー、およびモード切替・順位ON/OFF・期間切替の操作をヘッドレスで確認（JSエラーなし・順位オーバーレイ整合・折れ線への切替で member が遅延取得され正しく描画）。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
