### PR TITLE
[STG] feat: アクセス集中時のページエラーを「500」から「503＋再読み込み案内」に変えてSEO悪影響を回避

### DIFF
--- a/app/Exceptions/ServiceUnavailableException.php
+++ b/app/Exceptions/ServiceUnavailableException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+/**
+ * サーバが一時的にリクエストを処理できないときに投げる例外（HTTP 503）。
+ *
+ * 主な用途: MySQL のユーザー単位同時接続上限（max_user_connections）への瞬間的な
+ * 張り付きや、サーバ瞬断による接続枯渇。これを 500 ではなく 503 + Retry-After として
+ * 返すことで、クローラには「混雑中・後で再試行」を正しく伝え（SEO 降格を避け）、
+ * ブラウザには再読み込み画面（app/Views/errors/error.php の 5xx 表示）を出す。
+ *
+ * 接続枯渇の元例外（\PDOException）は $previous として連結する。これにより
+ * DB::isConnectionException() が getPrevious をたどって接続障害と判定でき、
+ * cron 等の既存リトライ判定の挙動を保てる。
+ *
+ * HTTP マッピングは Shared\MimimalCmsConfig::$httpErrors に登録する。
+ */
+class ServiceUnavailableException extends \RuntimeException
+{
+}

--- a/app/Views/errors/503.php
+++ b/app/Views/errors/503.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * HTTP 503 (Service Unavailable) 用のエラービュー。
+ *
+ * 画面は 5xx 共通の「再読み込み」画面（error.php）をそのまま流用する。
+ * 503 固有の差分は Retry-After ヘッダーのみ:
+ *   - クローラ（Googlebot 等）に「一時的な混雑。少し後で再クロールして」と伝える。
+ *     503 + Retry-After は 500 と違い検索順位を落とさない正規の「混雑」シグナル。
+ *   - 軽いジッタ(30〜90秒)で再試行時刻を分散し、復帰直後の再集中(サンダリングハード)を避ける。
+ *
+ * error.php 自体が no-store を設定するため、503 が CDN/ブラウザにキャッシュされることはない。
+ */
+
+if (!headers_sent()) {
+    header('Retry-After: ' . random_int(30, 90));
+}
+
+require __DIR__ . '/error.php';

--- a/shared/MimimalCMS_ExceptionHandler.php
+++ b/shared/MimimalCMS_ExceptionHandler.php
@@ -62,6 +62,25 @@ class ExceptionHandler
      */
     public static function handleException(\Throwable $e)
     {
+        // 接続枯渇（MySQL の max_user_connections 到達・サーバ瞬断など）で未捕捉のまま
+        // ここへ来た例外は、500 ではなく 503(Service Unavailable) として扱う。
+        // ServiceUnavailableException に包み直すと、以降の $httpErrors マッピングに乗り、
+        // Retry-After + 5xx「再読み込み」画面(error.php)で返る。元例外は $previous に連結する。
+        // ※ ここはグローバルハンドラ＝「未捕捉でここまで来た例外」のみが対象。個別に
+        //   catch 済みの箇所（登録フォーム等の独自ハンドリング）には到達しないため影響しない。
+        $dbClass = \App\Models\Repositories\DB::class;
+        if (
+            !($e instanceof \App\Exceptions\ServiceUnavailableException)
+            && class_exists($dbClass)
+            && $dbClass::isConnectionException($e)
+        ) {
+            $e = new \App\Exceptions\ServiceUnavailableException(
+                'Service temporarily unavailable: database connection',
+                0,
+                $e
+            );
+        }
+
         $appHandlerClass = ApplicationExceptionHandler::class;
         if (class_exists($appHandlerClass) && isset($appHandlerClass::$exceptionMap)) {
             $className = get_class($e);

--- a/shared/MimimalCmsConfig.php
+++ b/shared/MimimalCmsConfig.php
@@ -125,6 +125,7 @@ class MimimalCmsConfig
         \Shared\Exceptions\SessionTimeoutException::class =>   ['httpCode' => 401, 'log' => true,  'httpStatusMessage' => 'Unauthorized'],
         \Shared\Exceptions\UnauthorizedException::class =>     ['httpCode' => 401, 'log' => true,  'httpStatusMessage' => 'Unauthorized'],
         \Shared\Exceptions\ThrottleRequestsException::class => ['httpCode' => 429, 'log' => true,  'httpStatusMessage' => 'Too Many Requests'],
+        \App\Exceptions\ServiceUnavailableException::class =>  ['httpCode' => 503, 'log' => false, 'httpStatusMessage' => 'Service Unavailable'],
     ];
 
     // Display exceptions


### PR DESCRIPTION
## 問題の概要

アクセスが集中して MySQL の同時接続上限（`max_user_connections=100`）に瞬間的に張り付くと、個別ルームページ等が **500 Internal Server Error** になっていた。これは恒久的な不具合ではなく一時的な「混雑」だが、500 を返すと検索エンジンにバグとみなされ、クロール頻度や順位に悪影響が出るおそれがある。

## 対処内容

接続枯渇に起因するエラーを **500 ではなく 503 Service Unavailable + Retry-After** で返す。

- **クローラ（Googlebot 等）**: 503 + Retry-After は「一時的に混んでいる。後で来て」という正規の混雑シグナル。500 と違って検索順位を落とさず、指定時刻に再クロールしてくれる。
- **ブラウザ**: 既存の 5xx「再読み込み」画面（[`error.php`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/feat/db-503-service-unavailable/app/Views/errors/error.php) の `$httpCode >= 500` 表示）をそのまま流用。500 と画面は共通で、**ステータスと Retry-After ヘッダーだけが変わる**。

これは連番の連投ではなく、先にマージ済みの「[接続の自動リトライ（#532）](https://github.com/Open-Chat-Graph/Open-Chat-Graph/pull/532)」と対になる施策。リトライで救えなかった残りを、500 ではなく 503 として穏便に返す。

## 実装

- `App\Exceptions\ServiceUnavailableException` を新設し、`MimimalCmsConfig::$httpErrors` に `503 / log=false` でマッピング（一過性のため例外ログに残さずログ肥大を回避）。
- グローバル例外ハンドラ（[`MimimalCMS_ExceptionHandler`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/feat/db-503-service-unavailable/shared/MimimalCMS_ExceptionHandler.php)）で、**未捕捉のまま到達した接続枯渇例外だけ**を `ServiceUnavailableException` に包み直す。
  - 元例外は `$previous` に連結 → cron の `isConnectionException()` 再試行や各所の `catch(\PDOException)` の挙動は **一切不変**。
  - 個別に `catch` 済みの箇所（ルーム登録フォームの「メンテ中・後で再試行」案内等）はハンドラに到達しないため **影響なし**（DB層では変換せず、ハンドラ＝最終段でのみ変換する設計）。
- `app/Views/errors/503.php` は `Retry-After`（30〜90秒のジッタで復帰直後の再集中を回避）を付与して `error.php` を流用。

## 動作確認

- **純ロジック検証 12 項目**（接続枯渇判定 / 503 マッピング / 包み直し / `getPrevious` 連鎖 / 二重包み防止 / 継承）すべて pass。
- **実コンテナで E2E**: 登録済みグローバルハンドラに接続枯渇 `PDOException` を渡し、`http_response_code()=503` ＋ 5xx 再読み込み画面の描画（タイトル「サーバーで一時的なエラーが発生しました」）を確認。
- **回帰なし**: 通常ページ `/`・`/policy` は 200、範囲外 `/oc/99999999999`・不明 URL は従来どおり 404。接続エラーのみ 503 化。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`