### PR TITLE
[PROD] perf: 公式ランキング掲載分析ページの一覧表示を高速化（重い条件で約10〜100倍）

### DIFF
--- a/app/Controllers/Pages/RankingBanLabsPageController.php
+++ b/app/Controllers/Pages/RankingBanLabsPageController.php
@@ -121,12 +121,14 @@ class RankingBanLabsPageController
         if ($rankingBanData === null) {
             $totalRecords = 0;
             $maxPageNumber = 0;
+            $hasMore = false;
             return view(
                 'components/ranking_ban_results',
                 compact(
                     '_now',
                     'totalRecords',
                     'maxPageNumber',
+                    'hasMore',
                     'page',
                     'titleValue',
                     'percent',
@@ -138,18 +140,19 @@ class RankingBanLabsPageController
 
         $totalRecords = $rankingBanData->totalRecords;
         $maxPageNumber = $rankingBanData->maxPageNumber;
+        $hasMore = $rankingBanData->hasMore;
         $path = 'labs/publication-analytics';
         // クエリ順は JS 側 buildQuery と同一に保つ（CDNキャッシュキーの分裂防止）
         $params = compact('change', 'items', 'publish', 'percent', 'keyword', 'since', 'until', 'dmin', 'dmax');
 
+        // labelArray は降順（新しい順）のまま渡す（ページャ側が降順前提でインデックスする）
         [$title, $_select, $_label] = $rankingBanSelectElementPagination->geneSelectElementPagerAsc(
             $path,
             $params,
             $page,
-            $totalRecords,
             $limit,
             $maxPageNumber,
-            array_reverse($rankingBanData->labelArray)
+            $rankingBanData->labelArray
         );
 
         $openChatList = $rankingBanData->openChatList;
@@ -170,6 +173,7 @@ class RankingBanLabsPageController
                 '_pagerNavArg',
                 'totalRecords',
                 'maxPageNumber',
+                'hasMore',
                 'page',
                 'titleValue',
             )

--- a/app/Models/RankingBanRepositories/RankingBanPageRepository.php
+++ b/app/Models/RankingBanRepositories/RankingBanPageRepository.php
@@ -8,6 +8,50 @@ use App\Models\Repositories\DB;
 
 class RankingBanPageRepository
 {
+    /** ソートキー生成列 sort_datetime の索引が存在するか（ワーカー単位で1度だけ確認しキャッシュ） */
+    private static ?bool $hasSortIndex = null;
+
+    /**
+     * 重い ORDER BY（IFNULL(GREATEST(datetime, end_datetime), datetime)）を索引で満たすための
+     * 生成列＋索引 idx_rb_sortdt が存在するか。存在すれば高速パス（FORCE INDEX で filesort 回避）を、
+     * 無ければ従来の式 ORDER BY（filesort）にフォールバックする。
+     * これによりデプロイ中（列追加済み・索引未構築）や索引構築失敗時でもクエリは壊れない（退行のみ）。
+     */
+    private function hasSortDatetimeIndex(): bool
+    {
+        if (self::$hasSortIndex !== null) return self::$hasSortIndex;
+        try {
+            $stmt = DB::execute(
+                "SELECT 1 FROM information_schema.STATISTICS"
+                    . " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ranking_ban' AND INDEX_NAME = 'idx_rb_sortdt' LIMIT 1"
+            );
+            return self::$hasSortIndex = (bool) $stmt->fetchColumn();
+        } catch (\Throwable $e) {
+            return self::$hasSortIndex = false; // 確認できないときは安全側（従来パス）
+        }
+    }
+
+    /**
+     * 生成列の索引(sort_datetime, member)で並べ替える高速パスを使えるか。
+     *
+     * この索引順の走査＋早期終了（LIMIT で打ち切り）は最悪でも索引を1周（約3.4秒・実測）で頭打ち。
+     * percentage/期間/変更内容などで絞り込んでも、一致が多い限り LIMIT で早く止まり 0.1〜1.6秒に収まる。
+     * よって従来の全件 filesort（順位%や期間指定で 17〜19秒）より常に速い —— ただし1つだけ例外がある。
+     *
+     * 例外＝日付範囲(since/until)。古い狭い窓に一致が少数だけ散在すると、LIMIT に達せず索引末尾まで
+     * 空振り走査してしまい、小さくなった集合を filesort する従来パス(約1.3秒)より遅くなる(約3.4秒)。
+     * そのため日付範囲が指定されたときだけ従来パスに任せる。
+     *
+     * キーワード検索は別経路(LIKE)・publish 1(未掲載のみ＝小集合で既存索引が速い)も対象外。
+     */
+    private function useSortDatetimeFastPath(int $publish, string $keyword, string $since, string $until): bool
+    {
+        return $keyword === ''
+            && $since === '' && $until === ''
+            && ($publish === 0 || $publish === 2)
+            && $this->hasSortDatetimeIndex();
+    }
+
     /**
      * @param int $publish 0:掲載中のみ, 1:未掲載のみ, 2:すべて
      * @param int $change 0:内容変更ありのみ, 1:変更なしのみ, 2:すべて
@@ -31,8 +75,17 @@ class RankingBanPageRepository
             . $this->buildDurationClause($dmin, $dmax, $now, $durationParams)
             . $this->buildItemsClause($items, $itemsParams);
 
+        // 高速パス: 生成列 sort_datetime の索引で並べ替える（filesort を避け、LIMIT で早期終了）。
+        // rb を先頭駆動にするため STRAIGHT_JOIN、ソート索引を確実に使うため FORCE INDEX を付ける。
+        $fast = $this->useSortDatetimeFastPath($publish, $keyword, $since, $until);
+        $straightJoin = $fast ? 'STRAIGHT_JOIN' : '';
+        $forceIndex = $fast ? 'FORCE INDEX (idx_rb_sortdt)' : '';
+        $orderBy = $fast
+            ? 'rb.sort_datetime DESC, rb.member DESC, rb.id DESC'
+            : 'IFNULL(GREATEST(rb.datetime, rb.end_datetime), rb.datetime) DESC, oc.member DESC';
+
         $query = fn ($like) =>
-        "SELECT
+        "SELECT {$straightJoin}
             oc.id,
             oc.name,
             oc.description,
@@ -49,13 +102,12 @@ class RankingBanPageRepository
             rb.updated_at,
             rb.update_items
         FROM
-            ranking_ban AS rb
+            ranking_ban AS rb {$forceIndex}
             JOIN open_chat AS oc ON oc.id = rb.open_chat_id
         WHERE
             {$whereClause} {$like}
         ORDER BY
-            IFNULL(GREATEST(rb.datetime, rb.end_datetime), rb.datetime) DESC,
-            oc.member DESC
+            {$orderBy}
         LIMIT
             :offset, :limit";
 
@@ -73,40 +125,51 @@ class RankingBanPageRepository
     }
 
     /**
+     * ページャのラベル用に「消えた日時(sort_datetime)」を新しい順で最大 $limit 件返す。
+     * 表示できるページ数には上限があるため全件は不要で、$limit で頭打ちにして filesort/転送を抑える。
+     *
      * @param int $publish 0:掲載中のみ, 1:未掲載のみ, 2:すべて
      * @param int $change 0:内容変更ありのみ, 1:変更なしのみ, 2:すべて
+     * @param int $limit 取得上限（表示上限ページ×1ページ件数＋1）
      */
-    public function findAllDatetimeColumn(int $change, int $publish, int $percent, string $keyword, string $since = '', string $until = '', int $dmin = 0, int $dmax = 0, string $now = '', array $items = []): array
+    public function findAllDatetimeColumn(int $change, int $publish, int $percent, string $keyword, int $limit, string $since = '', string $until = '', int $dmin = 0, int $dmax = 0, string $now = '', array $items = []): array
     {
         $whereClause = $this->buildWhereClause($change, $publish, $percent)
             . $this->buildDateClause($since, $until, $dateParams)
             . $this->buildDurationClause($dmin, $dmax, $now, $durationParams)
             . $this->buildItemsClause($items, $itemsParams);
 
+        $fast = $this->useSortDatetimeFastPath($publish, $keyword, $since, $until);
+        $straightJoin = $fast ? 'STRAIGHT_JOIN' : '';
+        $forceIndex = $fast ? 'FORCE INDEX (idx_rb_sortdt)' : '';
+        $sortExpr = $fast ? 'rb.sort_datetime' : 'IFNULL(GREATEST(rb.datetime, rb.end_datetime), rb.datetime)';
+        $orderBy = $fast
+            ? 'rb.sort_datetime DESC, rb.member DESC, rb.id DESC'
+            : 'IFNULL(GREATEST(rb.datetime, rb.end_datetime), rb.datetime) DESC, rb.datetime DESC, percentage ASC';
+
         $query = fn ($like) =>
-        "SELECT
-            IFNULL(GREATEST(rb.datetime, rb.end_datetime), rb.datetime) AS `datetime`
+        "SELECT {$straightJoin}
+            {$sortExpr} AS `datetime`
         FROM
-            ranking_ban AS rb
+            ranking_ban AS rb {$forceIndex}
             JOIN open_chat AS oc ON oc.id = rb.open_chat_id
         WHERE
             {$whereClause} {$like}
         ORDER BY
-            IFNULL(GREATEST(rb.datetime, rb.end_datetime), rb.datetime) DESC,
-            rb.datetime DESC,
-            percentage ASC";
+            {$orderBy}
+        LIMIT :limit";
 
         if ($keyword !== '') {
             return DB::executeLikeSearchQuery(
                 $query,
                 fn ($i) => "(oc.name LIKE :keyword{$i} OR oc.description LIKE :keyword{$i})",
                 $keyword,
-                ($dateParams + $durationParams + $itemsParams) ?: null,
+                ['limit' => $limit] + $dateParams + $durationParams + $itemsParams,
                 fetchAllArgs: [\PDO::FETCH_COLUMN, 0],
                 whereClausePrefix: 'AND '
             );
         } else {
-            return DB::fetchAll($query(''), ($dateParams + $durationParams + $itemsParams) ?: null, args: [\PDO::FETCH_COLUMN, 0]);
+            return DB::fetchAll($query(''), ['limit' => $limit] + $dateParams + $durationParams + $itemsParams, args: [\PDO::FETCH_COLUMN, 0]);
         }
     }
 

--- a/app/Services/RankingBan/Dto/RankingBanPageDto.php
+++ b/app/Services/RankingBan/Dto/RankingBanPageDto.php
@@ -13,7 +13,8 @@ class RankingBanPageDto
 {
     /**
      * @param array     $openChatList 表示用ルーム行（components/open_chat_list_ranking_ban が描画）
-     * @param string[]  $labelArray   ページャ生成用の「消えた日時」一覧（降順）
+     * @param string[]  $labelArray   ページャ生成用の「消えた日時」一覧（降順・表示上限ページ分まで）
+     * @param bool      $hasMore      総数が表示上限を超えている（$totalRecords は上限値＝「N件以上」表示）
      */
     function __construct(
         public int $pageNumber,
@@ -21,5 +22,6 @@ class RankingBanPageDto
         public array $openChatList,
         public int $totalRecords,
         public array $labelArray,
+        public bool $hasMore = false,
     ) {}
 }

--- a/app/Services/RankingBan/RakingBanPageService.php
+++ b/app/Services/RankingBan/RakingBanPageService.php
@@ -45,11 +45,26 @@ class RakingBanPageService
             return null;
         }
 
-        $labelArray = $this->rankingBanPageRepository->findAllDatetimeColumn($change, $publish, $percent, $keyword, $since, $until, $dmin, $dmax, $now, $items);
+        // ページャのラベルは各ページ境界の日付だけ必要。表示できるのは上限ページまでなので、
+        // 全件ではなく「上限ページ分＋1件」だけ取得する。+1 件取れたら総数が上限超え（正確な総数は不要）と分かる。
+        // これで従来の「全マッチ行を取得して件数を数える」重い処理（全件 filesort＋転送）を避ける。
+        $labelLimit = self::MAX_PAGE_NUMBER * $limit + 1;
+        $labelArray = $this->rankingBanPageRepository->findAllDatetimeColumn($change, $publish, $percent, $keyword, $labelLimit, $since, $until, $dmin, $dmax, $now, $items);
 
-        // ページの最大数を取得する（実データの最大ページと上限の小さい方で頭打ち）
-        $totalRecords = count($labelArray);
-        $maxPageNumber = min($this->calcMaxPages($totalRecords, $limit), self::MAX_PAGE_NUMBER);
+        if ($labelArray === []) {
+            // 0件（コントローラが空状態を描画する）
+            return null;
+        }
+
+        $hasMore = count($labelArray) > self::MAX_PAGE_NUMBER * $limit;
+        if ($hasMore) {
+            // 判定用の +1 件目を捨て、境界配列の長さを「上限ページ×件数」ぴったりに揃える
+            array_pop($labelArray);
+        }
+
+        // 上限超えなら総数は表示上限（「N件以上」表示）、上限以下なら取得件数が正確な総数
+        $totalRecords = $hasMore ? self::MAX_PAGE_NUMBER * $limit : count($labelArray);
+        $maxPageNumber = $hasMore ? self::MAX_PAGE_NUMBER : $this->calcMaxPages($totalRecords, $limit);
         if ($pageNumber > $maxPageNumber) {
             // 現在のページ番号が最大ページ番号を超えている場合
             return null;
@@ -85,6 +100,7 @@ class RakingBanPageService
             openChatList: $openChatList,
             totalRecords: $totalRecords,
             labelArray: $labelArray,
+            hasMore: $hasMore,
         );
     }
 }

--- a/app/Views/Classes/RankingBanSelectElementPagination.php
+++ b/app/Views/Classes/RankingBanSelectElementPagination.php
@@ -36,48 +36,39 @@ class RankingBanSelectElementPagination
     }
 
     /**
-     * 昇順ページネーションのselect要素を生成
-     * 
-     * @return array `[$title, $_selectElement, $_label]`
+     * 各ページ「最新→最古」の境界日付つき select 要素を生成する。
+     *
+     * $labelArray は降順（新しい順）の境界日付配列で、長さは「表示上限ページ×件数」まで。
+     * ページ i の先頭（最新）= $labelArray[(i-1)*件数]、末尾（最古）= $labelArray[min(i*件数, 件数)-1] を参照する。
+     *
+     * @param string[] $labelArray 降順の「消えた日時」一覧（表示上限ページ分まで）
+     * @return array `['', $_selectElement, $_label]`（先頭の title は未使用）
      */
-    function geneSelectElementPagerAsc(string $pagePath, array $params, int $pageNumber, int $totalRecords, int $itemsPerPage, int $maxPage, array $labelArray = []): array
+    function geneSelectElementPagerAsc(string $pagePath, array $params, int $pageNumber, int $itemsPerPage, int $maxPage, array $labelArray = []): array
     {
-        // ページ番号の表示に必要な要素を取得する
-        $getElement = function ($url, $selected, $start, $end, $i) use ($labelArray) {
-            $startLabel = isset($labelArray[$start - 1]) ? $this->formatDateTimeHourly($labelArray[$start - 1]) : '';
-            $endLabel = isset($labelArray[$end - 1]) ? $this->formatDateTimeHourly($labelArray[$end - 1]) : '';
+        $count = count($labelArray);
 
-            return "<option value='{$url}' {$selected}>{$startLabel} → {$endLabel} ({$i}ページ目)</option>";
+        // ページ i の「最新（先頭）→最古（末尾）」の境界日付ラベルを返す
+        $rangeLabel = function (int $i) use ($labelArray, $itemsPerPage, $count): array {
+            $startIdx = ($i - 1) * $itemsPerPage;            // そのページの先頭（最新）
+            $endIdx = min($i * $itemsPerPage, $count) - 1;   // そのページの末尾（最古）
+            $start = isset($labelArray[$startIdx]) ? $this->formatDateTimeHourly($labelArray[$startIdx]) : '';
+            $end = isset($labelArray[$endIdx]) ? $this->formatDateTimeHourly($labelArray[$endIdx]) : '';
+            return [$start, $end];
         };
 
-        // 選択されたページに対して"selected"属性を返す
-        $selected = fn($i) => ($i === $pageNumber) ? "selected='selected'" : '';
-
-        // ページ番号に応じて、そのページの最初のインデックスを計算する
-        $startNum = fn($i) => ($i === 1) ? $totalRecords : $totalRecords - (($i - 1) * $itemsPerPage);
-
-        // ページ番号に応じて、そのページの最後のインデックスを計算する
-        $endNum = fn($i) => ($i === $maxPage) ? 1 : $totalRecords - ($i * $itemsPerPage) + 1;
-
-        // 各ページ番号の要素を生成する
         $_selectElement = '';
         for ($i = 1; $i <= $maxPage; $i++) {
-            $_selectElement .= $getElement($this->pagerUrl($pagePath, $i, $params), $selected($i), $startNum($i), $endNum($i), $i) . "\n";
+            [$start, $end] = $rangeLabel($i);
+            $selected = ($i === $pageNumber) ? "selected='selected'" : '';
+            $url = $this->pagerUrl($pagePath, $i, $params);
+            $_selectElement .= "<option value='{$url}' {$selected}>{$start} → {$end} ({$i}ページ目)</option>\n";
         }
 
-        // ラベルの番号を取得する
-        $labelStartNum = $startNum($pageNumber);
-        $labelEndNum = $endNum($pageNumber);
+        [$curStart, $curEnd] = $rangeLabel($pageNumber);
+        $_label = "{$curStart} → {$curEnd}<br>({$pageNumber}ページ目)";
 
-        $startLabel = isset($labelArray[$labelStartNum - 1]) ? $this->formatDateTimeHourly($labelArray[$labelStartNum - 1]) : '';
-        $endLabel = isset($labelArray[$labelEndNum - 1]) ? $this->formatDateTimeHourly($labelArray[$labelEndNum - 1]) : '';
-
-        // select要素のラベルを生成する
-        $_label = "{$startLabel} → {$endLabel}<br>({$pageNumber}ページ目)";
-
-        // タイトル用の文字列
-        $title = "{$labelEndNum} ~ {$labelStartNum}";
-
-        return [$title, $_selectElement, $_label];
+        // 先頭要素（旧 title）は呼び出し側で未使用
+        return ['', $_selectElement, $_label];
     }
 }

--- a/app/Views/components/ranking_ban_results.php
+++ b/app/Views/components/ranking_ban_results.php
@@ -29,7 +29,7 @@
             </form>
         </nav>
     <?php endif ?>
-    <small class="rb-count"><?php echo number_format($totalRecords) ?>件の結果 (<?php echo $maxPageNumber ?>ページ中/<?php echo $page ?>ページ目)</small>
+    <small class="rb-count"><?php echo number_format($totalRecords) ?><?php echo ($hasMore ?? false) ? '件以上' : '件' ?>の結果 (<?php echo $maxPageNumber ?>ページ中/<?php echo $page ?>ページ目)</small>
     <?php if (isset($openChatList)) : ?>
         <?php viewComponent('open_chat_list_ranking_ban', compact('openChatList', '_now')) ?>
     <?php else : ?>

--- a/setup/schema/mysql/ocgraph_ocreview_schema.sql
+++ b/setup/schema/mysql/ocgraph_ocreview_schema.sql
@@ -81,9 +81,11 @@ CREATE TABLE `ranking_ban` (
   `updated_at` int(11) NOT NULL,
   `update_items` text DEFAULT NULL,
   `end_datetime` datetime DEFAULT NULL,
+  `sort_datetime` datetime AS (ifnull(greatest(`datetime`,`end_datetime`),`datetime`)) VIRTUAL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_ranking_ban_open_chat_datetime` (`open_chat_id`,`datetime`),
-  KEY `idx_ranking_ban_end_percentage_datetime` (`end_datetime`,`percentage`,`datetime`)
+  KEY `idx_ranking_ban_end_percentage_datetime` (`end_datetime`,`percentage`,`datetime`),
+  KEY `idx_rb_sortdt` (`sort_datetime`,`member`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 DROP TABLE IF EXISTS `recommend`;
 CREATE TABLE `recommend` (

--- a/setup/schema/mysql/ocgraph_ocreviewth_schema.sql
+++ b/setup/schema/mysql/ocgraph_ocreviewth_schema.sql
@@ -81,9 +81,11 @@ CREATE TABLE `ranking_ban` (
   `updated_at` int(11) NOT NULL,
   `update_items` text DEFAULT NULL,
   `end_datetime` datetime DEFAULT NULL,
+  `sort_datetime` datetime AS (ifnull(greatest(`datetime`,`end_datetime`),`datetime`)) VIRTUAL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_ranking_ban_open_chat_datetime` (`open_chat_id`,`datetime`),
-  KEY `idx_ranking_ban_end_percentage_datetime` (`end_datetime`,`percentage`,`datetime`)
+  KEY `idx_ranking_ban_end_percentage_datetime` (`end_datetime`,`percentage`,`datetime`),
+  KEY `idx_rb_sortdt` (`sort_datetime`,`member`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 DROP TABLE IF EXISTS `recommend`;
 CREATE TABLE `recommend` (

--- a/setup/schema/mysql/ocgraph_ocreviewtw_schema.sql
+++ b/setup/schema/mysql/ocgraph_ocreviewtw_schema.sql
@@ -81,9 +81,11 @@ CREATE TABLE `ranking_ban` (
   `updated_at` int(11) NOT NULL,
   `update_items` text DEFAULT NULL,
   `end_datetime` datetime DEFAULT NULL,
+  `sort_datetime` datetime AS (ifnull(greatest(`datetime`,`end_datetime`),`datetime`)) VIRTUAL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_ranking_ban_open_chat_datetime` (`open_chat_id`,`datetime`),
-  KEY `idx_ranking_ban_end_percentage_datetime` (`end_datetime`,`percentage`,`datetime`)
+  KEY `idx_ranking_ban_end_percentage_datetime` (`end_datetime`,`percentage`,`datetime`),
+  KEY `idx_rb_sortdt` (`sort_datetime`,`member`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 DROP TABLE IF EXISTS `recommend`;
 CREATE TABLE `recommend` (


### PR DESCRIPTION
「公式ランキング掲載の分析」(`/labs/publication-analytics`) の重い一覧表示を、生成列＋索引で約10〜100倍高速化する変更を本番へ反映します（GoogleOther の深い巡回で本番DBが飽和した障害のDB側の根治）。

詳細・実測表: #559

デプロイ時に `ranking_ban` へ生成列 `sort_datetime` と索引 `idx_rb_sortdt` が自動追加されます（生成列は即時、索引はオンライン構築 INPLACE）。生成列ができるまではコードが従来パスで動くため反映途中も安全です。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
