### PR TITLE
[PROD] fix: デプロイのX自動投稿が変数名で失敗する不具合を修正（cashtag無効化）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -320,13 +320,17 @@ jobs:
                 }
               }
 
+              // X は "$WORD" を cashtag ($SYMBOL) と解釈し「1投稿につき1つまで」の制限で 403 になる。
+              // PR 本文/タイトルに PHP 変数名 ($foo, $_bar) 等が複数あると弾かれるため、
+              // "$" + 英字/アンダースコア を全角 "＄" に置換して cashtag を無効化する (文字数は不変)。
+              const neutralizeCashtags = (s) => s.replace(/\$(?=[A-Za-z_])/g, '＄');
               const message = head + bodySection + urlSuffix;
 
               // X Premium 前提でフル本文を送信。文字数超過で X に拒否された場合のみ
               // head + 区切り + 切り詰め本文 で再送する。
               let tweet;
               try {
-                tweet = await client.v2.tweet(message);
+                tweet = await client.v2.tweet(neutralizeCashtags(message));
               } catch (err) {
                 const errCodes = (err && err.data && err.data.errors) ? err.data.errors.map(e => e.code) : [];
                 const tooLong = errCodes.includes(186) || /too long|character limit/i.test((err && err.message) || '');
@@ -338,7 +342,7 @@ jobs:
                 const limit = 280; // X 拒否時のフォールバック上限
                 const truncatedBody = prBody.slice(0, Math.max(0, limit - baseLen - 1)) + '…';
                 const fallback = head + (truncatedBody.length > 1 ? '\n---\n' + truncatedBody : '') + urlSuffix;
-                tweet = await client.v2.tweet(fallback);
+                tweet = await client.v2.tweet(neutralizeCashtags(fallback));
               }
               console.log('Tweet posted: ' + tweet.data.id);
 


### PR DESCRIPTION
## 本番へ反映する内容

PRマージ後にXへ自動投稿するデプロイ処理の不具合修正を本番へ反映します。

PR本文やタイトルにコードの変数名（ドル記号始まりの語）が複数含まれると、Xがそれを「キャッシュタグ」と解釈し「1投稿につき1つまで」の制限で投稿が失敗していました。デプロイ本体は成功しても最後の投稿ステップでワークフローが赤くなるため、投稿直前にドル記号始まりの語を全角ドルへ置換して無効化します（文字数は不変、価格や正規表現の後方参照は温存）。

stg で実デプロイ＋X投稿成功を確認済み。詳細は PR #551 を参照。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`
