### PR TITLE
[PROD] fix: アクセス集中時にページが接続エラーで開けない問題を緩和（接続の自動リトライ＋混雑時は503案内）

### DIFF
--- a/app/Exceptions/ServiceUnavailableException.php
+++ b/app/Exceptions/ServiceUnavailableException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+/**
+ * サーバが一時的にリクエストを処理できないときに投げる例外（HTTP 503）。
+ *
+ * 主な用途: MySQL のユーザー単位同時接続上限（max_user_connections）への瞬間的な
+ * 張り付きや、サーバ瞬断による接続枯渇。これを 500 ではなく 503 + Retry-After として
+ * 返すことで、クローラには「混雑中・後で再試行」を正しく伝え（SEO 降格を避け）、
+ * ブラウザには再読み込み画面（app/Views/errors/error.php の 5xx 表示）を出す。
+ *
+ * 接続枯渇の元例外（\PDOException）は $previous として連結する。これにより
+ * DB::isConnectionException() が getPrevious をたどって接続障害と判定でき、
+ * cron 等の既存リトライ判定の挙動を保てる。
+ *
+ * HTTP マッピングは Shared\MimimalCmsConfig::$httpErrors に登録する。
+ */
+class ServiceUnavailableException extends \RuntimeException
+{
+}

--- a/app/Models/Repositories/DB.php
+++ b/app/Models/Repositories/DB.php
@@ -25,10 +25,14 @@ class DB extends \Shadow\DB implements DBInterface
             try {
                 return parent::connect($config);
             } catch (\PDOException $e) {
-                // 接続数上限（max_user_connections / too many connections）の瞬間的なスパイクは
-                // 少し待ってリトライすれば空きが出て捌ける場合がある。
+                // 接続確立時の一時的な障害は、少し待ってリトライすれば張れる場合がある。
+                // - 1226/1040: 接続数上限（max_user_connections / too many connections）の瞬間スパイク
+                // - 2006/2013: server has gone away / lost connection
+                //   （max_user_connections 到達時、接続が受理直後に切られ 2006 として浮上することがある。
+                //     PDO::__construct で発生し errorInfo 未設定のためメッセージでも判定する）
+                // - 2002: Can't connect（ソケットを一瞬受けられない）
                 // 失敗時は static::$pdo は null のまま（new \PDO が例外を投げたため）なので再試行できる。
-                if ($attempt < self::CONNECT_MAX_ATTEMPTS - 1 && static::isTooManyConnections($e)) {
+                if ($attempt < self::CONNECT_MAX_ATTEMPTS - 1 && static::isConnectionException($e)) {
                     // FPMワーカーを長時間占有しないよう待機は短く、軽いジッタで分散させる
                     usleep(random_int(100000, 250000) * ($attempt + 1)); // 約0.1〜0.5秒
                     continue;

--- a/app/Views/errors/503.php
+++ b/app/Views/errors/503.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * HTTP 503 (Service Unavailable) 用のエラービュー。
+ *
+ * 画面は 5xx 共通の「再読み込み」画面（error.php）をそのまま流用する。
+ * 503 固有の差分は Retry-After ヘッダーのみ:
+ *   - クローラ（Googlebot 等）に「一時的な混雑。少し後で再クロールして」と伝える。
+ *     503 + Retry-After は 500 と違い検索順位を落とさない正規の「混雑」シグナル。
+ *   - 軽いジッタ(30〜90秒)で再試行時刻を分散し、復帰直後の再集中(サンダリングハード)を避ける。
+ *
+ * error.php 自体が no-store を設定するため、503 が CDN/ブラウザにキャッシュされることはない。
+ */
+
+if (!headers_sent()) {
+    header('Retry-After: ' . random_int(30, 90));
+}
+
+require __DIR__ . '/error.php';

--- a/shared/MimimalCMS_ExceptionHandler.php
+++ b/shared/MimimalCMS_ExceptionHandler.php
@@ -62,6 +62,25 @@ class ExceptionHandler
      */
     public static function handleException(\Throwable $e)
     {
+        // 接続枯渇（MySQL の max_user_connections 到達・サーバ瞬断など）で未捕捉のまま
+        // ここへ来た例外は、500 ではなく 503(Service Unavailable) として扱う。
+        // ServiceUnavailableException に包み直すと、以降の $httpErrors マッピングに乗り、
+        // Retry-After + 5xx「再読み込み」画面(error.php)で返る。元例外は $previous に連結する。
+        // ※ ここはグローバルハンドラ＝「未捕捉でここまで来た例外」のみが対象。個別に
+        //   catch 済みの箇所（登録フォーム等の独自ハンドリング）には到達しないため影響しない。
+        $dbClass = \App\Models\Repositories\DB::class;
+        if (
+            !($e instanceof \App\Exceptions\ServiceUnavailableException)
+            && class_exists($dbClass)
+            && $dbClass::isConnectionException($e)
+        ) {
+            $e = new \App\Exceptions\ServiceUnavailableException(
+                'Service temporarily unavailable: database connection',
+                0,
+                $e
+            );
+        }
+
         $appHandlerClass = ApplicationExceptionHandler::class;
         if (class_exists($appHandlerClass) && isset($appHandlerClass::$exceptionMap)) {
             $className = get_class($e);

--- a/shared/MimimalCmsConfig.php
+++ b/shared/MimimalCmsConfig.php
@@ -125,6 +125,7 @@ class MimimalCmsConfig
         \Shared\Exceptions\SessionTimeoutException::class =>   ['httpCode' => 401, 'log' => true,  'httpStatusMessage' => 'Unauthorized'],
         \Shared\Exceptions\UnauthorizedException::class =>     ['httpCode' => 401, 'log' => true,  'httpStatusMessage' => 'Unauthorized'],
         \Shared\Exceptions\ThrottleRequestsException::class => ['httpCode' => 429, 'log' => true,  'httpStatusMessage' => 'Too Many Requests'],
+        \App\Exceptions\ServiceUnavailableException::class =>  ['httpCode' => 503, 'log' => false, 'httpStatusMessage' => 'Service Unavailable'],
     ];
 
     // Display exceptions


### PR DESCRIPTION
stg で検証済みの「MySQL 接続枯渇まわりの耐性強化」2件を本番へ反映する。

## 背景

このサーバ（共有ホスティング）の MySQL はユーザー単位の同時接続上限が **100**（`max_user_connections=100`）。アクセスが集中すると一瞬で 100 に張り付き、新規接続が確立できず **個別ルームページ等が 500 エラー**になっていた（本番ログで、ある日のクロール集中の約18分で接続確立時エラーが551件発生していた）。

## 含まれる変更

### 1. 接続の自動リトライ（#532）
接続確立時の一時的な障害（`max_user_connections` / `server has gone away` / `can't connect`）を、短いバックオフ（約0.1〜0.5秒・最大3回）で自動リトライ。単発の瞬断は自己修復する。再接続経路も連鎖で改善。

### 2. 混雑時は 500 ではなく 503＋再読み込み案内（#533）
リトライでも救えない接続枯渇は、500 ではなく **503 Service Unavailable + Retry-After** で返す。

- クローラ（Googlebot 等）には「一時的な混雑、後で再クロールして」が正しく伝わり、500 のような検索順位への悪影響を避けられる。
- ブラウザには既存の「再読み込み」画面を表示（画面は従来の5xxと共通、ステータスとヘッダーのみ変更）。
- 接続枯渇のみ 503 化。通常エラー（404 等）や個別 catch 済みの独自ハンドリングには影響なし。

## 検証

- #532: CI green（既存分類器 `isConnectionException` の再利用、最小差分）。
- #533: 純ロジック検証12項目 + 実コンテナで E2E（接続枯渇例外→HTTP 503＋再読み込み画面描画）+ 通常200・404の回帰なし + CI green。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: \`user-B550M-Pro4:~/repos/oc-graph-3\`