### PR TITLE
[STG] skip-ci: グラフのライトモードで背景グリッドをもう少し薄くする

### DIFF
--- a/frontend/oc-app/src/graph/util/theme.ts
+++ b/frontend/oc-app/src/graph/util/theme.ts
@@ -91,7 +91,7 @@ export const colors: { light: ChartColors; dark: ChartColors } = {
         { offset: 0, color: 'rgba(22, 194, 193, 0.45)' },
       ],
     },
-    grid: '#efefef',
+    grid: '#f4f4f4',
     border: '#efefef',
     borderWeekly: 'rgba(0,0,0,0)',
     text: {


### PR DESCRIPTION
ライトモードの背景グリッド線が少し主張していたため、白地でより控えめになるようわずかに薄くしました（#efefef→#f4f4f4）。ダークモードは変更ありません。

フロントエンド（theme.ts）のみの変更で、PHP は触っていません。ヘッドレス Chrome のライトモードでグリッドが控えめになり、線・順位バーの視認性は保たれていることを確認済みです。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
