### PR TITLE
[PROD] スワイプ中の隣スライドで関連テーマのフォントがズレる問題を修正

### DIFF
--- a/frontend/ranking/src/components/FetchOpenChatRankingList.tsx
+++ b/frontend/ranking/src/components/FetchOpenChatRankingList.tsx
@@ -175,18 +175,21 @@ export function DummyOpenChatRankingList({
 
   return (
     <div className="dummy-list" style={{ position: 'relative' }}>
-      <div
-        className="div-fetchOpenChatRankingList"
-        style={{ position: 'absolute', top: `${window.scrollY}px`, width: '100%' }}
-      >
+      {/* 絶対配置のラッパに「棚」と「リスト」を縦に並べる。棚を .div-fetchOpenChatRankingList の中に
+          入れると、`.div-fetchOpenChatRankingList * { font-family }`(OpenChatList.css)で棚のフォントが
+          上書きされ、通常フローのアクティブ側の棚（var(--font-family)）と字面/サイズがズレる（iOSで顕著・
+          切替直後にガタつく）。棚はこのセレクタの外＝ラッパ直下に置き、アクティブ側と同じフォントにする。 */}
+      <div style={{ position: 'absolute', top: `${window.scrollY}px`, width: '100%' }}>
         {shelf}
-        <ListTitleDesc
-          cateIndex={cateIndex}
-          isSearch={!!params.keyword}
-          list={params.list}
-          visibility={false}
-        />
-        <FetchDummyList cateIndex={cateIndex} query={query} />
+        <div className="div-fetchOpenChatRankingList">
+          <ListTitleDesc
+            cateIndex={cateIndex}
+            isSearch={!!params.keyword}
+            list={params.list}
+            visibility={false}
+          />
+          <FetchDummyList cateIndex={cateIndex} query={query} />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
stg の #555 を本番(main)へ昇格。

スワイプ中の隣スライド（ダミー）で関連テーマのフォント／サイズがズレ、切替直後に下にズレる問題を修正（iOSで顕著）。直前のデプロイ(#554)で棚を .div-fetchOpenChatRankingList の中に入れた際、`* { font-family }` ルールで棚のフォントだけ上書きされていたのが原因。棚をそのセレクタの外に出してアクティブ側と統一。

stg PR: #555（base=main / head=stg）

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
