### PR TITLE
[STG] fix: デプロイのX自動投稿が変数名で失敗する不具合を修正（cashtag無効化）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -320,13 +320,17 @@ jobs:
                 }
               }
 
+              // X は "$WORD" を cashtag ($SYMBOL) と解釈し「1投稿につき1つまで」の制限で 403 になる。
+              // PR 本文/タイトルに PHP 変数名 ($foo, $_bar) 等が複数あると弾かれるため、
+              // "$" + 英字/アンダースコア を全角 "＄" に置換して cashtag を無効化する (文字数は不変)。
+              const neutralizeCashtags = (s) => s.replace(/\$(?=[A-Za-z_])/g, '＄');
               const message = head + bodySection + urlSuffix;
 
               // X Premium 前提でフル本文を送信。文字数超過で X に拒否された場合のみ
               // head + 区切り + 切り詰め本文 で再送する。
               let tweet;
               try {
-                tweet = await client.v2.tweet(message);
+                tweet = await client.v2.tweet(neutralizeCashtags(message));
               } catch (err) {
                 const errCodes = (err && err.data && err.data.errors) ? err.data.errors.map(e => e.code) : [];
                 const tooLong = errCodes.includes(186) || /too long|character limit/i.test((err && err.message) || '');
@@ -338,7 +342,7 @@ jobs:
                 const limit = 280; // X 拒否時のフォールバック上限
                 const truncatedBody = prBody.slice(0, Math.max(0, limit - baseLen - 1)) + '…';
                 const fallback = head + (truncatedBody.length > 1 ? '\n---\n' + truncatedBody : '') + urlSuffix;
-                tweet = await client.v2.tweet(fallback);
+                tweet = await client.v2.tweet(neutralizeCashtags(fallback));
               }
               console.log('Tweet posted: ' + tweet.data.id);
 


### PR DESCRIPTION
## 何をするか

PRマージ後にXへ自動投稿するデプロイ処理で、PR本文やタイトルにコードの変数名（ドル記号始まりの語）が複数含まれると、Xがそれを「キャッシュタグ」と解釈し、「1投稿につき1つまで」の制限で投稿が 403 で失敗していました（直前の本番デプロイの直前まで実際に発生）。

デプロイ本体は成功してもこの最後の投稿ステップでワークフローが赤くなるため、**投稿直前にドル記号始まりの語（英字・アンダースコア始まり）を全角ドルに置換してキャッシュタグを無効化**します。文字数は不変で、価格表記のドル＋数字や正規表現の後方参照（ドル＋数字）は対象外なので温存されます。

## 変更

- `.github/workflows/deploy.yml` の X 投稿スクリプト（post-pr-merge.js）に neutralizeCashtags を追加し、本送信・フォールバック送信の両方に適用。

## 確認

- YAML 妥当性 OK
- 抽出したスクリプトの node --check OK
- 実際の変数名トークンで「英字キャッシュタグ残存ゼロ」、価格・後方参照は温存されることを確認

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`
