### PR TITLE
[PROD] fix: データベースの瞬断でその時間の統計データを取り損ねる問題を修正

### DIFF
--- a/app/Models/Repositories/DB.php
+++ b/app/Models/Repositories/DB.php
@@ -111,6 +111,55 @@ class DB extends \Shadow\DB implements DBInterface
     }
 
     /**
+     * 一時的なMySQL接続障害（サーバの瞬断・再起動・接続数スパイク）かどうかを判定する。
+     *
+     * 個別クエリ単位の再接続（execute()/connect() の内部リトライ）では救えない、
+     * 「サーバ自体が数十秒〜分単位で消える」ケースを判定するための広めの分類器。
+     * 毎時処理のような冪等な一括処理を、丸ごと少し待って再試行してよいかの判断に使う。
+     *
+     * - 2006: server has gone away / 2013: Lost connection（動作中クエリ）
+     * - 2002: サーバ未起動・ソケット無し / Connection refused（新規接続が張れない）
+     * - 1226/1040: 接続数上限（max_user_connections / too many connections）
+     *
+     * 例外チェーン（getPrevious）を辿り、別プロセスのDBエラー文字列を包んだ
+     * RuntimeException（例: バックグラウンドDB反映失敗の通知）も拾えるよう、
+     * 型とメッセージの両面で判定する。
+     */
+    public static function isConnectionException(\Throwable $e): bool
+    {
+        for ($current = $e; $current !== null; $current = $current->getPrevious()) {
+            if ($current instanceof \PDOException) {
+                if (static::isConnectionLost($current) || static::isTooManyConnections($current)) {
+                    return true;
+                }
+
+                // 2002: Can't connect / No such file or directory
+                // （PDO::__construct で発生し errorInfo が未設定のことが多い）
+                $driverCode = $current->errorInfo[1] ?? null;
+                if ($driverCode !== null && (int) $driverCode === 2002) {
+                    return true;
+                }
+            }
+
+            $message = $current->getMessage();
+            if (
+                str_contains($message, 'server has gone away')
+                || str_contains($message, 'Lost connection')
+                || str_contains($message, '[2002]')
+                || str_contains($message, "Can't connect to")
+                || str_contains($message, 'Connection refused')
+                || str_contains($message, 'Too many connections')
+                || str_contains($message, 'max_user_connections')
+                || str_contains($message, 'max_connections')
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * MySQL接続をリセットして再接続する
      */
     private static function reconnect(): void

--- a/app/Models/Repositories/test/DBConnectionExceptionTest.php
+++ b/app/Models/Repositories/test/DBConnectionExceptionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * DB::isConnectionException() のテスト
+ *
+ * 実行コマンド:
+ * docker compose exec app ./vendor/bin/phpunit app/Models/Repositories/test/DBConnectionExceptionTest.php
+ *
+ * テスト内容:
+ * - 一時的なMySQL接続障害（2006/2013/2002/接続数上限）を true と判定する
+ * - errorInfo 未設定でもメッセージから判定できる（PDO::__construct 由来の 2002 等）
+ * - 別プロセスのDBエラー文字列を包んだ RuntimeException・例外チェーンも拾う
+ * - 接続障害でない例外（SQL構文エラー等）は false と判定する
+ *
+ * DB接続を一切張らない純粋ロジックのテスト（本番データに触れない）。
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Models\Repositories\DB;
+
+class DBConnectionExceptionTest extends TestCase
+{
+    private function pdoException(string $message, ?array $errorInfo = null): \PDOException
+    {
+        $e = new \PDOException($message);
+        if ($errorInfo !== null) {
+            $e->errorInfo = $errorInfo;
+        }
+        return $e;
+    }
+
+    public function test_server_has_gone_away_2006(): void
+    {
+        $e = $this->pdoException(
+            'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away',
+            ['HY000', 2006, 'MySQL server has gone away'],
+        );
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_lost_connection_2013(): void
+    {
+        $e = $this->pdoException(
+            'SQLSTATE[HY000]: General error: 2013 Lost connection to MySQL server during query',
+            ['HY000', 2013, 'Lost connection to MySQL server during query'],
+        );
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_cannot_connect_2002_message_only(): void
+    {
+        // PDO::__construct 由来は errorInfo 未設定のことが多い。今朝の本番障害がこの形。
+        $e = $this->pdoException('SQLSTATE[HY000] [2002] No such file or directory');
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_connection_refused_message_only(): void
+    {
+        $e = $this->pdoException("SQLSTATE[HY000] [2002] Can't connect to MySQL server on 'localhost' (Connection refused)");
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_too_many_connections_1040(): void
+    {
+        $e = $this->pdoException(
+            'SQLSTATE[HY000] [1040] Too many connections',
+            ['HY000', 1040, 'Too many connections'],
+        );
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_max_user_connections_1226(): void
+    {
+        $e = $this->pdoException(
+            "SQLSTATE[42000] [1226] User 'x' has exceeded the 'max_user_connections' resource",
+            ['42000', 1226, "User 'x' has exceeded the 'max_user_connections' resource"],
+        );
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_wrapped_runtime_exception_from_background_process(): void
+    {
+        // バックグラウンドDB反映プロセスの失敗通知（型は RuntimeException だが本文に接続断を含む）
+        $e = new \RuntimeException(
+            'バックグラウンドDB反映プロセスがエラーで終了: SQLSTATE[HY000]: General error: 2006 MySQL server has gone away',
+        );
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_exception_chain_with_previous_pdo(): void
+    {
+        $previous = $this->pdoException(
+            'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away',
+            ['HY000', 2006, 'MySQL server has gone away'],
+        );
+        $e = new \RuntimeException('毎時処理に失敗しました', 0, $previous);
+        $this->assertTrue(DB::isConnectionException($e));
+    }
+
+    public function test_sql_syntax_error_is_not_connection(): void
+    {
+        $e = $this->pdoException(
+            "SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax",
+            ['42000', 1064, 'You have an error in your SQL syntax'],
+        );
+        $this->assertFalse(DB::isConnectionException($e));
+    }
+
+    public function test_generic_exception_is_not_connection(): void
+    {
+        $this->assertFalse(DB::isConnectionException(new \LogicException('something else')));
+    }
+}

--- a/app/Services/Cron/SyncOpenChat.php
+++ b/app/Services/Cron/SyncOpenChat.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cron;
 
+use App\Models\Repositories\DB;
 use App\Models\Repositories\OcSitemapLastmodRepositoryInterface;
 use App\Models\Repositories\SyncOpenChatStateRepositoryInterface;
 use App\Services\Cron\Enum\BatchScript;
@@ -23,6 +24,12 @@ use Shared\MimimalCmsConfig;
 
 class SyncOpenChat
 {
+    /** 毎時処理がDB接続障害で落ちた場合の再試行回数（初回実行を除く） */
+    private const HOURLY_RETRY_LIMIT = 3;
+
+    /** 毎時処理を再試行する前の待機秒数 */
+    private const HOURLY_RETRY_INTERVAL_SEC = 60;
+
     function __construct(
         private OpenChatApiDbMerger $merger,
         private SitemapGenerator $sitemap,
@@ -50,7 +57,7 @@ class SyncOpenChat
             $this->retryDailyTask();
         } else {
             // 23:30を除く毎時30分に実行
-            $this->hourlyTask();
+            $this->hourlyTaskWithRetry();
         }
 
         $this->sitemap->generate();
@@ -95,6 +102,47 @@ class SyncOpenChat
         $this->hourlyTaskAfterDbMerge();
 
         CronUtility::addCronLog('【毎時処理】完了');
+    }
+
+    /**
+     * 毎時処理を実行する。MySQLの瞬断（サーバ再起動・接続断・接続数スパイク）で落ちた場合は、
+     * 次の毎時cron（約1時間後）を待たずに、同一プロセス内で少し待って毎時処理を丸ごと再試行する。
+     * これにより、DBが短時間だけ落ちても、その時間帯のデータ欠損を防ぐ。
+     *
+     * 再試行のたびに init() を通すことで、中断した前回分の残骸（isHourlyTaskActive フラグ・
+     * 残存バックグラウンドDB反映プロセス）を掃除してからやり直す。これは次の毎時cronが行う
+     * 復帰処理（init → hourlyTask）と同一であり、実績のある経路にそのまま乗せている。
+     * 毎時処理は冪等で、再実行するとその時間帯のスナップショットを取り直す。
+     *
+     * 接続障害以外の例外は再試行せず即座に投げ直す（恒久的な不具合を握りつぶさないため）。
+     */
+    private function hourlyTaskWithRetry()
+    {
+        for ($attempt = 0; ; $attempt++) {
+            try {
+                // 2回目以降は前回の残骸を掃除してからやり直す（初回は handle() で init 済み）
+                if ($attempt > 0) {
+                    $this->init();
+                }
+
+                $this->hourlyTask();
+                return;
+            } catch (\Throwable $e) {
+                if ($attempt >= self::HOURLY_RETRY_LIMIT || !DB::isConnectionException($e)) {
+                    throw $e;
+                }
+
+                CronUtility::addCronLog(sprintf(
+                    '[警告] 毎時処理がDB接続障害で中断。%d秒後に再試行します（%d/%d回目）: %s',
+                    self::HOURLY_RETRY_INTERVAL_SEC,
+                    $attempt + 1,
+                    self::HOURLY_RETRY_LIMIT,
+                    $e->getMessage(),
+                ));
+
+                sleep(self::HOURLY_RETRY_INTERVAL_SEC);
+            }
+        }
     }
 
     private function hourlyTaskAfterDbMerge()


### PR DESCRIPTION
## 問題の概要

データベースが一瞬だけ落ちる（再起動・接続断）と、**その時間帯のオープンチャット統計データが丸ごと欠損**していた。次の毎時更新（約1時間後）まで何も再試行されないため、ランキングやメンバー数の推移グラフにその1時間分の穴が空く。

### 今朝（2026-06-15 06:30 JST）の本番障害

毎時処理の途中で MariaDB が瞬断し、メインプロセスが `[2002] No such file or directory`（サーバ/ソケットに接続できない）で停止。トップレベルでログと管理者通知を出して終了するだけで、**07:30 まで6時台のデータを取り損ねた**。

技術的には、`DB::execute()` / `DB::connect()` の内蔵リトライは「動作中クエリの接続断（2006/2013）」と「接続数上限」だけが対象で、**サーバ自体が消える 2002 は素通り**してトップレベル catch（[`batch/cron/cron_crawling.php`](../blob/main/batch/cron/cron_crawling.php) の例外処理）まで貫通する。そして「毎時処理を丸ごとやり直す」のは*次の cron が `init()` 経由で行う経路しか無く、それが1時間後*だったのが空白の正体。

## 対処内容

接続障害で毎時処理が落ちたら、**次の cron を待たず同一プロセス内で60秒待って毎時処理を丸ごと再試行する（最大3回）**。瞬断は数十秒〜分で復帰する想定なので、その時間帯のデータをほぼ確実に確保できる。

- [`app/Models/Repositories/DB.php`](../blob/main/app/Models/Repositories/DB.php): `isConnectionException(\Throwable): bool` を追加。`2006`/`2013`/`2002`/接続数上限（`1226`/`1040`）を、**例外チェーン（`getPrevious`）とメッセージの両面**で判定する。別プロセスのDBエラー文字列を包んだ `RuntimeException`（バックグラウンドDB反映の失敗通知）や、`2002` で `errorInfo` 未設定のケースも拾う。接続障害**以外**の例外は再試行せず即 throw（恒久バグを握り潰さない）。
- [`app/Services/Cron/SyncOpenChat.php`](../blob/main/app/Services/Cron/SyncOpenChat.php): 毎時パスを `hourlyTaskWithRetry()` 経由に変更。再試行のたびに `init()` を通すため、**残骸（`isHourlyTaskActive` フラグ・残存バックグラウンドプロセス）の掃除は、次の cron が毎時行っている既存の復帰処理と完全に同一**。毎時処理は冪等で、再実行するとその時間帯のスナップショットを取り直す。

### 安全性

- 再実行は既存の cron 復帰経路と同じで実績あり。`startBackgroundPersistence()` は冒頭で前回プロセスを kill するため二重起動しない。`fetchOpenChatApiRankingAll()` 冒頭で kill フラグを自動リセット。
- `/tw`・`/th` も同じ `handle()` 経由で自動適用。**日次処理（23:30）は既存のリトライ機構を持つため非変更**。
- 最悪の再試行時間（数分 × 3 ＋ 待機）でも次の :30 cron まで十分余裕。

## テスト

- `app/Models/Repositories/test/DBConnectionExceptionTest.php` を追加（DB接続を一切張らない純粋ロジックのテスト・本番データ非接触）。

```
docker compose exec app vendor/bin/phpunit app/Models/Repositories/test/DBConnectionExceptionTest.php
OK (10 tests, 10 assertions)
```

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`
