### PR TITLE
[STG] skip-ci: スワイプ中の隣スライドで関連テーマのフォントがズレる問題を修正

### DIFF
--- a/frontend/ranking/src/components/FetchOpenChatRankingList.tsx
+++ b/frontend/ranking/src/components/FetchOpenChatRankingList.tsx
@@ -175,18 +175,21 @@ export function DummyOpenChatRankingList({
 
   return (
     <div className="dummy-list" style={{ position: 'relative' }}>
-      <div
-        className="div-fetchOpenChatRankingList"
-        style={{ position: 'absolute', top: `${window.scrollY}px`, width: '100%' }}
-      >
+      {/* 絶対配置のラッパに「棚」と「リスト」を縦に並べる。棚を .div-fetchOpenChatRankingList の中に
+          入れると、`.div-fetchOpenChatRankingList * { font-family }`(OpenChatList.css)で棚のフォントが
+          上書きされ、通常フローのアクティブ側の棚（var(--font-family)）と字面/サイズがズレる（iOSで顕著・
+          切替直後にガタつく）。棚はこのセレクタの外＝ラッパ直下に置き、アクティブ側と同じフォントにする。 */}
+      <div style={{ position: 'absolute', top: `${window.scrollY}px`, width: '100%' }}>
         {shelf}
-        <ListTitleDesc
-          cateIndex={cateIndex}
-          isSearch={!!params.keyword}
-          list={params.list}
-          visibility={false}
-        />
-        <FetchDummyList cateIndex={cateIndex} query={query} />
+        <div className="div-fetchOpenChatRankingList">
+          <ListTitleDesc
+            cateIndex={cateIndex}
+            isSearch={!!params.keyword}
+            list={params.list}
+            visibility={false}
+          />
+          <FetchDummyList cateIndex={cateIndex} query={query} />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
スワイプ中の隣スライド（ダミー）で関連テーマのフォント／サイズがズレ、切替直後に下にズレる問題を修正（iOSで顕著）。

## 原因
直前の修正でダミーの関連テーマ棚を `.div-fetchOpenChatRankingList` の中に入れたが、このセレクタには `.div-fetchOpenChatRankingList * { font-family: ... }`（OpenChatList.css）があり、ダミーの棚だけフォントが上書きされていた。アクティブ側の棚はこのセレクタの外で `var(--font-family)` 系。日本語グリフのメトリクス差でスワイプ中の隣スライドの棚がサイズ違いに見え、切替直後に高さが変わって下にズレていた。

## 対処
ダミーでも棚を絶対配置ラッパ直下（= `.div-fetchOpenChatRankingList` の外）に置き、アクティブ側と同じフォントに統一。リスト本体だけがそのセレクタ内に残る。スクロール中スワイプの位置合わせ（top: scrollY）はラッパに移して維持。

実機（iOS）で修正を確認済み。型・lint・テスト24件・ビルドOK。

skip-ci: PHP非変更（ランキングのフロント TSX のみ）。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
