### PR TITLE
[PROD] fix: 重い分析ページの同時多重リクエストを1件に制限してサーバ過負荷を防ぐ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ storage/transient_errors.queue
 storage/transient_errors.queue.lock
 storage/furigana/**
 storage/*/api_rate_limit/**
+storage/*/inflight_locks/**
 storage/*/analysis_jobs/*
 storage/*/logs/*
 storage/*/SQLite/*/*.db

--- a/app/Config/FileStorageServiceConfig.php
+++ b/app/Config/FileStorageServiceConfig.php
@@ -37,6 +37,7 @@ class FileStorageServiceConfig
         'tagList' =>                      '/static_data_top/tag_list.dat',
         'relatedTags' =>                  '/static_data_top/related_tags.dat',
         'apiRateLimitDir' =>              '/api_rate_limit',
+        'inFlightLockDir' =>             '/inflight_locks',
         'analysisJobsDir' =>             '/analysis_jobs',
         'recommendStaticDataDir' =>       '/static_data_recommend/tag',
         'categoryStaticDataDir' =>        '/static_data_recommend/category',

--- a/app/Controllers/Api/AdvancedGrowthAnalysisApiController.php
+++ b/app/Controllers/Api/AdvancedGrowthAnalysisApiController.php
@@ -6,6 +6,8 @@ namespace App\Controllers\Api;
 
 use App\Config\AppConfig;
 use App\Services\Analysis\AdvancedGrowthAnalysisService;
+use App\Services\Security\ConcurrentRequestGuard;
+use App\Services\Storage\FileStorageInterface;
 use Shadow\Kernel\Reception as Recp;
 use Shadow\Kernel\Validator as Valid;
 use Shared\Exceptions\BadRequestException as HTTP400;
@@ -23,12 +25,22 @@ class AdvancedGrowthAnalysisApiController
 {
     public function __construct(
         private AdvancedGrowthAnalysisService $service,
+        private FileStorageInterface $fileStorage,
     ) {}
 
     public function status()
     {
         noStore();
         Recp::$isJson = true;
+
+        // 同一IPの未完了 status が処理中なら 2本目は受け付けない。status は重い集計を1チャンク進めるため、
+        // 同時実行は無駄なDB負荷＋進捗状態の競合になる。正常なポーリングは逐次なので発生しない（フックが既存リトライで吸収）。
+        $guard = new ConcurrentRequestGuard($this->fileStorage);
+        if (!$guard->tryAcquire('analysis-status', getIP())) {
+            header('Retry-After: 1');
+            return response(['error' => 'busy'], 429);
+        }
+
         [$metric, $period, $from, $to] = $this->commonInputs();
 
         return response($this->service->advance($metric, $period, $from, $to));
@@ -39,6 +51,14 @@ class AdvancedGrowthAnalysisApiController
         checkLastModified($this->service->hourlyUpdatedAt());
 
         Recp::$isJson = true;
+
+        // 同一IPの未完了 result が処理中なら 2本目は受け付けない（CDN未ヒット時の重い整形を同時に積み上げない）。
+        $guard = new ConcurrentRequestGuard($this->fileStorage);
+        if (!$guard->tryAcquire('analysis-result', getIP())) {
+            header('Retry-After: 1');
+            return response(['error' => 'busy'], 429);
+        }
+
         $error = HTTP400::class;
         [$metric, $period, $from, $to] = $this->commonInputs();
 

--- a/app/Controllers/Pages/RankingBanLabsPageController.php
+++ b/app/Controllers/Pages/RankingBanLabsPageController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Controllers\Pages;
 
 use App\Services\RankingBan\RakingBanPageService;
+use App\Services\Security\ConcurrentRequestGuard;
 use App\Services\Storage\FileStorageInterface;
 use App\Views\RankingBanSelectElementPagination;
+use Shadow\Kernel\Response;
 use Shadow\Kernel\ViewInterface;
 
 class RankingBanLabsPageController
@@ -85,10 +87,18 @@ class RankingBanLabsPageController
         string $since,
         string $until,
         string $items
-    ): ViewInterface|false {
+    ): ViewInterface|Response|false {
         // noindex: フラグメント自体は検索結果に出さない。nofollow: ページャの深いページリンクを
         // クローラに辿らせない（cf.client.bot はCFヘッダゲートを通れるため、深いOFFSETの巡回を抑止）
         header('X-Robots-Tag: noindex, nofollow');
+
+        // 同一IPからの未完了 /list が処理中なら 2本目は受け付けない（重い一覧の同時積み上げでDBを飽和させない）。
+        // 正常な利用は1本ずつなので発生せず、連打・高速フィルタ変更時のみ一時的に 429（フロントが少し待って再取得）。
+        $guard = new ConcurrentRequestGuard($fileStorage);
+        if (!$guard->tryAcquire('pubanalytics-list', getIP())) {
+            header('Retry-After: 1');
+            return response('', 429);
+        }
 
         $since = $this->validDate($since);
         $until = $this->validDate($until);

--- a/app/Services/Security/ConcurrentRequestGuard.php
+++ b/app/Services/Security/ConcurrentRequestGuard.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Security;
+
+use App\Services\Storage\FileStorageInterface;
+
+/**
+ * 同一クライアント(IP)×スコープ単位の「同時1リクエスト」ガード。
+ *
+ * 重いエンドポイント（公式ランキング掲載分析の一覧 /list・詳細成長分析 /analysis-*）で、
+ * 1つのIPからの未完了リクエストがあるうちは同じスコープの2本目を受け付けない（即 429）。
+ * これにより、1IPが重いリクエストを多数並列に積み上げてDBを飽和させるのを防ぐ
+ * （2026-06-24 のクローラ深堀り巡回による gone away 障害の再発防止・多層防御）。
+ *
+ * 仕組み: storage/{locale}/inflight_locks/{scope}_{IP由来バケット}.lock を flock(LOCK_EX|LOCK_NB)。
+ * - ロックはこのリクエスト処理が終わる（＝スクリプト終了でファイルハンドルが閉じる）と自動解放される。
+ * - 取得済みなら別リクエストが処理中 → false を返す（呼び出し側が 429 を返す）。
+ * - ロックファイルが作れない等の異常時は true（フェイルオープン＝本処理は止めない）。
+ *
+ * クライアントが fetch を中断(abort)しても、サーバ側は処理が終わるまでロックを保持する
+ * （DBクエリ中は切断検知できないため）。高速なフィルタ変更で 2本目が一時的に 429 になりうるが、
+ * フロント側で短い待機後にリトライして吸収する（一覧JS／成長分析フックの既存リトライ）。
+ *
+ * 排他ロックの取り方は App\Services\Api\DatabaseApiRateLimiter（データAPIのユーザー単位版）と同型。
+ */
+class ConcurrentRequestGuard
+{
+    /**
+     * IP をこの数のバケットへ写像してロックファイル数を上限化する。
+     * IP ごとに無限にファイルを作ると共有ホスティングの inode 上限を食い潰すため。
+     * 同一IPは常に同じバケットなので「IP単位の同時1リクエスト」は厳密に保たれる。
+     * 別IPが同じバケットに当たる確率は 1/この数で、ロック保持は一瞬（リクエスト処理中だけ）のため誤ブロックは無視できる。
+     */
+    private const LOCK_BUCKETS = 4096;
+
+    /** @var resource|null 同時実行ロックのファイルハンドル（リクエスト終了まで保持する） */
+    private $lockHandle = null;
+
+    public function __construct(
+        private FileStorageInterface $fileStorage,
+    ) {}
+
+    /**
+     * 指定スコープ×IP の同時実行ロックを取得する。実行中の同一リクエストがあれば false。
+     * ロックファイルが作れない等の異常時は true（フェイルオープン）。
+     *
+     * @param string $scope エンドポイント種別（例 'pubanalytics-list'）。別スコープ同士は互いに阻害しない
+     * @param string $ip    クライアントIP（getIP()）
+     */
+    public function tryAcquire(string $scope, string $ip): bool
+    {
+        // ロック機構の不具合（権限・I/O 等）でリクエスト本体を止めない（フェイルオープン）。
+        // ※ このアプリのエラーハンドラは @ を無視して警告を例外化するため try/catch で受ける。
+        try {
+            $dir = $this->fileStorage->getStorageFilePath('inFlightLockDir');
+            if (!is_dir($dir)) {
+                // 併発リクエストが同時に mkdir すると「File exists」になるが、出来ていれば問題ない
+                try {
+                    mkdir($dir, 0777, true);
+                } catch (\Throwable $e) {
+                    // レースは無視（直後の is_dir で確認）
+                }
+                if (!is_dir($dir)) {
+                    return true; // 作成できない異常時はフェイルオープン
+                }
+            }
+
+            // ファイル名 = スコープ名＋IP由来のバケット番号（スコープごとに最大 LOCK_BUCKETS 個・無限増殖しない）
+            $bucket = hexdec(substr(hash('sha256', $ip), 0, 8)) % self::LOCK_BUCKETS;
+            $safeScope = preg_replace('/[^a-z0-9_-]/', '', $scope);
+            $fp = fopen($dir . '/' . $safeScope . '_' . $bucket . '.lock', 'c');
+            if ($fp === false) {
+                return true; // フェイルオープン
+            }
+
+            if (!flock($fp, LOCK_EX | LOCK_NB)) {
+                fclose($fp);
+                return false; // 同一IP×スコープのリクエストが処理中
+            }
+
+            $this->lockHandle = $fp;
+            return true;
+        } catch (\Throwable $e) {
+            return true; // フェイルオープン
+        }
+    }
+
+    /**
+     * 明示解放（通常は不要＝リクエスト終了で自動解放されるが、重い処理の前後で早く手放したいとき用）。
+     */
+    public function release(): void
+    {
+        if ($this->lockHandle !== null) {
+            flock($this->lockHandle, LOCK_UN);
+            fclose($this->lockHandle);
+            $this->lockHandle = null;
+        }
+    }
+}

--- a/app/Views/ranking_ban_content.php
+++ b/app/Views/ranking_ban_content.php
@@ -441,6 +441,17 @@ viewComponent('head', compact('_css', '_meta')) ?>
                             location.href = pageUrl(s);
                             return null;
                         }
+                        if (res.status === 429) {
+                            // 同一IPの直前の取得がまだ処理中（混雑）。少し待って同じ条件で取り直す。
+                            // 連打・高速フィルタ変更で前リクエストのサーバ側ロックが残るケースを吸収する。
+                            const n = (opts.retry429 || 0) + 1;
+                            if (n <= 4) {
+                                setTimeout(function () {
+                                    if (myGen === gen) load(Object.assign({}, opts, { push: false, retry429: n }));
+                                }, 400 * n);
+                                return null;
+                            }
+                        }
                         // その他のエラーはエラー表示＋再試行（遷移ループ防止）
                         throw new Error('HTTP ' + res.status);
                     })


### PR DESCRIPTION
重い分析ページ（一覧 `/labs/publication-analytics`・詳細成長分析 `/labs/growth`）で、同じ訪問者(IP)からの**未完了リクエストの同時多重実行を1件に制限**するガードを本番へ反映します（クローラ巡回でDBが飽和した障害の再発防止・多層防御）。

詳細: #561

- `/list`・`/analysis-status`・`/analysis-result` に適用。2本目は即429（Retry-After付き、フロントが少し待って再取得）。
- ロックファイルはIPを固定バケットに写像して上限化（inode対策）。状態ファイルは gitignore 済み。
- Cloudflare のレート制限（既に対象）と二層で保護。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
