### PR TITLE
[STG] 公式ランキング掲載分析ページの深いページ巡回で本番DBが過負荷になる問題を修正

### DIFF
--- a/app/Controllers/Pages/RankingBanLabsPageController.php
+++ b/app/Controllers/Pages/RankingBanLabsPageController.php
@@ -86,7 +86,9 @@ class RankingBanLabsPageController
         string $until,
         string $items
     ): ViewInterface|false {
-        header('X-Robots-Tag: noindex');
+        // noindex: フラグメント自体は検索結果に出さない。nofollow: ページャの深いページリンクを
+        // クローラに辿らせない（cf.client.bot はCFヘッダゲートを通れるため、深いOFFSETの巡回を抑止）
+        header('X-Robots-Tag: noindex, nofollow');
 
         $since = $this->validDate($since);
         $until = $this->validDate($until);

--- a/app/Services/RankingBan/RakingBanPageService.php
+++ b/app/Services/RankingBan/RakingBanPageService.php
@@ -12,6 +12,16 @@ class RakingBanPageService
 {
     use TraitPaginationRecordsCalculator;
 
+    /**
+     * ページ番号の上限。深い OFFSET は ranking_ban(open_chat との JOIN＋計算式 ORDER BY による
+     * 全件 filesort)を数十秒に膨らませ、本番 DB を飽和させた(2026-06-24 障害。クローラが
+     * page=962〜2372 を深掘り巡回し MySQL が gone away を多発)。実利用で必要な範囲を十分に
+     * 超えるこのページ数で頭打ちにし、超過は範囲外(null→コントローラが404→フロントが1ページ目へ
+     * 復帰)として重いクエリ自体を実行しない。CF ヘッダゲート(一次対策)に対する多層防御で、
+     * cf.client.bot(Googlebot 等)はゲートを通れるためコード側でも最悪値を bound する。
+     */
+    private const MAX_PAGE_NUMBER = 100;
+
     public function __construct(
         private RankingBanPageRepository $rankingBanPageRepository
     ) {
@@ -30,11 +40,16 @@ class RakingBanPageService
      */
     public function getAllOrderByDateTime(int $change, int $publish, int $percent, string $keyword, int $pageNumber, int $limit, string $since = '', string $until = '', int $dmin = 0, int $dmax = 0, string $now = '', array $items = []): ?RankingBanPageDto
     {
+        // 上限を超える深いページは件数取得すら走らせず範囲外として返す（重い OFFSET から DB を守る）
+        if ($pageNumber > self::MAX_PAGE_NUMBER) {
+            return null;
+        }
+
         $labelArray = $this->rankingBanPageRepository->findAllDatetimeColumn($change, $publish, $percent, $keyword, $since, $until, $dmin, $dmax, $now, $items);
 
-        // ページの最大数を取得する
+        // ページの最大数を取得する（実データの最大ページと上限の小さい方で頭打ち）
         $totalRecords = count($labelArray);
-        $maxPageNumber = $this->calcMaxPages($totalRecords, $limit);
+        $maxPageNumber = min($this->calcMaxPages($totalRecords, $limit), self::MAX_PAGE_NUMBER);
         if ($pageNumber > $maxPageNumber) {
             // 現在のページ番号が最大ページ番号を超えている場合
             return null;


### PR DESCRIPTION
## 問題の概要

本日 2026-06-24 早朝、本番の MySQL が「server has gone away」を大量に出し、サイト全体が断続的に 503 になりました（ホスト load average 120 超、MySQL の同時実行クエリ 38）。

### 具体的な問題

Google のクローラ（GoogleOther）が「公式ランキング掲載の分析」ページ（`/labs/publication-analytics`）の一覧を `page=962`〜`2372` と深いページまで次々に巡回していました。一覧データは次の重いクエリで、深いページほど致命的に遅くなります（1本あたり60〜100秒）:

- `ranking_ban`（約237万行）× `open_chat` を JOIN
- 並び順が計算式（`GREATEST(...)`）のため索引が効かず、毎回フィルタ後の全件を filesort
- `LIMIT (page-1)*200, 200` の深い OFFSET（`page=2372` で約47万行を走査して大半を破棄）

これが多数並列で走り、本番DBが飽和。無関係なリクエストの接続まで切られ「server has gone away」が連鎖しました。最近のデプロイ（フロントのみ）・DB再起動・接続数上限のいずれでもなく、純粋なクエリ飽和です。

## 一次対策（実施済み・Cloudflare）

裏の非同期データ取得 `/labs/publication-analytics/list` を、既存の `X-Ocg-Client` ヘッダゲート（`/oclist` 等と同じ仕組み）に載せました。サイト内のJS（[`ranking_ban_content.php`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Views/ranking_ban_content.php) の fetch）は `X-Ocg-Client` を送るので初回訪問者も通り、ヘッダ無しの直叩きクローラは edge で 403。本体ページはインデックス可・OGP可のまま。反映後に発生は停止しました。

## このPRの対処（コード側の多層防御）

`cf.client.bot`（Googlebot 等の検証済みbot）はヘッダゲートを通れるため、コード側でも最悪値を抑えます。

- 一覧の上限を 100 ページに制限（[`RakingBanPageService`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Services/RankingBan/RakingBanPageService.php)）。超過は範囲外として件数取得すら走らせず `null` を返し、コントローラが 404 → フロントは既存処理で1ページ目へ復帰。
- 非同期フラグメントの `X-Robots-Tag` を `noindex, nofollow` に変更（[`RankingBanLabsPageController::fragment`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/stg/app/Controllers/Pages/RankingBanLabsPageController.php)）。クローラがページャの深いリンクを辿らないようにする。

本体ページ `/labs/publication-analytics` の表示・インデックス・OGP・初回読み込みは不変です。

## 確認

- PHPStan: エラーなし
- ローカル（本番データ共有）: `page=101` → 404（重いクエリ未実行）/ `page=100`・`page=1` → 200

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
