### PR TITLE
[STG] fix: アクセス集中時に一部ページが稀に接続エラーで開けない問題を自動リトライで緩和

### DIFF
--- a/app/Models/Repositories/DB.php
+++ b/app/Models/Repositories/DB.php
@@ -25,10 +25,14 @@ class DB extends \Shadow\DB implements DBInterface
             try {
                 return parent::connect($config);
             } catch (\PDOException $e) {
-                // 接続数上限（max_user_connections / too many connections）の瞬間的なスパイクは
-                // 少し待ってリトライすれば空きが出て捌ける場合がある。
+                // 接続確立時の一時的な障害は、少し待ってリトライすれば張れる場合がある。
+                // - 1226/1040: 接続数上限（max_user_connections / too many connections）の瞬間スパイク
+                // - 2006/2013: server has gone away / lost connection
+                //   （max_user_connections 到達時、接続が受理直後に切られ 2006 として浮上することがある。
+                //     PDO::__construct で発生し errorInfo 未設定のためメッセージでも判定する）
+                // - 2002: Can't connect（ソケットを一瞬受けられない）
                 // 失敗時は static::$pdo は null のまま（new \PDO が例外を投げたため）なので再試行できる。
-                if ($attempt < self::CONNECT_MAX_ATTEMPTS - 1 && static::isTooManyConnections($e)) {
+                if ($attempt < self::CONNECT_MAX_ATTEMPTS - 1 && static::isConnectionException($e)) {
                     // FPMワーカーを長時間占有しないよう待機は短く、軽いジッタで分散させる
                     usleep(random_int(100000, 250000) * ($attempt + 1)); // 約0.1〜0.5秒
                     continue;


### PR DESCRIPTION
## 問題の概要

アクセスが集中したとき（クローラの一斉巡回など）、個別ルームページが稀に **500エラー（接続エラー）** で表示できないことがある。

### 具体的な問題

このサーバ（共有ホスティング）の MySQL は **ユーザー単位の同時接続上限が 100**（`max_user_connections=100`、サーバ全体の `max_connections=3000` は余裕あり）。アクセス集中でこの 100 に瞬間的に張り付くと、新規接続が確立できずページ生成が落ちる。

本番の例外ログを解析したところ、**接続確立時の「MySQL server has gone away」(エラーコード2006) が、2026-06-10 11:15〜11:33 の約18分間のクロール集中だけで551件**発生していた（同時刻に上限到達エラー `max_user_connections` も多数）。

- 上限到達は **大半が `1226 (max_user_connections)`** として返るが、**一部は接続が受理された直後に切られ `2006 (gone away)`** として浮上する。同じ「接続枯渇」現象の別の顔。
- ところが、これまで [`DB::connect()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/fix/mysql-connect-retry-transient/app/Models/Repositories/DB.php) のリトライ対象は `1226/1040` のみで、接続確立時の `2006/2013/2002` は素通りで `throw` していた。
- 再接続経路 [`DB::reconnect()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/fix/mysql-connect-retry-transient/app/Models/Repositories/DB.php) も内部で `connect()` を呼ぶため、瞬断時に復帰できず連鎖して失敗していた。

## 対処内容

`connect()` のリトライ判定を、**既存の分類器 `isConnectionException()`（`1226/1040/2006/2013/2002` を網羅）に広げる**だけ。瞬間的な接続障害は短いバックオフ（約0.1〜0.5秒・最大3回）で吸収し、自己修復する。

- FPMワーカーを長時間占有しないよう待機は短いまま。
- **永続接続は導入しない**（接続上限100の下では各ワーカーが接続を握り続け、かえって上限到達が常態化して悪化するため）。

## 限界（別対応）

数十分続く接続ストームそのものは本PRでは解消しない（リトライ予算は約1秒）。ストームを根本から起こさない対策（毎時の `/oc` 全CDNパージの見直し、ホットパスのSQLite化、攻撃的クローラのレート制限）は別途進める。本PRは「残りの単発瞬断を確実に自己修復する」低リスクな下支え。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/oc-graph-3\`