### PR TITLE
[PROD] fix: 個別ルームのグラフが稀に読み込めない問題を解消（読み取り接続を永続化してロック競合を解消）

### DIFF
--- a/app/Models/SQLite/AbstractSQLite.php
+++ b/app/Models/SQLite/AbstractSQLite.php
@@ -35,8 +35,15 @@ abstract class AbstractSQLite extends DB implements DBInterface
      * - busyTimeout=20ms: 1回のロック待ちを短く刻む。続きはリトライ側のジッター付き
      *   待機で互いにずらして再試行する（下記 READER_RETRY_*）。既定の10秒のまま rw 化
      *   すると競合時に全リクエストが10秒待ちになる（PR #367→#370 差し戻しの事故）
+     * - persistent=true: FPM ワーカー内で接続(と -shm/wal-index のマップ・読みマークスロット)を
+     *   リクエストをまたいで使い回す。クエリ毎に接続を開き直す churn こそが wal-index ロック競合
+     *   （SQLITE_PROTOCOL "locking protocol" / SQLITE_BUSY "database is locked"）の主因のため、
+     *   読み取り接続を永続化して churn 自体を断つ。SQLite 3.26 では busy_timeout が wal-index
+     *   ロックに効かない（blocking locks は 3.30+）ので「待つ」より「開き直さない」方が効く。
+     *   書き込み(rwc)接続は cron 単一プロセスで churn が無く、トランザクション持ち越しリスクも
+     *   あるため persistent にしない（読み取り専用の rw/ro 接続にのみ付ける）。
      */
-    public const WEB_READER = ['mode' => '?mode=rw', 'busyTimeout' => 20];
+    public const WEB_READER = ['mode' => '?mode=rw', 'busyTimeout' => 20, 'persistent' => true];
 
     protected const MAX_RETRIES = 7;
     // 書き込み(rwc)接続用: busy_timeout=10秒が主に待つので、間隔はゆっくり長く
@@ -55,10 +62,11 @@ abstract class AbstractSQLite extends DB implements DBInterface
     ];
 
     /**
-     * @param ?array{storageFileKey?: string, filePath?: string, mode?: ?string, busyTimeout?: ?int} $config
+     * @param ?array{storageFileKey?: string, filePath?: string, mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config
      *  mode default is '?mode=rwc' / busyTimeout default is 10000ms。
-     *  Web リクエスト中の読み取りは self::WEB_READER を渡す（rw + 短い busy_timeout）。
+     *  Web リクエスト中の読み取りは self::WEB_READER を渡す（rw + 短い busy_timeout + persistent）。
      *  バッチの読み取りは '?mode=rw' のみ指定し busyTimeout は既定の10秒のままにする。
+     *  persistent=true で PDO 永続接続にする（FPM ワーカーで接続/-shm を使い回し churn を断つ）。
      */
     /** @var array<class-string, string> 接続中のモード（接続使い回し判定用） */
     private static array $connectedMode = [];
@@ -88,7 +96,12 @@ abstract class AbstractSQLite extends DB implements DBInterface
         $sqliteFilePath = $config['filePath']
             ?? app(FileStorageInterface::class)->getStorageFilePath($config['storageFileKey']);
 
-        static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode);
+        // 読み取り(rw/ro)接続のみ persistent にして churn を断つ（WEB_READER 経由）。
+        // 書き込み(rwc)はトランザクション持ち越し事故を避けるため非 persistent のまま。
+        $options = (!empty($config['persistent']) && !str_contains($mode, 'rwc'))
+            ? [\PDO::ATTR_PERSISTENT => true]
+            : [];
+        static::$pdo = new \PDO('sqlite:file:' . $sqliteFilePath . $mode, null, null, $options);
         self::$connectedMode[static::class] = $mode;
 
         // Set busy timeout for all modes (including read-only) to handle concurrent access

--- a/app/Models/SQLite/SQLiteOcgraphSqlapi.php
+++ b/app/Models/SQLite/SQLiteOcgraphSqlapi.php
@@ -25,7 +25,7 @@ class SQLiteOcgraphSqlapi extends AbstractSQLite implements DBInterface
      * 接続使い回し・WAL等のPRAGMA適用条件を全SQLiteで統一するため。以前の独自実装は
      * mode=ro だと busy_timeout が未設定・最初に開いたモードを使い回す問題があった）。
      *
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      * @return \PDO
      */
     public static function connect(?array $config = null): \PDO
@@ -34,6 +34,7 @@ class SQLiteOcgraphSqlapi extends AbstractSQLite implements DBInterface
             'filePath' => AppConfig::SQLITE_OCGRAPH_SQLAPI_DB_PATH,
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteRankingPosition.php
+++ b/app/Models/SQLite/SQLiteRankingPosition.php
@@ -11,7 +11,7 @@ class SQLiteRankingPosition extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteRankingPosition extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteRankingPositionDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteRankingPositionOhlc.php
+++ b/app/Models/SQLite/SQLiteRankingPositionOhlc.php
@@ -11,7 +11,7 @@ class SQLiteRankingPositionOhlc extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteRankingPositionOhlc extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteRankingPositionOhlcDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteStatistics.php
+++ b/app/Models/SQLite/SQLiteStatistics.php
@@ -11,7 +11,7 @@ class SQLiteStatistics extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteStatistics extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteStatisticsDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }

--- a/app/Models/SQLite/SQLiteStatisticsOhlc.php
+++ b/app/Models/SQLite/SQLiteStatisticsOhlc.php
@@ -11,7 +11,7 @@ class SQLiteStatisticsOhlc extends AbstractSQLite implements DBInterface
     public static ?\PDO $pdo = null;
 
     /**
-     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int} $config mode default is '?mode=rwc'
+     * @param ?array $config array{mode?: ?string, busyTimeout?: ?int, persistent?: ?bool} $config mode default is '?mode=rwc'
      */
     public static function connect(?array $config = null): \PDO
     {
@@ -19,6 +19,7 @@ class SQLiteStatisticsOhlc extends AbstractSQLite implements DBInterface
             'storageFileKey' => 'sqliteStatisticsOhlcDb',
             'mode' => $config['mode'] ?? null,
             'busyTimeout' => $config['busyTimeout'] ?? null,
+            'persistent' => $config['persistent'] ?? null,
         ]);
     }
 }


### PR DESCRIPTION
stg(#530)で検証済みの本番反映。

## 問題
個別ルームの**メンバー数グラフが稀に表示できず**、`database is locked` の例外が出ていた。毎時のデータ更新と重なる時間帯や検索エンジンの巡回時に、数秒〜30秒の窓に数十件まとめて失敗するバースト型で発生。

## 真因
巨大な統計SQLite(5.8GB)への読み取りが **WALのwal-index(-shm)ロック競合**で落ちていた。原因は「クエリ毎に非永続接続を開き直す churn」×**SQLite 3.26（`busy_timeout`がwal-indexロックに効かない／効くのは3.30+）**。本番exception.logで `locking protocol` 956件 / `database is locked` 81件。書き込み競合でもbot過多でもない（CFのWAFで`/chart`は保護済み）。

## 対処
Webリクエストの読み取り接続(`WEB_READER`)を **PDO永続接続(`ATTR_PERSISTENT`)** にし、FPMワーカーで接続/-shmを使い回して競合源の churn を断つ。読み取り(rw/ro)のみ・書き込み(rwc/cron)は非永続のまま（トランザクション持ち越し事故を回避）。

## 検証（stg・SQLite 3.26＝本番同一）
- 競合: 24リーダ×300回+常時writer で 非persistent=失敗0〜66%／persistent=**全試行0%**
- 速度: 1読み取り **0.44ms→0.08ms（約5倍速）**。接続open＋-shm map/recoverが消えるため（本番の5.8GBでは差はさらに拡大）
- テスト: 関連phpunit 10/10 green
- 副作用: トランザクション持ち越しは構造的に排除（永続化は autocommit のSELECT専用接続のみ・書き込み/MySQLは非永続）。WALチェックポイント阻害なし。batch/cron影響なし

恒久策は SQLite 3.30+ 更新だが共有ホスティングで版上げ可否は別途。本PRはアプリ完結の即効策。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`