### PR TITLE
[PROD] ランキングのカテゴリタブをスワイプで中央表示にし、切替時のちらつきも解消

### DIFF
--- a/frontend/ranking/src/components/CategoryTabsBar.tsx
+++ b/frontend/ranking/src/components/CategoryTabsBar.tsx
@@ -1,0 +1,142 @@
+import { memo, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { basePath, OPEN_CHAT_CATEGORY } from '../config/config'
+import { samePageLinkNavi } from '../utils/utils'
+import { t } from '../config/translation'
+
+const INDICATOR_TRANSITION =
+  'left 260ms cubic-bezier(0.4, 0, 0.2, 1), width 260ms cubic-bezier(0.4, 0, 0.2, 1)'
+
+// MUI の Tab と同じフォント（テーマで typography.fontFamily を上書きしていないので MUI 既定値）。
+// 指定しないと素の <a> が body 継承に失敗して Safari で明朝体になる／MUI と字面がズレる。
+const TAB_FONT_FAMILY = '"Roboto", "Helvetica", "Arial", sans-serif'
+
+/**
+ * カテゴリタブバー（自前実装）。MUI の Tabs を使わず、横スクロールと下線インジケータを自前で持つ。
+ * これで「アクティブタブを中央寄せ」をスムーズかつ確実に実現する（MUI Tabs の scrollSelectedIntoView は
+ * 選択タブを端ギリギリまでしか寄せず、かつ自前のスムーズ中央寄せと競合して幅広タブが右に張り付いたり
+ * 下線がズレたりする。自前なら競合しない）。
+ * - タブは本物の <a href>（SEO / 送客）。同一ページ遷移はクリックを奪って Swiper を slideTo する。
+ * - cateIndex が変わるたび: 下線を選択タブへスライド（CSS transition）＋コンテナを rAF でスムーズに
+ *   中央へスクロール。下線はスクロール内容と一緒に動くので選択タブの真下に追従する。
+ * - 見た目は従来の MUI 版に合わせる（太字・選択は --c-text-1 / 非選択は --c-text-4・下線 2px）。
+ */
+const CategoryTabsBar = memo(function CategoryTabsBar({
+  cateIndex,
+  onSelect,
+}: {
+  cateIndex: number
+  onSelect: (index: number) => void
+}) {
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const tabRefs = useRef<(HTMLAnchorElement | null)[]>([])
+  const mountedRef = useRef(false)
+  const rafRef = useRef(0)
+  const [indicator, setIndicator] = useState({ left: 0, width: 0, animate: false })
+
+  useLayoutEffect(() => {
+    const scroller = scrollerRef.current
+    const tab = tabRefs.current[cateIndex]
+    if (!scroller || !tab) return
+
+    // 下線を選択タブへ（content 座標）。初回はアニメさせない。
+    setIndicator({ left: tab.offsetLeft, width: tab.offsetWidth, animate: mountedRef.current })
+
+    // 選択タブが中央に来る scrollLeft（端は越えないよう clamp）。
+    const max = scroller.scrollWidth - scroller.clientWidth
+    const target = Math.max(
+      0,
+      Math.min(max, tab.offsetLeft + tab.offsetWidth / 2 - scroller.clientWidth / 2)
+    )
+
+    // 初回（ページ読み込み時）はアニメ無しで即中央へ。
+    if (!mountedRef.current) {
+      mountedRef.current = true
+      scroller.scrollLeft = target
+      return
+    }
+
+    cancelAnimationFrame(rafRef.current)
+    const from = scroller.scrollLeft
+    if (Math.abs(target - from) < 1) return
+
+    const duration = 300
+    const easeOutCubic = (p: number) => 1 - Math.pow(1 - p, 3)
+    let start = 0
+    const step = (ts: number) => {
+      if (!start) start = ts
+      const p = Math.min(1, (ts - start) / duration)
+      scroller.scrollLeft = from + (target - from) * easeOutCubic(p)
+      if (p < 1) rafRef.current = requestAnimationFrame(step)
+    }
+    rafRef.current = requestAnimationFrame(step)
+  }, [cateIndex])
+
+  useEffect(() => () => cancelAnimationFrame(rafRef.current), [])
+
+  return (
+    <div
+      ref={scrollerRef}
+      className="hide-scrollbar-x category-tab"
+      role="tablist"
+      aria-label={t('オープンチャットのカテゴリータブ')}
+      style={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'stretch',
+        minHeight: 39,
+        borderBottom: '1px solid var(--c-border)',
+        WebkitOverflowScrolling: 'touch',
+      }}
+    >
+      {OPEN_CHAT_CATEGORY.map((el, i) => {
+        const selected = i === cateIndex
+        return (
+          <a
+            key={i}
+            ref={(node) => {
+              tabRefs.current[i] = node
+            }}
+            role="tab"
+            aria-selected={selected}
+            href={`/${basePath}${el[1] ? '/' + el[1] : ''}`}
+            onClick={(e) => {
+              if (samePageLinkNavi(e)) {
+                e.preventDefault()
+                onSelect(i)
+              }
+            }}
+            style={{
+              flex: '0 0 auto',
+              display: 'flex',
+              alignItems: 'center',
+              padding: '0 16px',
+              fontFamily: TAB_FONT_FAMILY,
+              fontSize: '0.875rem',
+              fontWeight: 700,
+              whiteSpace: 'nowrap',
+              textDecoration: 'none',
+              userSelect: 'none',
+              color: selected ? 'var(--c-text-1)' : 'var(--c-text-4)',
+            }}
+          >
+            {el[0]}
+          </a>
+        )
+      })}
+      <span
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          height: 2,
+          left: indicator.left,
+          width: indicator.width,
+          background: 'var(--c-text-1)',
+          transition: indicator.animate ? INDICATOR_TRANSITION : 'none',
+        }}
+      />
+    </div>
+  )
+})
+
+export default CategoryTabsBar

--- a/frontend/ranking/src/components/FetchOpenChatRankingList.tsx
+++ b/frontend/ranking/src/components/FetchOpenChatRankingList.tsx
@@ -163,9 +163,13 @@ const ListTitleDesc = memo(OCListTitleDesc)
 export function DummyOpenChatRankingList({
   query,
   cateIndex,
+  shelf,
 }: {
   query: string
   cateIndex: number
+  // 関連テーマ棚。絶対配置コンテナの中（リストの上）に入れて、スクロール中スワイプでも棚の高さ分
+  // リストを押し下げず、棚もリストと一緒に正しい位置へ来るようにする。
+  shelf?: React.ReactNode
 }) {
   const params = useAtomValue(listParamsState)
 
@@ -175,6 +179,7 @@ export function DummyOpenChatRankingList({
         className="div-fetchOpenChatRankingList"
         style={{ position: 'absolute', top: `${window.scrollY}px`, width: '100%' }}
       >
+        {shelf}
         <ListTitleDesc
           cateIndex={cateIndex}
           isSearch={!!params.keyword}

--- a/frontend/ranking/src/components/OcListMainTabs.tsx
+++ b/frontend/ranking/src/components/OcListMainTabs.tsx
@@ -1,40 +1,20 @@
 import { basePath, OPEN_CHAT_CATEGORY } from '../config/config'
 import React, { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Box, Tabs, Tab } from '@mui/material'
+import { Box } from '@mui/material'
 import { type Swiper as SwiperCore } from 'swiper'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import 'swiper/css'
 import FetchOpenChatRankingList, { DummyOpenChatRankingList } from './FetchOpenChatRankingList'
-import {
-  isSP,
-  samePageLinkNavi,
-  scrollToTop,
-  setTitle,
-  updateURLSearchParams,
-} from '../utils/utils'
+import { scrollToTop, setTitle, updateURLSearchParams } from '../utils/utils'
 import { CategoryListAppBar } from './CategoryListAppBar'
 import { listParamsState } from '../store/atom'
 import { useAtom } from 'jotai'
 import SiteHeader from './SiteHeader'
 import { useInView } from 'react-intersection-observer'
-import { t } from '../config/translation'
 import RecommendThemeShelf from './RecommendThemeShelf'
+import CategoryTabsBar from './CategoryTabsBar'
 import { trackEvent } from '../utils/track'
-
-function LinkTab(props: { label?: string; href?: string }) {
-  return (
-    <Tab
-      component="a"
-      onClick={(e: LinkEvent) => {
-        if (samePageLinkNavi(e)) {
-          e.preventDefault()
-        }
-      }}
-      {...props}
-    />
-  )
-}
 
 const OpenChatRankingList = memo(FetchOpenChatRankingList)
 
@@ -120,7 +100,7 @@ function OcListSwiper({
       onSwiper={onSwiper}
       speed={260}
     >
-      {OPEN_CHAT_CATEGORY.map((el, i) => (
+      {OPEN_CHAT_CATEGORY.map((_el, i) => (
         <SwiperSlide key={i}>
           <div
             style={{
@@ -138,36 +118,51 @@ function OcListSwiper({
               const isActive = i === cateIndex
               const isTransition = !!tIndex && i === tIndex[0]
 
-              // 棚は inView に関係なく隣接スライド(±1)にも常時マウントして先に取得・計測まで済ませる。
-              // こうするとスワイプで入った瞬間に再マウントせず、チップも右端フェードもそのまま見える。
-              // （inView ゲートのままだと隣スライドの棚が未マウント→スワイプ時に新規取得でスケルトンに
-              //   なり、右端フェードが一瞬消えて戻る／一覧がガタつく原因になる）。
-              const showShelf = isActive || isTransition || i === cateIndex - 1 || i === cateIndex + 1
-
-              // リストは従来どおり inView のときだけ（全カテゴリ分を同時描画しない）。
-              const isPrev = !tIndex && prevInView && i === cateIndex - 1
-              const isNext = !tIndex && nextInView && i === cateIndex + 1
+              // リストは inView の隣接スライドだけ描画（全カテゴリ同時描画は避ける）。
+              // ここで tIndex(遷移中)をゲートに入れない: 入れると、スワイプ開始(transitionStart)で
+              // tIndex がセットされた瞬間に「入ってくる側スライド」のダミーが消える一方、まだ cateIndex は
+              // 更新されておらず active にもならないため、可視スライドが1フレーム“リスト無し”になって
+              // チラつく。遷移中もダミーを保持して空フレームを無くす。
+              const isPrev = prevInView && i === cateIndex - 1
+              const isNext = nextInView && i === cateIndex + 1
               const showList = isActive || isTransition || isPrev || isNext
+              if (!showList) return null
 
-              if (!showShelf && !showList) return null
+              // 関連テーマ棚はリストと一緒に出す。
+              // - active / 遷移中: 通常フロー（リストの上）。リストごと縦スクロールする。
+              // - ダミー（隣接スライド）: ダミーリストは絶対配置(top:scrollY)なので、棚を通常フローに
+              //   置くと棚の高さ分だけダミーリストを押し下げてマージン過多になり、棚自身もスクロールで
+              //   画面外へ消える（スクロール中スワイプの不具合）。棚をダミーの絶対配置コンテナ内に入れ、
+              //   リストと一緒に正しい位置へ置く。
+              const shelf = (
+                <RecommendThemeShelf
+                  category={OPEN_CHAT_CATEGORY[i][1]}
+                  subCategory={isActive ? params.sub_category : ''}
+                />
+              )
 
+              if (isActive) {
+                return (
+                  <>
+                    {shelf}
+                    <OpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
+                  </>
+                )
+              }
+              if (isTransition && tIndex) {
+                return (
+                  <>
+                    {shelf}
+                    <OpenChatRankingList query={tIndex[1]} cateIndex={i} />
+                  </>
+                )
+              }
               return (
-                <>
-                  {showShelf && (
-                    <RecommendThemeShelf
-                      category={OPEN_CHAT_CATEGORY[i][1]}
-                      subCategory={isActive ? params.sub_category : ''}
-                    />
-                  )}
-                  {showList &&
-                    (isActive ? (
-                      <OpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
-                    ) : isTransition && tIndex ? (
-                      <OpenChatRankingList query={tIndex[1]} cateIndex={i} />
-                    ) : (
-                      <DummyOpenChatRankingList query={getQuery(i, cateIndex, params)} cateIndex={i} />
-                    ))}
-                </>
+                <DummyOpenChatRankingList
+                  query={getQuery(i, cateIndex, params)}
+                  cateIndex={i}
+                  shelf={shelf}
+                />
               )
             })()}
             {i === cateIndex && (
@@ -198,9 +193,8 @@ function OcListSwiper({
 export default function OcListMainTabs({ cateIndex }: { cateIndex: number }) {
   const swiperRef = useRef<SwiperCore | null>(null)
 
-  const handleChange = useCallback((e: React.SyntheticEvent, newValue: number) => {
-    if (e.type === 'click' && !samePageLinkNavi(e as LinkEvent)) return
-    swiperRef.current?.slideTo(newValue)
+  const handleSelectCategory = useCallback((index: number) => {
+    swiperRef.current?.slideTo(index)
   }, [])
 
   const siperSlideTo = (index: number): void => {
@@ -210,20 +204,7 @@ export default function OcListMainTabs({ cateIndex }: { cateIndex: number }) {
   return (
     <Box>
       <SiteHeader siperSlideTo={siperSlideTo} height="78px">
-        <Tabs
-          className="fix-min-width category-tab"
-          value={cateIndex}
-          onChange={handleChange}
-          variant="scrollable"
-          scrollButtons={true}
-          allowScrollButtonsMobile={!isSP()}
-          aria-label={t('オープンチャットのカテゴリータブ')}
-          sx={{ borderBottom: 1, borderColor: 'divider' }}
-        >
-          {OPEN_CHAT_CATEGORY.map((el, i) => (
-            <LinkTab label={el[0]} href={`/${basePath}${el[1] ? '/' + el[1] : ''}`} key={i} />
-          ))}
-        </Tabs>
+        <CategoryTabsBar cateIndex={cateIndex} onSelect={handleSelectCategory} />
       </SiteHeader>
       <CategoryListAppBar />
       <OcListSwiper cateIndex={cateIndex} swiperRef={swiperRef} />


### PR DESCRIPTION
stg の #553 を本番(main)へ昇格。

ランキングのカテゴリ切替を公式アプリ風に改善: アクティブなカテゴリタブを中央へスムーズにスクロール（幅広タブも中央／下線ピッタリ）、Safariでの明朝体フォールバック解消、スワイプ切替時の一覧の黒いちらつき解消、スクロール中スワイプで関連テーマが出ない／余白過剰の修正。

stg PR: #553（base=main / head=stg）

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
