### PR TITLE
[STG] skip-ci: カテゴリをスワイプで切り替えると「関連テーマ」が遅れて表示されて一覧がガタつく問題を修正

### DIFF
--- a/frontend/ranking/src/__tests__/RecommendThemeShelf.test.tsx
+++ b/frontend/ranking/src/__tests__/RecommendThemeShelf.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { Provider } from 'jotai'
+import { SWRConfig } from 'swr'
 import RecommendThemeShelf from '../components/RecommendThemeShelf'
 
 // /oclist-tags が「表示中の上位ルームのタグ」を返す前提のモック。
@@ -26,7 +27,7 @@ describe('RecommendThemeShelf', () => {
     render(
       <MemoryRouter>
         <Provider>
-          <RecommendThemeShelf />
+          <RecommendThemeShelf category={0} subCategory="" />
         </Provider>
       </MemoryRouter>
     )
@@ -39,5 +40,28 @@ describe('RecommendThemeShelf', () => {
     expect(links[0]).toHaveTextContent('ゲーム')
     expect(links[1]).toHaveAttribute('href', '/recommend/%E9%9B%91%E8%AB%87')
     expect(screen.getByText('関連テーマ')).toBeInTheDocument()
+  })
+
+  it('取得前はスケルトンで高さを確保する（null で潰してリストをガタつかせない）', () => {
+    // 解決しない fetch にして「読み込み中」状態を再現する。
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {}))
+    )
+
+    const { container } = render(
+      // 前テストの SWR グローバルキャッシュを引き継がないよう、空キャッシュで隔離する。
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <MemoryRouter>
+          <Provider>
+            <RecommendThemeShelf category={0} subCategory="" />
+          </Provider>
+        </MemoryRouter>
+      </SWRConfig>
+    )
+
+    // 取得前はチップ（リンク）は無いが、高さ確保用のスケルトンは描画されている。
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+    expect(container.querySelector('.MuiSkeleton-root')).not.toBeNull()
   })
 })

--- a/frontend/ranking/src/components/OcListMainTabs.tsx
+++ b/frontend/ranking/src/components/OcListMainTabs.tsx
@@ -134,21 +134,36 @@ function OcListSwiper({
                 : {}),
             }}
           >
-            {i === cateIndex && <RecommendThemeShelf />}
             {(() => {
-              if (i === cateIndex) {
-                return <OpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
-              } else if (tIndex && i === tIndex[0]) {
-                return <OpenChatRankingList query={tIndex[1]} cateIndex={i} />
-              } else if (!tIndex && prevInView && i === cateIndex - 1) {
-                return (
-                  <DummyOpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
-                )
-              } else if (!tIndex && nextInView && i === cateIndex + 1) {
-                return (
-                  <DummyOpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
-                )
-              }
+              const isActive = i === cateIndex
+              const isTransition = !!tIndex && i === tIndex[0]
+              const isPrev = !tIndex && prevInView && i === cateIndex - 1
+              const isNext = !tIndex && nextInView && i === cateIndex + 1
+              if (!(isActive || isTransition || isPrev || isNext)) return null
+
+              // 関連テーマ棚はリストと同じスライド集合（現在/遷移/隣接）で描画する。隣接スライドにも
+              // 先出しして取得を始めることで、スワイプ後に棚が遅れて現れて下のリストが押し下げられる
+              // 「ガタッ」を防ぐ（取得前は棚側がスケルトンで高さを確保する）。
+              const shelf = (
+                <RecommendThemeShelf
+                  category={OPEN_CHAT_CATEGORY[i][1]}
+                  subCategory={isActive ? params.sub_category : ''}
+                />
+              )
+              const list = isActive ? (
+                <OpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
+              ) : isTransition && tIndex ? (
+                <OpenChatRankingList query={tIndex[1]} cateIndex={i} />
+              ) : (
+                <DummyOpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
+              )
+
+              return (
+                <>
+                  {shelf}
+                  {list}
+                </>
+              )
             })()}
             {i === cateIndex && (
               <div

--- a/frontend/ranking/src/components/OcListMainTabsVertical.tsx
+++ b/frontend/ranking/src/components/OcListMainTabsVertical.tsx
@@ -118,7 +118,10 @@ export default function OcListMainTabsVertical({ cateIndex }: { cateIndex: numbe
           <SiteHeaderVerticalSearch />
         </Box>
         <Box sx={{ p: '1.5rem', pt: '1rem' }}>
-          <RecommendThemeShelf />
+          <RecommendThemeShelf
+            category={OPEN_CHAT_CATEGORY[cateIndex][1]}
+            subCategory={params.sub_category}
+          />
           {OPEN_CHAT_CATEGORY.map((el, i) => (
             <TabPanel value={cateIndex} index={i} key={i}>
               <FetchOpenChatRankingList query={query} cateIndex={cateIndex} />

--- a/frontend/ranking/src/components/RecommendThemeShelf.tsx
+++ b/frontend/ranking/src/components/RecommendThemeShelf.tsx
@@ -1,8 +1,7 @@
 import { memo } from 'react'
 import useSWR from 'swr'
-import { Chip } from '@mui/material'
+import { Chip, Skeleton } from '@mui/material'
 import { useAtomValue } from 'jotai'
-import { useParams } from 'react-router-dom'
 import { rankingArgDto } from '../config/config'
 import { t } from '../config/translation'
 import { isSP } from '../utils/utils'
@@ -19,27 +18,41 @@ const fetcher = (url: string): Promise<ThemeTag[]> =>
     r.ok ? r.json() : []
   )
 
+// チップ取得待ちのプレースホルダ（pill 形・高さ32でチップと同寸）。見出しは静的なので
+// スケルトンにせず実テキストを出し、API から来るチップ部分だけをこれで埋めて高さを確保する。
+const SKELETON_CHIP_WIDTHS = [76, 56, 92, 64, 84]
+
 /**
  * 回遊シェルフ（#1ページ /ranking → 高RPMの /recommend）。
  * いま表示中（カテゴリ・検索・list[時間軸]・sort・order）の上位ルームが持つ recommend タグを
  * /oclist-tags から取得してチップ表示する。ランキングの絞り込みが変わると中身も連動する。
+ * - 見出し「関連テーマ」は静的テキスト。チップ（タグ）だけが API 取得なので、取得待ちは
+ *   チップ部分のみスケルトンにする（見出しは最初から実テキストで出す）。
  * - サブカテゴリ絞り込みchip(灰)と区別するため緑系（CSS .theme-link）。本物の <a href>（SEO/送客）。
  * - 横スクロール: PC(非タッチ)はドラッグ、SP(タッチ)は Swiper にジェスチャを奪われないよう
  *   swiper-no-swiping を付与しネイティブスクロール。右端フェードで可スクロールを明示。
- * - タグが無い文脈では何も出さない。並び替え中も keepPreviousData でちらつかせない。
+ * - category / subCategory は描画中スライドの値を受け取る（隣接スライドにも先出しできるよう props 化）。
+ *   リストと同じく描画開始時から取得を始め、取得前はチップをスケルトンで埋めて高さを確保する
+ *   （スワイプ後にチップが遅れて入って下のリストが押し下げられる「ガタッ」を防ぐ）。
+ * - 取得後にタグが無い文脈では何も出さない。並び替え中も keepPreviousData でちらつかせない。
  */
-const RecommendThemeShelf = memo(function RecommendThemeShelf() {
+const RecommendThemeShelf = memo(function RecommendThemeShelf({
+  category,
+  subCategory,
+}: {
+  category: number
+  subCategory: string
+}) {
   const params = useAtomValue(listParamsState)
-  const { category } = useParams()
   const sp = isSP()
 
   // ランキング一覧と同じ絞り込みを送る（先頭ページの上位ルームを対象に集約）。
   const query = new URLSearchParams({
-    category: category ? String(parseInt(category, 10) || 0) : '0',
+    category: String(category),
     list: params.list,
     sort: params.sort,
     order: params.order,
-    sub_category: params.sub_category,
+    sub_category: subCategory,
     keyword: params.keyword,
     limit: '20',
     page: '0',
@@ -54,7 +67,9 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf() {
   const [isRightScrollable, scrollRef] = useIsRightScrollable(themes)
   const { events } = useDraggableScroll(scrollRef)
 
-  if (themes.length === 0) return null
+  // 取得前はチップをスケルトンで埋める。取得後にタグが無ければ何も出さない（見出しごと畳む）。
+  const loading = data === undefined
+  if (!loading && themes.length === 0) return null
 
   return (
     <section
@@ -88,24 +103,35 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf() {
           style={{
             display: 'flex',
             gap: 8,
-            overflowX: 'auto',
+            overflowX: loading ? 'hidden' : 'auto',
             paddingBottom: 2,
             cursor: sp ? 'auto' : 'grab',
             scrollbarWidth: 'none',
           }}
         >
-          {themes.map((theme, i) => (
-            <Chip
-              key={`${theme.slug}-${i}`}
-              component="a"
-              href={recommendHref(theme.slug)}
-              label={theme.name}
-              clickable
-              draggable={false}
-              className="openchat-item-header-chip category theme-link"
-              sx={{ flexShrink: 0 }}
-            />
-          ))}
+          {loading
+            ? SKELETON_CHIP_WIDTHS.map((w, i) => (
+                <Skeleton
+                  key={i}
+                  variant="rounded"
+                  width={w}
+                  height={32}
+                  aria-hidden="true"
+                  sx={{ flex: '0 0 auto', borderRadius: '99px' }}
+                />
+              ))
+            : themes.map((theme, i) => (
+                <Chip
+                  key={`${theme.slug}-${i}`}
+                  component="a"
+                  href={recommendHref(theme.slug)}
+                  label={theme.name}
+                  clickable
+                  draggable={false}
+                  className="openchat-item-header-chip category theme-link"
+                  sx={{ flexShrink: 0 }}
+                />
+              ))}
         </div>
         {isRightScrollable && (
           <div

--- a/frontend/ranking/src/components/RecommendThemeShelf.tsx
+++ b/frontend/ranking/src/components/RecommendThemeShelf.tsx
@@ -133,7 +133,7 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf({
                 />
               ))}
         </div>
-        {isRightScrollable && (
+        {!loading && isRightScrollable && (
           <div
             aria-hidden="true"
             style={{

--- a/frontend/ranking/src/hooks/ScrollableHooks.ts
+++ b/frontend/ranking/src/hooks/ScrollableHooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 
 export function useIsRightScrollable(
   useEffectTrigerValue: unknown
@@ -16,7 +16,10 @@ export function useIsRightScrollable(
     }
   }
 
-  useEffect(() => {
+  // useLayoutEffect: 初回描画(ペイント)前に計測して右端フェードの有無を確定させる。
+  // useEffect だとペイント後に false→true へ更新されるため、スライド切替で棚が再マウント
+  // するたびフェードが一瞬消えて戻る「ちらつき」が出る。
+  useLayoutEffect(() => {
     checkScrollButtons()
     const currentRef = ref.current
     currentRef?.addEventListener('scroll', checkScrollButtons)
@@ -47,7 +50,10 @@ export function useIsLeftRightScrollable(
     }
   }
 
-  useEffect(() => {
+  // useLayoutEffect: 初回描画(ペイント)前に計測して右端フェードの有無を確定させる。
+  // useEffect だとペイント後に false→true へ更新されるため、スライド切替で棚が再マウント
+  // するたびフェードが一瞬消えて戻る「ちらつき」が出る。
+  useLayoutEffect(() => {
     checkScrollButtons()
     const currentRef = ref.current
     currentRef?.addEventListener('scroll', checkScrollButtons)


### PR DESCRIPTION
ランキングでカテゴリをスワイプ／タブで切り替えた直後、上部の「関連テーマ」がタグの取得を待ってから出現し、その分だけ下のランキング一覧が押し下げられてガタッと動いていた。

## 原因

関連テーマ棚は「いま開いているスライド」だけに描画され、かつタグ取得が終わるまで高さ0（非表示）だった。切替先のスライドには棚が無く、取得完了後に現れて一覧を押し下げていた。

## 対処

- 関連テーマ棚を一覧と同じスライド集合（現在・遷移中・隣接）に描画し、隣接スライドにも先出しして取得を開始（描画と同時にフェッチ）。
- 見出し「関連テーマ」は静的テキストなので最初から表示。API取得が必要なタグ（チップ）部分だけを取得待ちの間スケルトン（チップと同じ高さの pill）で埋めて、一覧の位置が動かないようにした。
- タグが無い文脈では従来どおり棚ごと非表示。

## 確認（ローカル・モバイル幅）

- 通常表示・カテゴリ切替・取得待ち（スケルトン）いずれもランキング一覧の縦位置が動かないことを確認。
- 取得待ちは見出しは実テキスト、チップ部分のみスケルトン。

## 主な変更ファイル

- `frontend/ranking/src/components/RecommendThemeShelf.tsx` … props化＋チップ部分だけスケルトン
- `frontend/ranking/src/components/OcListMainTabs.tsx` … 一覧と同じスライド集合に棚を描画
- `frontend/ranking/src/components/OcListMainTabsVertical.tsx` … props 受け渡し

skip-ci: PHP非変更（ランキングのフロント TSX のみ）。CIはMock環境のクローリング+URLテストで、このクライアント側Reactの挙動は対象外のため。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
