### PR TITLE
[STG] skip-ci: ランキングのカテゴリ切替で「関連テーマ」右端のフェードがちらつく問題を修正

### DIFF
--- a/frontend/ranking/src/components/OcListMainTabs.tsx
+++ b/frontend/ranking/src/components/OcListMainTabs.tsx
@@ -137,31 +137,36 @@ function OcListSwiper({
             {(() => {
               const isActive = i === cateIndex
               const isTransition = !!tIndex && i === tIndex[0]
+
+              // 棚は inView に関係なく隣接スライド(±1)にも常時マウントして先に取得・計測まで済ませる。
+              // こうするとスワイプで入った瞬間に再マウントせず、チップも右端フェードもそのまま見える。
+              // （inView ゲートのままだと隣スライドの棚が未マウント→スワイプ時に新規取得でスケルトンに
+              //   なり、右端フェードが一瞬消えて戻る／一覧がガタつく原因になる）。
+              const showShelf = isActive || isTransition || i === cateIndex - 1 || i === cateIndex + 1
+
+              // リストは従来どおり inView のときだけ（全カテゴリ分を同時描画しない）。
               const isPrev = !tIndex && prevInView && i === cateIndex - 1
               const isNext = !tIndex && nextInView && i === cateIndex + 1
-              if (!(isActive || isTransition || isPrev || isNext)) return null
+              const showList = isActive || isTransition || isPrev || isNext
 
-              // 関連テーマ棚はリストと同じスライド集合（現在/遷移/隣接）で描画する。隣接スライドにも
-              // 先出しして取得を始めることで、スワイプ後に棚が遅れて現れて下のリストが押し下げられる
-              // 「ガタッ」を防ぐ（取得前は棚側がスケルトンで高さを確保する）。
-              const shelf = (
-                <RecommendThemeShelf
-                  category={OPEN_CHAT_CATEGORY[i][1]}
-                  subCategory={isActive ? params.sub_category : ''}
-                />
-              )
-              const list = isActive ? (
-                <OpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
-              ) : isTransition && tIndex ? (
-                <OpenChatRankingList query={tIndex[1]} cateIndex={i} />
-              ) : (
-                <DummyOpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
-              )
+              if (!showShelf && !showList) return null
 
               return (
                 <>
-                  {shelf}
-                  {list}
+                  {showShelf && (
+                    <RecommendThemeShelf
+                      category={OPEN_CHAT_CATEGORY[i][1]}
+                      subCategory={isActive ? params.sub_category : ''}
+                    />
+                  )}
+                  {showList &&
+                    (isActive ? (
+                      <OpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
+                    ) : isTransition && tIndex ? (
+                      <OpenChatRankingList query={tIndex[1]} cateIndex={i} />
+                    ) : (
+                      <DummyOpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
+                    ))}
                 </>
               )
             })()}


### PR DESCRIPTION
ランキングでカテゴリをスワイプ切替したとき、上部「関連テーマ」の右端にある黒いフェードが一瞬消えてまた戻る（ちらつく）問題の追加修正。

## 原因

先のPR #545 で「描画前に計測（useLayoutEffect）」「取得待ち中はフェード非表示」を入れたが、本体原因が残っていた。関連テーマ棚は表示領域に入っているスライドにしかマウントされず、スワイプで入った瞬間に新規マウント→タグ未取得でスケルトン（フェード無し）になり、フェードが一瞬消えて戻っていた。

## 対処

関連テーマ棚を inView に関係なく隣接スライド(±1)へ常時マウントし、先に取得・計測まで済ませる。スワイプで入っても再マウントが起きず、チップと右端フェードがそのまま保たれる。ランキング一覧本体は従来どおり inView のときだけ描画（全カテゴリ同時描画は避ける）。

## 確認（ローカル・モバイル幅）

- フレーム単位で計測し、隣接スライド先読み後は表示中スライドのフェードが落ちる瞬間ゼロ・スケルトン表示ゼロを確認。
- next/prev 両方向＋連続スワイプでも再現しないことを確認。

変更ファイル: `frontend/ranking/src/components/OcListMainTabs.tsx`

skip-ci: PHP非変更（ランキングのフロント TSX のみ）。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
