### PR TITLE
[PROD] feat: オファーウォールを訪問者ごとに出し分け（おすすめ＋個別ルーム）— 検索からの初見には出さず第一印象を保護

### DIFF
--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -8,6 +8,28 @@ class GoogleAdsenseConfig
     static string $googleAdsenseClient = 'ca-pub-2330982526015125'; // 広告クライアントID
 
     /**
+     * Offerwall（全画面メッセージ）を「常に表示」にする /recommend タグ（ja の正規タグ名で一致判定）。
+     *
+     * 通常の /recommend ページは GoogleAdsense::gTag(smartOfferwall: true) でクライアント側の出し分けを行い、
+     * 「初回 × 検索エンジン流入」の初見訪問にだけ Offerwall を抑制して SEO ランディングの第一印象を守る。
+     * 一方ここに挙げたタグは、アダルト/大人系で（a）Offerwall の違和感が小さく（b）第一印象を守る必要性が低く
+     * （c）高収益なので、出し分けの例外として「初見でも常時表示」する。
+     *
+     * 判定は recommend_content.php で $_tagIndex（= 正規タグ = URLパス = Cloudflare のキャッシュキー）に対して行うため、
+     * 訪問者ごとに HTML が変わらず、エッジキャッシュと無衝突。タグを増減したいときはこの配列を編集するだけ。
+     */
+    static array $offerwallAlwaysOnTags = [
+        '下ネタ',
+        '大人',
+        'その先',
+        '40代',
+        '50代',
+        '60代',
+        '70代',
+        '全国 雑談', // 半角スペース（U+0020）。ja.json の正規タグと完全一致させること
+    ];
+
+    /**
      * Google AdSense広告スロット設定
      *
      * キー: スロット識別子（文字列）

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -269,10 +269,6 @@ function purgeCacheCloudFlare(
         return 'Cloudflareは無効化されています';
     }
 
-    if (AppConfig::$isStaging || AppConfig::$isDevlopment) {
-        return 'Cloudflareキャッシュ削除はステージング・開発環境では実行されません';
-    }
-
     // cURLセッションを初期化
     $ch = curl_init();
 

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -7,9 +7,7 @@ use App\Config\AppConfig;
 use App\Services\OpenChat\Utility\OpenChatServicesUtility;
 use Shadow\Kernel\Dispatcher\ReceptionInitializer;
 use Shadow\Kernel\Utility\KernelUtility;
-use Shared\Exceptions\NotFoundException;
 use Shared\MimimalCmsConfig;
-use Symfony\Component\HttpClient\RetryableHttpClient;
 
 /**
  * Inserts HTML line breaks before all newlines in a string.
@@ -265,7 +263,7 @@ function purgeCacheCloudFlare(
     $zoneID = $zoneID ?? SecretsConfig::$cloudFlareZoneId;
     $apiKey = $apiKey ?? SecretsConfig::$cloudFlareApiKey;
 
-    if (!AppConfig::$enableCloudflare) {
+    if (!AppConfig::$enableCloudflare || !$zoneID || !$apiKey || !AppConfig::$isDevlopment) {
         return 'Cloudflareは無効化されています';
     }
 

--- a/app/Services/DailyUpdateCronService.php
+++ b/app/Services/DailyUpdateCronService.php
@@ -66,9 +66,9 @@ class DailyUpdateCronService
         CronUtility::addCronLog('ランキング外オープンチャットのクローリング' . $title . ': 残り' . count($outOfRankId) . '件');
 
         // 開発環境・ステージング環境の場合、更新制限をかける
-        $isDevelopment = AppConfig::$isDevlopment;
+        $isDevlopment = AppConfig::$isDevlopment;
         $isStaging = AppConfig::$isStaging;
-        if ($isDevelopment || $isStaging) {
+        if ($isDevlopment || $isStaging) {
             $limit = AppConfig::$developmentEnvUpdateLimit['DailyUpdateCronService'] ?? 1;
             $outOfRankIdCount = count($outOfRankId);
             $outOfRankId = array_slice($outOfRankId, 0, $limit);

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -84,21 +84,17 @@ class GoogleAdsense
     }
 
     /**
-     * Offerwall switchback 実験（oc-pdca 2026-06開始）: ISO週番号の偶奇で自動 ON/OFF を交代する。
-     * 奇数週 = 抑制ON（壁を出さない）/ 偶数週 = OFF（通常表示）。週の境界は月曜 0時 JST。
-     * 人手での切り替えは不要。分析時は GA4/AdSense の日次データを ISO 週の偶奇で分けて集計する。
-     * 実験終了時は呼び出し箇所（recommend_content.php）を固定値 true/false に置き換えること。
-     */
-    public static function isOfferwallSuppressionWeek(): bool
-    {
-        return ((int)date('W')) % 2 === 1;
-    }
-
-    /**
-     * @param bool $suppressOfferwall true でこのページの Offerwall（プライバシーとメッセージ）のみ抑制する。
+     * @param bool $suppressOfferwall true でこのページの Offerwall（全画面メッセージ）のみ常時抑制する。
      *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
+     *                                （blog 記事など「初見読者に絶対 Offerwall を出さない」ページ用）
+     * @param bool $smartOfferwall    true で Offerwall を訪問者ごとに出し分ける（oc-pdca 2026-06）。
+     *                                「初回訪問 × 検索エンジンからの流入」のときだけ Offerwall を抑制して
+     *                                SEO ランディングの第一印象を守り、再訪・Direct/SNS・2ページ目以降は通常表示。
+     *                                判定はブラウザ JS（document.referrer + localStorage）で行うため、
+     *                                サーバが返す HTML は全訪問者で同一＝Cloudflare のエッジキャッシュと無衝突。
+     *                                $suppressOfferwall が true の場合はそちらが優先（常時抑制）。
      */
-    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false)
+    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false, bool $smartOfferwall = false)
     {
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
 
@@ -111,6 +107,37 @@ class GoogleAdsense
                 googlefc.controlledMessagingFunction = function (message) {
                     message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
                 };
+            </script>
+            EOT;
+        } elseif ($smartOfferwall) {
+            // 訪問者ごとの出し分け。判定（初回×検索流入）はクライアント JS の実行時に行うので、
+            // キャッシュされる HTML 自体は全訪問者で同一。adsbygoogle.js より前に定義する必要があるため
+            // 文字列補間を避けて nowdoc で出力する。https://developers.google.com/funding-choices/fc-api-docs
+            echo <<<'EOT'
+            <script>
+                (function () {
+                    window.googlefc = window.googlefc || {};
+                    var suppress = false;
+                    try {
+                        var host = '';
+                        try { host = new URL(document.referrer).hostname; } catch (e) {}
+                        var fromSearch = /(^|\.)(google|bing|yahoo|duckduckgo|baidu|naver|daum|ecosia|brave|sogou)\./i.test(host);
+                        var firstVisit = false;
+                        try {
+                            firstVisit = !window.localStorage.getItem('ocReturning');
+                            if (firstVisit) window.localStorage.setItem('ocReturning', '1');
+                        } catch (e) {}
+                        // 初回訪問 かつ 検索エンジンからの流入のときだけ Offerwall を抑制する
+                        suppress = firstVisit && fromSearch;
+                    } catch (e) { suppress = false; }
+                    googlefc.controlledMessagingFunction = function (message) {
+                        if (suppress) {
+                            message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
+                        } else {
+                            message.proceed(true);
+                        }
+                    };
+                })();
             </script>
             EOT;
         }

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -135,13 +135,29 @@ class GoogleAdsense
                         var host = '';
                         try { host = new URL(document.referrer).hostname; } catch (e) {}
                         var fromSearch = /(^|\.)(google|bing|yahoo|duckduckgo|baidu|naver|daum|ecosia|brave|sogou)\./i.test(host);
-                        var firstVisit = false;
-                        try {
-                            firstVisit = !window.localStorage.getItem('ocReturning');
-                            if (firstVisit) window.localStorage.setItem('ocReturning', '1');
-                        } catch (e) {}
+                        var firstVisit = true;
+                        try { firstVisit = !window.localStorage.getItem('ocReturning'); } catch (e) {}
                         // 初回訪問 かつ 検索エンジンからの流入のときだけ Offerwall を抑制する
                         suppress = firstVisit && fromSearch;
+                        // 「再訪」フラグは“ページを開いた瞬間”では立てない。即バック（無反応で離脱）した人は
+                        // 次回も初見扱いのまま壁を猶予する。簡単なエンゲージメント（スクロール / 操作 / 約10秒滞在）が
+                        // 起きたときだけ ocReturning を立て、以降の訪問は通常表示にする。
+                        if (firstVisit) {
+                            var marked = false, dwellTimer = 0;
+                            var mark = function () {
+                                if (marked) return;
+                                marked = true;
+                                try { window.localStorage.setItem('ocReturning', '1'); } catch (e) {}
+                                window.removeEventListener('scroll', mark);
+                                window.removeEventListener('pointerdown', mark);
+                                window.removeEventListener('keydown', mark);
+                                if (dwellTimer) { clearTimeout(dwellTimer); }
+                            };
+                            window.addEventListener('scroll', mark, { passive: true });
+                            window.addEventListener('pointerdown', mark, { passive: true });
+                            window.addEventListener('keydown', mark, { passive: true });
+                            try { dwellTimer = window.setTimeout(mark, 10000); } catch (e) {}
+                        }
                     } catch (e) { suppress = false; }
                     googlefc.controlledMessagingFunction = function (message) {
                         if (suppress) {

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -84,6 +84,19 @@ class GoogleAdsense
     }
 
     /**
+     * このタグ（/recommend の正規タグ、または /oc の部屋タグ $oc['tag1']）が
+     * 「Offerwall 常時表示」対象か。GoogleAdsenseConfig::$offerwallAlwaysOnTags と照合する。
+     * tag1 等は DB から HTML エスケープされた形で来る場合があるので、内部で
+     * htmlspecialchars_decode してから厳密一致する（recommend_content.php と同じ正規化）。
+     * /recommend と /oc がこの1メソッドを共用し、判定がドリフトしないようにする。
+     */
+    public static function isOfferwallAlwaysOn(?string $tag): bool
+    {
+        if ($tag === null || $tag === '') return false;
+        return in_array(htmlspecialchars_decode($tag), GoogleAdsenseConfig::$offerwallAlwaysOnTags, true);
+    }
+
+    /**
      * @param bool $suppressOfferwall true でこのページの Offerwall（全画面メッセージ）のみ常時抑制する。
      *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
      *                                （blog 記事など「初見読者に絶対 Offerwall を出さない」ページ用）

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -207,7 +207,14 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
 
     <?php if ($enableAdsense): ?>
       <?php // ocTopWide2(手動横長)は撤去済み: impRPM¥14/CTR0.21%で「関連ルーム」棚への回遊を遮るだけだった(2026-06実測)。gTag は自動広告に必要なので維持 ?>
-      <?php \App\Views\Ads\GoogleAdsense::gTag() ?>
+      <?php
+      // Offerwall 出し分け(oc-pdca): /oc も /recommend と同じ判定。初回×検索流入の初見だけ壁を抑制して
+      // SEO ランディングの第一印象を守り（再訪・Direct/SNS・2ページ目以降は表示）、長尾24万ページの初見体験を守る。
+      // 部屋の recommend タグ($oc['tag1'])が常時ON対象（例: 下ネタ）なら例外として常時表示。
+      // 判定は部屋単位＝全訪問者同一HTMLなので Cloudflare のエッジキャッシュと無衝突。判定ロジックは /recommend と共用。
+      $_ocOfferwallAlwaysOn = GAd::isOfferwallAlwaysOn((string)($oc['tag1'] ?? ''));
+      ?>
+      <?php GAd::gTag(smartOfferwall: !$_ocOfferwallAlwaysOn) ?>
     <?php endif ?>
 
     <?php // 関連ルーム(類似サイズ/おすすめ)は recommend 静的キャッシュ(.dat)から都度組み立て（MySQL不使用） ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -61,8 +61,14 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
     <section class="recommend-ranking-section">
       <?php if (isset($recommend)) : ?>
         <?php if ($enableAdsense): ?>
-          <?php // Offerwall switchback 実験(oc-pdca): 奇数ISO週のみ Offerwall を抑制。広告自体は常に通常表示 ?>
-          <?php GAd::gTag(suppressOfferwall: GAd::isOfferwallSuppressionWeek()) ?>
+          <?php
+          // Offerwall 出し分け(oc-pdca): 初回×検索流入の初見だけ壁を抑制して SEO ランディングの第一印象を守り、
+          // 再訪・Direct/SNS・2ページ目以降は通常表示（判定はクライアント JS）。広告自体は常に通常表示。
+          // ただしアダルト/大人系の高収益タグ（GoogleAdsenseConfig::$offerwallAlwaysOnTags）は出し分けの例外＝常時表示。
+          // 判定は $_tagIndex（= 正規タグ = URLパス = CF キャッシュキー）単位なのでエッジキャッシュと無衝突。
+          $_offerwallAlwaysOn = in_array($_tagIndex, \App\Config\GoogleAdsenseConfig::$offerwallAlwaysOnTags, true);
+          ?>
+          <?php GAd::gTag(smartOfferwall: !$_offerwallAlwaysOn) ?>
         <?php endif ?>
         <?php // 手動広告(recommendSeparatorResponsive)は撤去済み: impRPM¥20=自動広告(¥220)の1/11なのに
               // リストを分断していた(2026-06実測)。広告挿入のためだけだったチャンク分割も廃止し30件を一本のリストで表示 ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -65,8 +65,8 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
           // Offerwall 出し分け(oc-pdca): 初回×検索流入の初見だけ壁を抑制して SEO ランディングの第一印象を守り、
           // 再訪・Direct/SNS・2ページ目以降は通常表示（判定はクライアント JS）。広告自体は常に通常表示。
           // ただしアダルト/大人系の高収益タグ（GoogleAdsenseConfig::$offerwallAlwaysOnTags）は出し分けの例外＝常時表示。
-          // 判定は $_tagIndex（= 正規タグ = URLパス = CF キャッシュキー）単位なのでエッジキャッシュと無衝突。
-          $_offerwallAlwaysOn = in_array($_tagIndex, \App\Config\GoogleAdsenseConfig::$offerwallAlwaysOnTags, true);
+          // 判定はタグ（= 正規タグ = URLパス = CF キャッシュキー）単位なのでエッジキャッシュと無衝突。/oc と同じ判定を共用。
+          $_offerwallAlwaysOn = GAd::isOfferwallAlwaysOn($tag);
           ?>
           <?php GAd::gTag(smartOfferwall: !$_offerwallAlwaysOn) ?>
         <?php endif ?>


### PR DESCRIPTION
## 本番へ反映する内容

オープンチャットの「おすすめ」ページと個別ルームページで、全画面の広告メッセージ（オファーウォール）の出し方を改善します。

- **検索エンジンから初めて訪れた方の最初の1ページ目には全画面メッセージを出さない** → サイトの第一印象を守る
- **再訪の方・2ページ目以降・SNS/直接アクセスの方にはこれまで通り表示** → 収益は維持
- 24万件ある個別ルームページ（サイト最大の検索流入面）にも適用
- 一部の高収益ページは例外として従来どおり常時表示
- 「再訪」は、前回スクロールや操作など簡単な反応があった方だけを対象にする（来てすぐ離脱した方は次回も第一印象を優先）
- 訪問者ごとの出し分けはブラウザ側で判定するため、Cloudflare のキャッシュと干渉しない

あわせて、ステージング環境の CDN キャッシュ設定の調整（3コミット）も本番へ取り込みます。

設計の詳細・データ根拠（A/B 実測など）は stg 側の PR #543 を参照。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`
