### PR TITLE
[STG] skip-ci: グラフのライトモードで順位バーの色を見やすく濃くする

### DIFF
--- a/frontend/oc-app/src/graph/util/theme.ts
+++ b/frontend/oc-app/src/graph/util/theme.ts
@@ -84,11 +84,11 @@ export const colors: { light: ChartColors; dark: ChartColors } = {
     },
     barGradient: {
       stops: [
-        { offset: 1, color: 'rgba(0, 183, 96, 0.2)' },
-        { offset: 0.7, color: 'rgba(17, 216, 113, 0.2)' },
-        { offset: 0.5, color: 'rgba(17, 213, 147, 0.2)' },
-        { offset: 0.3, color: 'rgba(18, 207, 205, 0.2)' },
-        { offset: 0, color: 'rgba(22, 194, 193, 0.2)' },
+        { offset: 1, color: 'rgba(0, 183, 96, 0.45)' },
+        { offset: 0.7, color: 'rgba(17, 216, 113, 0.45)' },
+        { offset: 0.5, color: 'rgba(17, 213, 147, 0.45)' },
+        { offset: 0.3, color: 'rgba(18, 207, 205, 0.45)' },
+        { offset: 0, color: 'rgba(22, 194, 193, 0.45)' },
       ],
     },
     grid: '#efefef',


### PR DESCRIPTION
ライトモード（白背景）で、ランキング・急上昇の順位バーが薄すぎて見えにくい状態でした。バーの不透明度を上げて（0.2→0.45）はっきり見えるようにします。線グラフより控えめな濃さは保ちつつ、白地でも判別できる濃さにしています。ダークモードは変更ありません。

フロントエンド（theme.ts）のみの変更で、PHP は触っていません。ヘッドレス Chrome のライトモードで急上昇・ランキング両方のバーが見やすくなったことを確認済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
