### PR TITLE
[PROD] 「関連テーマ」右端フェードのちらつきを根治（CSSフェードに変更）

### DIFF
--- a/frontend/ranking/src/components/RecommendThemeShelf.tsx
+++ b/frontend/ranking/src/components/RecommendThemeShelf.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useRef } from 'react'
 import useSWR from 'swr'
 import { Chip, Skeleton } from '@mui/material'
 import { useAtomValue } from 'jotai'
@@ -7,7 +7,6 @@ import { t } from '../config/translation'
 import { isSP } from '../utils/utils'
 import { listParamsState } from '../store/atom'
 import { useDraggableScroll } from '../hooks/useDraggableScroll'
-import { useIsRightScrollable } from '../hooks/ScrollableHooks'
 
 // urlRoot: '' (ja) | '/tw' | '/th'。slug はサーバ側 urlencode 済みなので再エンコードしない。
 const recommendHref = (slug: string) => `${rankingArgDto.urlRoot}/recommend/${slug}`
@@ -18,8 +17,12 @@ const fetcher = (url: string): Promise<ThemeTag[]> =>
     r.ok ? r.json() : []
   )
 
-// チップ取得待ちのプレースホルダ（pill 形・高さ32でチップと同寸）。見出しは静的なので
-// スケルトンにせず実テキストを出し、API から来るチップ部分だけをこれで埋めて高さを確保する。
+// 右端フェードは CSS の mask-image で出す（JS状態に紐づけない）。チップが右端まで届いたとき
+// だけ自然にフェードし、収まっていれば右端は空なので見えない。JSの実測 boolean を使うと
+// 「初期 false → 計測後 true」を必ず経由してスライド切替でちらつくため、CSS に寄せている。
+const RIGHT_FADE_MASK = 'linear-gradient(to right, #000 calc(100% - 36px), transparent 100%)'
+
+// 取得前に高さを確保するチップ用スケルトン（pill 形・高さ32でチップと同寸）。
 const SKELETON_CHIP_WIDTHS = [76, 56, 92, 64, 84]
 
 /**
@@ -30,10 +33,8 @@ const SKELETON_CHIP_WIDTHS = [76, 56, 92, 64, 84]
  *   チップ部分のみスケルトンにする（見出しは最初から実テキストで出す）。
  * - サブカテゴリ絞り込みchip(灰)と区別するため緑系（CSS .theme-link）。本物の <a href>（SEO/送客）。
  * - 横スクロール: PC(非タッチ)はドラッグ、SP(タッチ)は Swiper にジェスチャを奪われないよう
- *   swiper-no-swiping を付与しネイティブスクロール。右端フェードで可スクロールを明示。
+ *   swiper-no-swiping を付与しネイティブスクロール。右端フェードは mask-image（CSSのみ）。
  * - category / subCategory は描画中スライドの値を受け取る（隣接スライドにも先出しできるよう props 化）。
- *   リストと同じく描画開始時から取得を始め、取得前はチップをスケルトンで埋めて高さを確保する
- *   （スワイプ後にチップが遅れて入って下のリストが押し下げられる「ガタッ」を防ぐ）。
  * - 取得後にタグが無い文脈では何も出さない。並び替え中も keepPreviousData でちらつかせない。
  */
 const RecommendThemeShelf = memo(function RecommendThemeShelf({
@@ -64,7 +65,7 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf({
   })
   const themes = data ?? []
 
-  const [isRightScrollable, scrollRef] = useIsRightScrollable(themes)
+  const scrollRef = useRef<HTMLDivElement>(null)
   const { events } = useDraggableScroll(scrollRef)
 
   // 取得前はチップをスケルトンで埋める。取得後にタグが無ければ何も出さない（見出しごと畳む）。
@@ -95,58 +96,45 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf({
         {t('関連テーマ')}
         <span aria-hidden="true" style={{ fontSize: 12 }}>✨</span>
       </div>
-      <div style={{ position: 'relative' }}>
-        <div
-          ref={scrollRef}
-          {...(sp ? {} : events)}
-          className="hide-scrollbar-x swiper-no-swiping"
-          style={{
-            display: 'flex',
-            gap: 8,
-            overflowX: loading ? 'hidden' : 'auto',
-            paddingBottom: 2,
-            cursor: sp ? 'auto' : 'grab',
-            scrollbarWidth: 'none',
-          }}
-        >
-          {loading
-            ? SKELETON_CHIP_WIDTHS.map((w, i) => (
-                <Skeleton
-                  key={i}
-                  variant="rounded"
-                  width={w}
-                  height={32}
-                  aria-hidden="true"
-                  sx={{ flex: '0 0 auto', borderRadius: '99px' }}
-                />
-              ))
-            : themes.map((theme, i) => (
-                <Chip
-                  key={`${theme.slug}-${i}`}
-                  component="a"
-                  href={recommendHref(theme.slug)}
-                  label={theme.name}
-                  clickable
-                  draggable={false}
-                  className="openchat-item-header-chip category theme-link"
-                  sx={{ flexShrink: 0 }}
-                />
-              ))}
-        </div>
-        {!loading && isRightScrollable && (
-          <div
-            aria-hidden="true"
-            style={{
-              position: 'absolute',
-              top: 0,
-              right: 0,
-              height: '100%',
-              width: 36,
-              pointerEvents: 'none',
-              background: 'linear-gradient(270deg, var(--c-bg) 35%, var(--c-bg-fade-end) 100%)',
-            }}
-          />
-        )}
+      <div
+        ref={scrollRef}
+        {...(sp ? {} : events)}
+        className="hide-scrollbar-x swiper-no-swiping"
+        style={{
+          display: 'flex',
+          gap: 8,
+          overflowX: loading ? 'hidden' : 'auto',
+          paddingBottom: 2,
+          cursor: sp ? 'auto' : 'grab',
+          scrollbarWidth: 'none',
+          // 右端フェード（CSSのみ・JS状態に依存しないのでちらつかない）。
+          maskImage: RIGHT_FADE_MASK,
+          WebkitMaskImage: RIGHT_FADE_MASK,
+        }}
+      >
+        {loading
+          ? SKELETON_CHIP_WIDTHS.map((w, i) => (
+              <Skeleton
+                key={i}
+                variant="rounded"
+                width={w}
+                height={32}
+                aria-hidden="true"
+                sx={{ flex: '0 0 auto', borderRadius: '99px' }}
+              />
+            ))
+          : themes.map((theme, i) => (
+              <Chip
+                key={`${theme.slug}-${i}`}
+                component="a"
+                href={recommendHref(theme.slug)}
+                label={theme.name}
+                clickable
+                draggable={false}
+                className="openchat-item-header-chip category theme-link"
+                sx={{ flexShrink: 0 }}
+              />
+            ))}
       </div>
     </section>
   )


### PR DESCRIPTION
stg の #549 を本番(main)へ昇格。

ランキングのカテゴリ切替で「関連テーマ」右端の黒フェードが一瞬消えて戻る（ちらつく）問題の根治。右端フェードを JS実測（isRightScrollable）から CSS の mask-image に変更し、JS状態に依存させないことで構造的にちらつかないようにした。

stg PR: #549（base=main / head=stg）

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
