### PR TITLE
[PROD] グラフのライトモードで順位バーの色を見やすく濃くする

### DIFF
--- a/frontend/oc-app/src/graph/util/theme.ts
+++ b/frontend/oc-app/src/graph/util/theme.ts
@@ -84,11 +84,11 @@ export const colors: { light: ChartColors; dark: ChartColors } = {
     },
     barGradient: {
       stops: [
-        { offset: 1, color: 'rgba(0, 183, 96, 0.2)' },
-        { offset: 0.7, color: 'rgba(17, 216, 113, 0.2)' },
-        { offset: 0.5, color: 'rgba(17, 213, 147, 0.2)' },
-        { offset: 0.3, color: 'rgba(18, 207, 205, 0.2)' },
-        { offset: 0, color: 'rgba(22, 194, 193, 0.2)' },
+        { offset: 1, color: 'rgba(0, 183, 96, 0.45)' },
+        { offset: 0.7, color: 'rgba(17, 216, 113, 0.45)' },
+        { offset: 0.5, color: 'rgba(17, 213, 147, 0.45)' },
+        { offset: 0.3, color: 'rgba(18, 207, 205, 0.45)' },
+        { offset: 0, color: 'rgba(22, 194, 193, 0.45)' },
       ],
     },
     grid: '#efefef',


### PR DESCRIPTION
stg で確認した内容を本番へ反映します。

詳細: #524（ライトモードでランキング・急上昇の順位バーが薄すぎたため、バーの不透明度を上げて見やすく）

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
