### PR TITLE
[STG] feat: オファーウォールを訪問者ごとに出し分け（おすすめ＋個別ルーム24万ページ）— 検索からの初見には出さず第一印象を保護、一部の高収益ページは常時表示

### DIFF
--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -8,6 +8,28 @@ class GoogleAdsenseConfig
     static string $googleAdsenseClient = 'ca-pub-2330982526015125'; // 広告クライアントID
 
     /**
+     * Offerwall（全画面メッセージ）を「常に表示」にする /recommend タグ（ja の正規タグ名で一致判定）。
+     *
+     * 通常の /recommend ページは GoogleAdsense::gTag(smartOfferwall: true) でクライアント側の出し分けを行い、
+     * 「初回 × 検索エンジン流入」の初見訪問にだけ Offerwall を抑制して SEO ランディングの第一印象を守る。
+     * 一方ここに挙げたタグは、アダルト/大人系で（a）Offerwall の違和感が小さく（b）第一印象を守る必要性が低く
+     * （c）高収益なので、出し分けの例外として「初見でも常時表示」する。
+     *
+     * 判定は recommend_content.php で $_tagIndex（= 正規タグ = URLパス = Cloudflare のキャッシュキー）に対して行うため、
+     * 訪問者ごとに HTML が変わらず、エッジキャッシュと無衝突。タグを増減したいときはこの配列を編集するだけ。
+     */
+    static array $offerwallAlwaysOnTags = [
+        '下ネタ',
+        '大人',
+        'その先',
+        '40代',
+        '50代',
+        '60代',
+        '70代',
+        '全国 雑談', // 半角スペース（U+0020）。ja.json の正規タグと完全一致させること
+    ];
+
+    /**
      * Google AdSense広告スロット設定
      *
      * キー: スロット識別子（文字列）

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -84,21 +84,17 @@ class GoogleAdsense
     }
 
     /**
-     * Offerwall switchback 実験（oc-pdca 2026-06開始）: ISO週番号の偶奇で自動 ON/OFF を交代する。
-     * 奇数週 = 抑制ON（壁を出さない）/ 偶数週 = OFF（通常表示）。週の境界は月曜 0時 JST。
-     * 人手での切り替えは不要。分析時は GA4/AdSense の日次データを ISO 週の偶奇で分けて集計する。
-     * 実験終了時は呼び出し箇所（recommend_content.php）を固定値 true/false に置き換えること。
-     */
-    public static function isOfferwallSuppressionWeek(): bool
-    {
-        return ((int)date('W')) % 2 === 1;
-    }
-
-    /**
-     * @param bool $suppressOfferwall true でこのページの Offerwall（プライバシーとメッセージ）のみ抑制する。
+     * @param bool $suppressOfferwall true でこのページの Offerwall（全画面メッセージ）のみ常時抑制する。
      *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
+     *                                （blog 記事など「初見読者に絶対 Offerwall を出さない」ページ用）
+     * @param bool $smartOfferwall    true で Offerwall を訪問者ごとに出し分ける（oc-pdca 2026-06）。
+     *                                「初回訪問 × 検索エンジンからの流入」のときだけ Offerwall を抑制して
+     *                                SEO ランディングの第一印象を守り、再訪・Direct/SNS・2ページ目以降は通常表示。
+     *                                判定はブラウザ JS（document.referrer + localStorage）で行うため、
+     *                                サーバが返す HTML は全訪問者で同一＝Cloudflare のエッジキャッシュと無衝突。
+     *                                $suppressOfferwall が true の場合はそちらが優先（常時抑制）。
      */
-    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false)
+    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false, bool $smartOfferwall = false)
     {
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
 
@@ -111,6 +107,37 @@ class GoogleAdsense
                 googlefc.controlledMessagingFunction = function (message) {
                     message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
                 };
+            </script>
+            EOT;
+        } elseif ($smartOfferwall) {
+            // 訪問者ごとの出し分け。判定（初回×検索流入）はクライアント JS の実行時に行うので、
+            // キャッシュされる HTML 自体は全訪問者で同一。adsbygoogle.js より前に定義する必要があるため
+            // 文字列補間を避けて nowdoc で出力する。https://developers.google.com/funding-choices/fc-api-docs
+            echo <<<'EOT'
+            <script>
+                (function () {
+                    window.googlefc = window.googlefc || {};
+                    var suppress = false;
+                    try {
+                        var host = '';
+                        try { host = new URL(document.referrer).hostname; } catch (e) {}
+                        var fromSearch = /(^|\.)(google|bing|yahoo|duckduckgo|baidu|naver|daum|ecosia|brave|sogou)\./i.test(host);
+                        var firstVisit = false;
+                        try {
+                            firstVisit = !window.localStorage.getItem('ocReturning');
+                            if (firstVisit) window.localStorage.setItem('ocReturning', '1');
+                        } catch (e) {}
+                        // 初回訪問 かつ 検索エンジンからの流入のときだけ Offerwall を抑制する
+                        suppress = firstVisit && fromSearch;
+                    } catch (e) { suppress = false; }
+                    googlefc.controlledMessagingFunction = function (message) {
+                        if (suppress) {
+                            message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
+                        } else {
+                            message.proceed(true);
+                        }
+                    };
+                })();
             </script>
             EOT;
         }

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -135,13 +135,29 @@ class GoogleAdsense
                         var host = '';
                         try { host = new URL(document.referrer).hostname; } catch (e) {}
                         var fromSearch = /(^|\.)(google|bing|yahoo|duckduckgo|baidu|naver|daum|ecosia|brave|sogou)\./i.test(host);
-                        var firstVisit = false;
-                        try {
-                            firstVisit = !window.localStorage.getItem('ocReturning');
-                            if (firstVisit) window.localStorage.setItem('ocReturning', '1');
-                        } catch (e) {}
+                        var firstVisit = true;
+                        try { firstVisit = !window.localStorage.getItem('ocReturning'); } catch (e) {}
                         // 初回訪問 かつ 検索エンジンからの流入のときだけ Offerwall を抑制する
                         suppress = firstVisit && fromSearch;
+                        // 「再訪」フラグは“ページを開いた瞬間”では立てない。即バック（無反応で離脱）した人は
+                        // 次回も初見扱いのまま壁を猶予する。簡単なエンゲージメント（スクロール / 操作 / 約10秒滞在）が
+                        // 起きたときだけ ocReturning を立て、以降の訪問は通常表示にする。
+                        if (firstVisit) {
+                            var marked = false, dwellTimer = 0;
+                            var mark = function () {
+                                if (marked) return;
+                                marked = true;
+                                try { window.localStorage.setItem('ocReturning', '1'); } catch (e) {}
+                                window.removeEventListener('scroll', mark);
+                                window.removeEventListener('pointerdown', mark);
+                                window.removeEventListener('keydown', mark);
+                                if (dwellTimer) { clearTimeout(dwellTimer); }
+                            };
+                            window.addEventListener('scroll', mark, { passive: true });
+                            window.addEventListener('pointerdown', mark, { passive: true });
+                            window.addEventListener('keydown', mark, { passive: true });
+                            try { dwellTimer = window.setTimeout(mark, 10000); } catch (e) {}
+                        }
                     } catch (e) { suppress = false; }
                     googlefc.controlledMessagingFunction = function (message) {
                         if (suppress) {

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -84,6 +84,19 @@ class GoogleAdsense
     }
 
     /**
+     * このタグ（/recommend の正規タグ、または /oc の部屋タグ $oc['tag1']）が
+     * 「Offerwall 常時表示」対象か。GoogleAdsenseConfig::$offerwallAlwaysOnTags と照合する。
+     * tag1 等は DB から HTML エスケープされた形で来る場合があるので、内部で
+     * htmlspecialchars_decode してから厳密一致する（recommend_content.php と同じ正規化）。
+     * /recommend と /oc がこの1メソッドを共用し、判定がドリフトしないようにする。
+     */
+    public static function isOfferwallAlwaysOn(?string $tag): bool
+    {
+        if ($tag === null || $tag === '') return false;
+        return in_array(htmlspecialchars_decode($tag), GoogleAdsenseConfig::$offerwallAlwaysOnTags, true);
+    }
+
+    /**
      * @param bool $suppressOfferwall true でこのページの Offerwall（全画面メッセージ）のみ常時抑制する。
      *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
      *                                （blog 記事など「初見読者に絶対 Offerwall を出さない」ページ用）

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -207,7 +207,14 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
 
     <?php if ($enableAdsense): ?>
       <?php // ocTopWide2(手動横長)は撤去済み: impRPM¥14/CTR0.21%で「関連ルーム」棚への回遊を遮るだけだった(2026-06実測)。gTag は自動広告に必要なので維持 ?>
-      <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+      <?php
+      // Offerwall 出し分け(oc-pdca): /oc も /recommend と同じ判定。初回×検索流入の初見だけ壁を抑制して
+      // SEO ランディングの第一印象を守り（再訪・Direct/SNS・2ページ目以降は表示）、長尾24万ページの初見体験を守る。
+      // 部屋の recommend タグ($oc['tag1'])が常時ON対象（例: 下ネタ）なら例外として常時表示。
+      // 判定は部屋単位＝全訪問者同一HTMLなので Cloudflare のエッジキャッシュと無衝突。判定ロジックは /recommend と共用。
+      $_ocOfferwallAlwaysOn = GAd::isOfferwallAlwaysOn((string)($oc['tag1'] ?? ''));
+      ?>
+      <?php GAd::gTag(smartOfferwall: !$_ocOfferwallAlwaysOn) ?>
     <?php endif ?>
 
     <?php // 関連ルーム(類似サイズ/おすすめ)は recommend 静的キャッシュ(.dat)から都度組み立て（MySQL不使用） ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -61,8 +61,14 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
     <section class="recommend-ranking-section">
       <?php if (isset($recommend)) : ?>
         <?php if ($enableAdsense): ?>
-          <?php // Offerwall switchback 実験(oc-pdca): 奇数ISO週のみ Offerwall を抑制。広告自体は常に通常表示 ?>
-          <?php GAd::gTag(suppressOfferwall: GAd::isOfferwallSuppressionWeek()) ?>
+          <?php
+          // Offerwall 出し分け(oc-pdca): 初回×検索流入の初見だけ壁を抑制して SEO ランディングの第一印象を守り、
+          // 再訪・Direct/SNS・2ページ目以降は通常表示（判定はクライアント JS）。広告自体は常に通常表示。
+          // ただしアダルト/大人系の高収益タグ（GoogleAdsenseConfig::$offerwallAlwaysOnTags）は出し分けの例外＝常時表示。
+          // 判定は $_tagIndex（= 正規タグ = URLパス = CF キャッシュキー）単位なのでエッジキャッシュと無衝突。
+          $_offerwallAlwaysOn = in_array($_tagIndex, \App\Config\GoogleAdsenseConfig::$offerwallAlwaysOnTags, true);
+          ?>
+          <?php GAd::gTag(smartOfferwall: !$_offerwallAlwaysOn) ?>
         <?php endif ?>
         <?php // 手動広告(recommendSeparatorResponsive)は撤去済み: impRPM¥20=自動広告(¥220)の1/11なのに
               // リストを分断していた(2026-06実測)。広告挿入のためだけだったチャンク分割も廃止し30件を一本のリストで表示 ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -65,8 +65,8 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
           // Offerwall 出し分け(oc-pdca): 初回×検索流入の初見だけ壁を抑制して SEO ランディングの第一印象を守り、
           // 再訪・Direct/SNS・2ページ目以降は通常表示（判定はクライアント JS）。広告自体は常に通常表示。
           // ただしアダルト/大人系の高収益タグ（GoogleAdsenseConfig::$offerwallAlwaysOnTags）は出し分けの例外＝常時表示。
-          // 判定は $_tagIndex（= 正規タグ = URLパス = CF キャッシュキー）単位なのでエッジキャッシュと無衝突。
-          $_offerwallAlwaysOn = in_array($_tagIndex, \App\Config\GoogleAdsenseConfig::$offerwallAlwaysOnTags, true);
+          // 判定はタグ（= 正規タグ = URLパス = CF キャッシュキー）単位なのでエッジキャッシュと無衝突。/oc と同じ判定を共用。
+          $_offerwallAlwaysOn = GAd::isOfferwallAlwaysOn($tag);
           ?>
           <?php GAd::gTag(smartOfferwall: !$_offerwallAlwaysOn) ?>
         <?php endif ?>


### PR DESCRIPTION
## 何をするか

全画面メッセージ（オファーウォール）の出し方を「ISO週ごとに全員一律ON/OFF」のA/B実験から、**訪問者ごとの賢い出し分け**へ切り替え、**おすすめ(/recommend)に加えて個別ルーム(/oc/{id})にも**適用します。

- **検索エンジンから初めて来た初見**には出さない → SEO着地の第一印象を守る
- **再訪（＝過去に簡単なエンゲージのあった人）・SNS/Direct・2ページ目以降**には通常表示 → 収益はしっかり取る
- **高収益タグ（下ネタ 等）は常時表示**（出し分けの例外）

## なぜ /oc も対象にするか（むしろ本丸）

/oc/{id} は**サイト最大の検索着地面**（GSC 90日で約22,600ページ・全行の約9割・約1.4万クリック、25k行上限で頭打ち＝実際はもっと）。これまで**壁が出っぱなし**（`oc_content.php:210` の `gTag()` が無印）で、検索初見の着地でいきなり壁、が24万ページで起きていました。ここを初見だけ猶予するのが効きます。判定材料は `$oc['tag1']`（recommend JOINで取得済み）＝新クエリ不要。

## データ精査の結論（実測でリストを検証）

ISO週A/B（実質1.5サイクル）を**タグ別**に精査した結果:

- **下ネタ**: 壁ありRPM **¥285 vs ¥165（+73%）**、**エンゲージ損ゼロ**（直帰はむしろ -1.6pp）。/recommend着地の約75%。→ **データで常時ON確定**。
- **他の全タグ**: 「効果が悪い」ではなく**「測定不能」**。AdSenseのURL別収益は口座全体で `totalMatchedRows=4`＝**下ネタしかURL単位で見えない**。GA4も他タグはバケット<30セッションでノイズ。
- **ギャンブルは追加せず**（競艇予想だけ壁ありで悪化の弱いヒント eng -8pp、データは追加に反対寄り）。

→ 含意: 下ネタ以外はオファーウォール収益が極小（AdSenseに映らないほど）なので、常時ONにしても収益はほぼ増えず第一印象だけ犠牲。よって**下ネタ以外は smart デフォルト**（2画面目から壁は出る）が低リスク最適。常時ONリストは現状の8タグ（下ネタ＋大人系）を維持し、**追加はしない**。

## 技術的なポイント（キャッシュ安全）

本番は Cloudflare がゾーン全体 Cache Everything で **HTMLを全員に同一配信**（キャッシュキーは host+path+query のみ）。よって**訪問者ごとの分岐はサーバ側不可→クライアントJSの実行時判定**で行う（HTML不変＝キャッシュ無衝突）。「どのタグ/部屋か」はパス（=キャッシュキー）or 部屋単位なのでサーバ側で焼き込んでOK。

`message.proceed(true)` は公式仕様上「メッセージを通常どおり表示（=関数未定義と等価）」なので、同意(GDPR)・広告ブロック回復は従来どおり。抑制時のみ `proceed(false, [OFFERWALL])` でオファーウォールだけ止める。

判定する出力JS（`GoogleAdsense::gTag()` の `smartOfferwall`）の要点:

```js
suppress = firstVisit && fromSearch;   // 初回 × 検索流入のときだけ壁を抑制
// 「再訪」フラグは“開いた瞬間”では立てない。即バックは初見扱いのまま壁を猶予。
// スクロール / 操作 / 約10秒滞在 のいずれか（=簡単なエンゲージ）が起きた時だけ立て、以降は通常表示。
if (firstVisit) { /* scroll/pointerdown/keydown/10s で localStorage('ocReturning')='1' */ }
googlefc.controlledMessagingFunction = function (message) {
  if (suppress) message.proceed(false, [googlefc.MessageTypeEnum.OFFERWALL]); // 壁だけ抑制(同意/広告ブロック回復は維持)
  else          message.proceed(true);                                        // 通常表示
};
```

## 変更点

- `app/Views/Classes/Ads/GoogleAdsense.php`: `gTag()` に `smartOfferwall` モード追加（クライアントJSで出し分け、再訪はエンゲージ後に判定）。判定を `isOfferwallAlwaysOn()` に集約し /recommend と /oc で共用（ドリフト＆tag1デコード漏れ防止）。週トグル `isOfferwallSuppressionWeek()` を削除。
- `app/Config/GoogleAdsenseConfig.php`: 常時表示タグ `$offerwallAlwaysOnTags`（下ネタ/大人/その先/40〜70代/全国 雑談）。
- `app/Views/recommend_content.php` / `app/Views/oc_content.php`: 共有ヘルパーで判定し `smartOfferwall` を適用（/oc は `$oc['tag1']` で判定）。

## 動作確認

- PHP構文チェック（全変更ファイル）OK / 出力JS `node --check` OK / ヘルパーの一致テストOK
- googlefc の `proceed()` 仕様を公式docで確認: `proceed(true)`＝全メッセージ通常表示（同意/広告ブロック回復を壊さない）、`proceed(false,[OFFERWALL])`＝オファーウォールのみ抑制、定義は広告スクリプトのロード前（実装の出力順で担保）
- ページ内で `controlledMessagingFunction` を定義するのは本クラスのみ（competing定義なし）、`ocReturning` キーも衝突なし
- 同意・広告ブロック回復メッセージは従来どおり

## スクリーンショットについて

Google側で表示制御される**不可視のオファーウォール（JS制御）**で、広告は **staging無効**のため画面スクショは取得不可。本番デプロイ後、おすすめ/個別ルームのHTMLへ `controlledMessagingFunction` が出ることと、AdSense/GA4の事後比較で検証します。

## 効果測定（Check）

週A/B廃止により清浄な対照が無くなるため、デプロイ後は **before/after** で /recommend・/oc の RPM・直帰・検索CTR/順位を観測。残りタグをデータで決めたい場合は、A/Bを数サイクル継続＋収益測定を AdSense PAGE_URL から GA4 広告収益イベントへ切替（PAGE_URLは上位URLしか見えない）。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`
