### PR TITLE
[STG] fix: 個別ルームのグラフが稀に読み込めない問題を解消（読み取り接続を永続化してロック競合を解消）

### DIFF
--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -35,8 +35,15 @@ abstract class AbstractSQLite extends DB implements DBInterface
      * - busyTimeout=20ms: 1回のロック待ちを短く刻む。続きはリトライ側のジッター付き
      *   待機で互いにずらして再試行する（下記 READER_RETRY_*）。既定の10秒のまま rw 化
      *   すると競合時に全リクエストが10秒待ちになる（PR #367→#370 差し戻しの事故）
+     * - persistent=true: FPM ワーカー内で接続(と -shm/wal-index のマップ・読みマークスロット)を
+     *   リクエストをまたいで使い回す。クエリ毎に接続を開き直す churn こそが wal-index ロック競合
+     *   （SQLITE_PROTOCOL "locking protocol" / SQLITE_BUSY "database is locked"）の主因のため、
+     *   読み取り接続を永続化して churn 自体を断つ。SQLite 3.26 では busy_timeout が wal-index
+     *   ロックに効かない（blocking locks は 3.30+）ので「待つ」より「開き直さない」方が効く。
+     *   書き込み(rwc)接続は cron 単一プロセスで churn が無く、トランザクション持ち越しリスクも
+     *   あるため persistent にしない（読み取り専用の rw/ro 接続にのみ付ける）。
      */
-    public const WEB_READER = ['mode' => '?mode=rw', 'busyTimeout' => 20];
+    public const WEB_READER = ['mode' => '?mode=rw', 'busyTimeout' => 20, 'persistent' => true];
 
     protected const MAX_RETRIES = 7;
     // 書き込み(rwc)接続用: busy_timeout=10秒が主に待つので、間隔はゆっくり長く
@@ -55,10 +62,11 @@ abstract class AbstractSQLite extends DB implements DBInterface
     ];
 
     /**
-     * @param ?array{storageFileKey?: string, filePath?: string, mode?: ?string, busyTimeout?: ?int} $config
+     * @param ?array{storageFileKey?: string, filePath?: string, mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config
      *  mode default is '?mode=rwc' / busyTimeout default is 10000ms。
-     *  Web リクエスト中の読み取りは self::WEB_READER を渡す（rw + 短い busy_timeout）。
+     *  Web リクエスト中の読み取りは self::WEB_READER を渡す（rw + 短い busy_timeout + persistent）。
      *  バッチの読み取りは '?mode=rw' のみ指定し busyTimeout は既定の10秒のままにする。
+     *  persistent=true で PDO 永続接続にする（FPM ワーカーで接続/-shm を使い回し churn を断つ）。
      */
     /** @var array<class-string, string> 接続中のモード（接続使い回し判定用） */
     private static array $connectedMode = [];
@@ -88,7 +96,12 @@ abstract class AbstractSQLite extends DB implements DBInterface
         $sqliteFilePath = $config['filePath']
             ?? app(FileStorageInterface::class)->getStorageFilePath($config['storageFileKey']);
 
-        static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode);
+        // 読み取り(rw/ro)接続のみ persistent にして churn を断つ（WEB_READER 経由）。
+        // 書き込み(rwc)はトランザクション持ち越し事故を避けるため非 persistent のまま。
+        $options = (!empty($config['persistent']) && !str_contains($mode, 'rwc'))
+            ? [\PDO::ATTR_PERSISTENT => true]
+            : [];
+        static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode, null, null, $options);
         self::$connectedMode[static::class] = $mode;
 
         // Set busy timeout for all modes (including read-only) to handle concurrent access

--- a/app/Models/SQLite/SQLiteOcgraphSqlapi.php
+++ b/app/Models/SQLite/SQLiteOcgraphSqlapi.php
@@ -25,7 +25,7 @@ class SQLiteOcgraphSqlapi extends AbstractSQLite implements DBInterface
      * 接続使い回し・WAL等のPRAGMA適用条件を全SQLiteで統一するため。以前の独自実装は
      * mode=ro だと busy_timeout が未設定・最初に開いたモードを使い回す問題があった）。
      *
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      * @return \PDO
      */
     public static function connect(?array $config = null): \PDO
@@ -34,6 +34,7 @@ class SQLiteOcgraphSqlapi extends AbstractSQLite implements DBInterface
             'filePath' => AppConfig::SQLITE_OCGRAPH_SQLAPI_DB_PATH,
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteRankingPosition.php
+++ b/app/Models/SQLite/SQLiteRankingPosition.php
@@ -11,7 +11,7 @@ class SQLiteRankingPosition extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteRankingPosition extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteRankingPositionDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteRankingPositionOhlc.php
+++ b/app/Models/SQLite/SQLiteRankingPositionOhlc.php
@@ -11,7 +11,7 @@ class SQLiteRankingPositionOhlc extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteRankingPositionOhlc extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteRankingPositionOhlcDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteStatistics.php
+++ b/app/Models/SQLite/SQLiteStatistics.php
@@ -11,7 +11,7 @@ class SQLiteStatistics extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteStatistics extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteStatisticsDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteStatisticsOhlc.php
+++ b/app/Models/SQLite/SQLiteStatisticsOhlc.php
@@ -11,7 +11,7 @@ class SQLiteStatisticsOhlc extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteStatisticsOhlc extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteStatisticsOhlcDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }


### PR DESCRIPTION
## 問題の概要

個別ルームの**メンバー数グラフが稀に表示できず**、サーバには `database is locked` の例外が出ていた（スマホで再現報告あり）。特に**毎時のデータ更新処理と重なる時間帯**や、検索エンジンがページを巡回するタイミングで、数秒〜30秒の窓に**数十件まとめて**失敗するバースト型で発生していた。

## 何が起きていたか（本番ログ調査）

本番 `exception.log` を調査:

- `database is locked`（SQLITE_BUSY） **81件** ＋ `locking protocol`（SQLITE_PROTOCOL） **956件**
- 発生元は巨大な統計SQLite（`statistics.db` ＝ ja 5.8GB）への**読み取り**。74/81 がグラフ描画（[`StatisticsChartArrayService`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Services/Statistics/StatisticsChartArrayService.php)）、残りが分析文生成
- 書き込みゼロの時間帯でも発生 → **書き込み競合ではなく読み取り側の競合**

### 根本原因：WALなのにロックする理由

WALモードでも「読みは書きを待たない」が成り立つのは**接続が安定して張りっぱなしのとき**だけ。本アプリは [`AbstractSQLite::connect()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Models/SQLite/AbstractSQLite.php) が**クエリ毎に非永続の `new PDO()` で接続を開き直す**ため、リクエスト毎に `-shm`(wal-index) をmap/recoverし、**5個しかない読みマークスロット**を取り直す。これが並列時に wal-index のバイトレンジロック競合を起こし、`locking protocol` / `database is locked` を吐く。

さらに本番 SQLite は **3.26.0(2018)** で、`busy_timeout` が wal-index ロックに効かない（効くのは blocking locks の入った 3.30+）。だから `busy_timeout=20ms` は素通りし、`SQLITE_PROTOCOL` 直行になる（PROTOCOL が 956件と圧倒的に多いのはこのため）。

## 対処内容

**Webリクエストの読み取り接続（`WEB_READER`）を PDO 永続接続（`ATTR_PERSISTENT`）にする。** FPMワーカー内で接続と `-shm` のマップ・読みマークスロットをリクエストをまたいで使い回し、**競合の発生源である「接続の開き直し churn」自体を断つ**。

- 対象は読み取り専用の `rw`/`ro` 接続のみ。**書き込み(`rwc`/cron)は非永続のまま**（単一プロセスで churn が無く、トランザクション持ち越し事故も避ける）
- 変更は [`AbstractSQLite`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Models/SQLite/AbstractSQLite.php) の `WEB_READER` と接続生成、各 `SQLite*` ラッパの `persistent` 転送のみ（6ファイル・+27/-9行）

## 実測（stg・SQLite 3.26.0＝本番と同一）

statistics.db のコピーに対し「24リーダ×300回（毎回接続→チャート相当の読取）＋常時writer」で計測:

| | 失敗率（database is locked） |
|---|---|
| 非persistent（現状） | **0〜66%**（試行ごとにばらつく＝バースト） |
| persistent（本PR） | **全試行 0%** |

タイミング依存で出たり出なかったりするのは、本番がバースト型で発生するのと一致。**persistentは全試行で競合ゼロ**。

## テスト

- 変更6ファイル `php -l` OK
- `SQLiteStatisticsTest` / `SqliteStatisticsRepositoryTest` / `StatisticsChartArrayServiceTest` … **10/10 green**
- （`SqliteStatisticsOhlcRepositoryTest` の5件errorは**本変更前から失敗する既存の壊れたテスト**。本PRとは無関係なことを stash で確認済み）

## 補足

- CFのWAFで `/chart` は既に「自前XHR(`x-ocg-client`)＋検証済みbotのみ通過・30req/10s/IP」で保護済み。つまり**トラフィック過多ではなく接続モデルの問題**で、robots等の対症療法は不要
- 本丸の恒久策は SQLite 3.30+ への更新（`busy_timeout` が wal-index に効く）だが、共有ホスティングで版を上げられるか別途要検討。本PRはアプリ側で完結する即効策
- 本PRがstgで安定したら、別途 stg→main で本番反映

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`