### PR TITLE
[STG] 分析Labsの一覧ページをカード型デザインに刷新

### DIFF
--- a/app/Controllers/Pages/LabsPageController.php
+++ b/app/Controllers/Pages/LabsPageController.php
@@ -14,7 +14,7 @@ class LabsPageController
     function index(
         PageBreadcrumbsListSchema $breadcrumbsShema,
     ) {
-        $_css = ['components/site_header', 'components/site_footer', 'components/room_list', 'pages/terms'];
+        $_css = ['components/site_header', 'components/site_footer', 'pages/terms', 'pages/labs'];
         $_meta = meta()->setTitle(self::Title);
         $_meta->setDescription(self::Desc)->setOgpDescription(self::Desc);
         $_breadcrumbsShema = $breadcrumbsShema->generateSchema(self::Title);

--- a/app/Views/labs_content.php
+++ b/app/Views/labs_content.php
@@ -1,61 +1,47 @@
 <!DOCTYPE html>
 <html lang="<?php echo t('ja') ?>">
-<?php
-
-use App\Views\Content\LabsNews;
-
-viewComponent('policy_head', compact('_css', '_meta')) ?>
+<?php viewComponent('policy_head', compact('_css', '_meta')) ?>
 
 <body>
     <div class="body">
         <?php viewComponent('site_header') ?>
         <main style="overflow: hidden;">
             <article class="terms">
-                <h1 style="letter-spacing: 0px;">
-                    <svg style="color: var(--c-text-1); fill: currentColor; display: inline-block; margin-right: 4px; margin-bottom: -4px; margin-left: -12px;" focusable="false" height="24px" viewBox="0 -960 960 960" width="24px">
+                <h1 class="labs-h1">
+                    <svg class="labs-h1-icon" focusable="false" viewBox="0 -960 960 960" aria-hidden="true">
                         <path d="M209-120q-42 0-70.5-28.5T110-217q0-14 3-25.5t9-21.5l228-341q10-14 15-31t5-34v-110h-20q-13 0-21.5-8.5T320-810q0-13 8.5-21.5T350-840h260q13 0 21.5 8.5T640-810q0 13-8.5 21.5T610-780h-20v110q0 17 5 34t15 31l227 341q6 9 9.5 20.5T850-217q0 41-28 69t-69 28H209Zm221-660v110q0 26-7.5 50.5T401-573L276-385q-6 8-8.5 16t-2.5 16q0 23 17 39.5t42 16.5q28 0 56-12t80-47q69-45 103.5-62.5T633-443q4-1 5.5-4.5t-.5-7.5l-78-117q-15-21-22.5-46t-7.5-52v-110H430Z"></path>
-                    </svg><span style="line-height: 2;">分析Labs</span>
+                    </svg>分析Labs
                 </h1>
-                <p>試験運用版の分析機能をお試しいただけます。</p>
+                <p class="labs-intro">試験運用版の分析機能をお試しいただけます。</p>
 
-                <h2>ライブトーク利用時間分析ツール</h2>
-                <a href="<?php echo url('labs/live') ?>" aria-label="ライブトーク利用時間分析ツール">
-                    <img src="/labs-img/livegraph.webp" alt="ライブトーク利用時間分析ツール" />
-                </a>
-                <p>ライブトークの利用時間を分析するツールです。トーク履歴から利用時間推移をグラフで表示します。</p>
-                <a class="readMore-btn top-ranking-readMore white-btn unset" style="m font-size: 16px" href="<?php echo url('labs/live') ?>">
-                    <span class="ranking-readMore" style="font-size: 16px">ライブトーク利用時間分析ツールを開く<span class="small"></span>
-                </a>
-                <h2>オープンチャット全体統計</h2>
-                <a href="<?php echo url('labs/all-room-stats') ?>" aria-label="オープンチャット全体統計">
-                    <img src="/labs-img/all_room_stats.webp" alt="オープンチャット全体統計" />
-                </a>
-                <p>オプチャグラフに登録されている全オープンチャットの統計データ。総ルーム数・総参加者数・カテゴリー別のルーム数などを一覧表示します。</p>
-                <a class="readMore-btn top-ranking-readMore white-btn unset" style="margin:0;" href="<?php echo url('labs/all-room-stats') ?>">
-                    <span class="ranking-readMore" style="font-size: 16px">オープンチャット全体統計を開く</span>
-                </a>
-                <h2>オプチャ公式ランキング掲載の分析</h2>
-                <a href="<?php echo url('labs/publication-analytics') ?>" aria-label="オプチャ公式ランキング掲載の分析">
-                <img src="/labs-img/ranking.webp" alt="オプチャ公式ランキング掲載の分析" />
-                </a>
-                <p>この分析機能は、ルームの集客にとって重要な公式ランキングの可視性の傾向を分析することができます。</p>
-                <p>全オープンチャットの状況を追跡し、ランキングへの掲載状態（掲載・未掲載）、および内容変更の履歴を記録しています。
-                    <br>特定のルームがいつからランキングに未掲載となり、またいつ再掲載されたかを一目で確認できます。
-                    <br>これにより、ルーム内容の変更後に生じる掲載状態の変動（例えば、検索からの除外など）を把握することができます
-                </p>
-                <a class="readMore-btn top-ranking-readMore white-btn unset" style="margin:0;" href="<?php echo url('labs/publication-analytics') ?>">
-                    <span class="ranking-readMore" style="font-size: 16px">オプチャ公式ランキング掲載の分析を開く</span>
-                </a>
-            </article>
-            <article class="terms" style="opacity: .5;">
-                <h2>(公開中止)タグで見るトレンド動向</h2>
-                <!-- <a href="<?php echo url('labs/tags') ?>" aria-label="タグで見るトレンド動向"> -->
-                <img src="/labs-img/tags.webp" alt="タグで見るトレンド動向" />
-                <!-- </a> -->
-                <p>タグによる分類を用いたトレンド分析では、グループごとに増減数や合計人数の集計を行います。これにより、各トピックの人気度やその変動を捉えることができます。</p>
-                <!-- <a class="readMore-btn top-ranking-readMore white-btn unset" style="margin:0;" href="<?php echo url('labs/tags') ?>">
-                    <span class="ranking-readMore" style="font-size: 16px">タグで見るトレンド動向を開く<span class="small"></span>
-                </a> -->
+                <div class="labs-list">
+                    <a class="labs-card" href="<?php echo url('labs/live') ?>" aria-label="ライブトーク利用時間分析ツールを開く">
+                        <img src="/labs-img/livegraph.webp" alt="ライブトーク利用時間分析ツール" width="643" height="610">
+                        <div class="labs-card-body">
+                            <h2>ライブトーク利用時間分析ツール</h2>
+                            <p>トーク履歴から、ライブトークの利用時間の推移をグラフで表示します。</p>
+                            <span class="labs-card-open">開く</span>
+                        </div>
+                    </a>
+
+                    <a class="labs-card" href="<?php echo url('labs/all-room-stats') ?>" aria-label="オープンチャット全体統計を開く">
+                        <img src="/labs-img/all_room_stats.webp" alt="オープンチャット全体統計" width="2400" height="2505">
+                        <div class="labs-card-body">
+                            <h2>オープンチャット全体統計</h2>
+                            <p>登録されている全オープンチャットの統計データ。総ルーム数・総参加者数・カテゴリー別の内訳を一覧表示します。</p>
+                            <span class="labs-card-open">開く</span>
+                        </div>
+                    </a>
+
+                    <a class="labs-card" href="<?php echo url('labs/publication-analytics') ?>" aria-label="オプチャ公式ランキング掲載の分析を開く">
+                        <img src="/labs-img/ranking.webp" alt="オプチャ公式ランキング掲載の分析" width="1192" height="796">
+                        <div class="labs-card-body">
+                            <h2>オプチャ公式ランキング掲載の分析</h2>
+                            <p>集客に重要な公式ランキングの掲載状態と内容変更の履歴を追跡し、いつ未掲載・再掲載になったかを確認できます。</p>
+                            <span class="labs-card-open">開く</span>
+                        </div>
+                    </a>
+                </div>
             </article>
         </main>
 

--- a/public/style/pages/labs.css
+++ b/public/style/pages/labs.css
@@ -1,0 +1,121 @@
+/* ============================================================
+   分析Labs インデックス（/labs）
+   試験運用ツールの一覧をカードで見せるだけの軽量ページ。
+   色はすべて design token（var(--c-*)）参照なのでダーク対応は自動。
+   ============================================================ */
+
+/* 見出し（フラスコアイコン＋タイトル） */
+.labs-h1 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  letter-spacing: 0;
+}
+
+.labs-h1-icon {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+}
+
+.labs-intro {
+  text-align: center;
+  color: var(--c-text-3);
+  margin: 0 0 2rem;
+}
+
+/* ツール一覧（モバイル1列・600px〜2列） */
+.labs-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 18px;
+}
+
+@media (min-width: 600px) {
+  .labs-list {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* カード（画像＋本文すべてがクリック可能な1リンク） */
+.labs-card {
+  display: block;
+  overflow: hidden;
+  border: 1px solid var(--c-border);
+  border-radius: 14px;
+  background: var(--c-card-bg);
+  box-shadow: var(--c-rg-shadow);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.labs-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 22px var(--c-shadow);
+}
+
+/* サイト既定の .terms img（width:87.5%・中央寄せ・影）を打ち消す */
+.labs-card img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: top;
+  margin: 0;
+  border: 0;
+  border-bottom: 1px solid var(--c-border);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.labs-card-body {
+  padding: 15px 17px 17px;
+}
+
+.labs-card-body h2 {
+  margin: 0 0 0.4rem;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.5;
+  color: var(--c-text-2);
+}
+
+.labs-card-body p {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.75;
+  color: var(--c-text-3);
+}
+
+/* 「開く ›」 ホバーでブランド色＋矢印が少し進む */
+.labs-card-open {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.9rem;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--c-text-2);
+}
+
+.labs-card-open::after {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-left: 6px;
+  border-top: 1.5px solid currentColor;
+  border-right: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.18s ease;
+}
+
+.labs-card:hover .labs-card-open {
+  color: var(--c-brand);
+}
+
+.labs-card:hover .labs-card-open::after {
+  transform: translateX(2px) rotate(45deg);
+}


### PR DESCRIPTION
分析Labs（/labs）のツール一覧ページを、突貫で作ったままの状態からカード型デザインに整理した。

変更点
- 各ツールを「画像と説明すべてがクリック可能な1枚のカード」に統一（画像リンクと「開く」ボタンの二重リンクを廃止）
- スタイルを新規 `pages/labs.css` に集約。色はすべてデザイントークン参照なのでダークモードに自動対応
- インラインstyleの羅列・タイポ・未使用の import を除去
- 公開中止だった「タグで見るトレンド動向」ブロックを削除
- ボタンを廃したので不要になった `room_list.css` の読み込みを外した

ライト / ダーク / モバイルで表示確認済み。コードは差し引きで短くなった。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
