### PR TITLE
[STG] skip-ci: メンバー数グラフで最新24時間タブに切り替えると下の項目がずれる問題を修正

### DIFF
--- a/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
+++ b/frontend/oc-app/src/graph/components/ChartLimitBtns.tsx
@@ -23,9 +23,12 @@ function CandlestickToggle() {
   const isCandlestick = chartMode === 'candlestick'
   // 表示中の期間タブにOHLCデータが無い場合はグレーアウト
   const disabled = !isCandlestick && !hasOhlcDataForLimit(limit)
+  // 最新24時間(limit=25)はローソク足非対応。ボタンは隠すが、他タブと高さを揃えて
+  // 下の「ランキングの順位を表示」がずれないよう、枠は残して visibility:hidden で消す
+  const hidden = limit === 25
 
   const handleToggle = () => {
-    if (disabled) return
+    if (disabled || hidden) return
     handleChangeChartMode(isCandlestick ? 'line' : 'candlestick')
   }
 
@@ -37,6 +40,7 @@ function CandlestickToggle() {
       onClick={handleToggle}
       size="small"
       sx={{
+        visibility: hidden ? 'hidden' : 'visible',
         opacity: disabled ? 0.4 : 1,
         cursor: disabled ? 'default' : 'pointer',
         '& .MuiChip-icon': {
@@ -75,8 +79,7 @@ export default function ChartLimitBtns() {
           {displayAll && <Tab value={0} label={t('全期間')} />}
         </Tabs>
       </Box>
-      {/* 最新24時間タブ(limit=25)はローソク足非対応なので切替ボタンごと非表示 */}
-      {hasOhlcData() && limit !== 25 && (
+      {hasOhlcData() && (
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', pt: '1rem' }}>
           <CandlestickToggle />
         </Box>


### PR DESCRIPTION
直前の変更(最新24時間タブでローソク足の切替ボタンを非表示)で、ボタンを枠ごと消していたため、最新24時間タブのときだけ下の「ランキングの順位を表示」が上にずれて見えた。

ボタンの枠(高さ)は残したまま中身だけ消す(visibility:hidden)ようにし、全タブで高さを揃えてズレをなくす。ボタン自体は引き続き最新24時間タブでは見えない・押せない。

変更箇所: frontend/oc-app/src/graph/components/ChartLimitBtns.tsx

PHP非変更のため skip-ci。X投稿も不要との指示で skip-post。ローカルでビルド(tsc型チェック)とlint通過、表示の改善は手元でも確認済み。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/Open-Chat-Graph\`