### PR TITLE
[STG] 公式ランキング掲載分析の絞り込みを改善（未掲載だった期間で絞る・消えていた時間の数値指定・「表示」ボタン）

### DIFF
--- a/app/Models/RankingBanRepositories/RankingBanPageRepository.php
+++ b/app/Models/RankingBanRepositories/RankingBanPageRepository.php
@@ -71,7 +71,7 @@ class RankingBanPageRepository
         array $items = [],
     ): array {
         $whereClause = $this->buildWhereClause($change, $publish, $percent)
-            . $this->buildDateClause($since, $until, $dateParams)
+            . $this->buildDateClause($since, $until, $now, $dateParams)
             . $this->buildDurationClause($dmin, $dmax, $now, $durationParams)
             . $this->buildItemsClause($items, $itemsParams);
 
@@ -135,7 +135,7 @@ class RankingBanPageRepository
     public function findAllDatetimeColumn(int $change, int $publish, int $percent, string $keyword, int $limit, string $since = '', string $until = '', int $dmin = 0, int $dmax = 0, string $now = '', array $items = []): array
     {
         $whereClause = $this->buildWhereClause($change, $publish, $percent)
-            . $this->buildDateClause($since, $until, $dateParams)
+            . $this->buildDateClause($since, $until, $now, $dateParams)
             . $this->buildDurationClause($dmin, $dmax, $now, $durationParams)
             . $this->buildItemsClause($items, $itemsParams);
 
@@ -174,20 +174,28 @@ class RankingBanPageRepository
     }
 
     /**
-     * 「消えた日時(rb.datetime)」の期間絞り込み。値はバインドパラメータで渡す（連結しない）。
+     * 「その期間に未掲載だった部屋」の絞り込み。消えた日そのものが期間内、ではなく、
+     * 未掲載の区間 [消えた日 rb.datetime 〜 復活日 rb.end_datetime（未掲載中なら基準時刻 $now）] が
+     * 指定期間 [since, until] と重なるレコードを対象にする。
+     * 例: 6/1〜6/7 を指定すると、5月に消えて今も未掲載／6/3に復活、も含む（区間が窓に掛かるため）。
+     * 値はバインドパラメータで渡す（連結しない）。
      *
      * @param string $since YYYY-MM-DD（検証済み・空文字なら条件なし）
      * @param string $until YYYY-MM-DD（同上）
+     * @param string $now 未掲載中(end_datetime NULL)の区間終端に使う基準時刻 'Y-m-d H:i:s'
      * @param array|null $dateParams バインド用パラメータの出力先
      */
-    private function buildDateClause(string $since, string $until, ?array &$dateParams): string
+    private function buildDateClause(string $since, string $until, string $now, ?array &$dateParams): string
     {
         $clause = '';
         $dateParams = [];
+        // 区間の終端（復活日。未掲載中は now まで継続）が since 以降 ＝ since より前に復活し終えていない
         if ($since !== '') {
-            $clause .= ' AND rb.datetime >= :since';
+            $clause .= ' AND COALESCE(rb.end_datetime, :sinceNow) >= :since';
             $dateParams['since'] = $since . ' 00:00:00';
+            $dateParams['sinceNow'] = $now !== '' ? $now : '9999-12-31 23:59:59';
         }
+        // 区間の始端（消えた日）が until 以前 ＝ until より後に消えたのではない
         if ($until !== '') {
             $clause .= ' AND rb.datetime <= :until';
             $dateParams['until'] = $until . ' 23:59:59';

--- a/app/Views/ranking_ban_content.php
+++ b/app/Views/ranking_ban_content.php
@@ -136,18 +136,33 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 </div>
             </div>
             <div class="rb-field">
-                <div class="rb-field-label" id="rb-label-period">消えた時期</div>
+                <div class="rb-field-label" id="rb-label-period"><span id="rb-period-label">未掲載だった時期</span></div>
                 <div class="rb-field-control">
                     <div class="rb-dates" role="group" aria-labelledby="rb-label-period">
-                        <input type="date" id="rb-since" class="rb-date-input" aria-label="消えた日の開始" value="<?php echo $since ?>">
+                        <input type="date" id="rb-since" class="rb-date-input" aria-label="期間の開始" value="<?php echo $since ?>">
                         <span class="rb-dates-sep" aria-hidden="true">〜</span>
-                        <input type="date" id="rb-until" class="rb-date-input" aria-label="消えた日の終了" value="<?php echo $until ?>">
+                        <input type="date" id="rb-until" class="rb-date-input" aria-label="期間の終了" value="<?php echo $until ?>">
                     </div>
-                    <p class="rb-field-hint">ランキングから消えた日で絞り込み（空欄＝全期間）</p>
+                    <p class="rb-field-hint">この期間に未掲載だった部屋で絞り込み（消えた日〜復活/現在が期間と重なるもの・空欄＝全期間）</p>
+                </div>
+            </div>
+            <div class="rb-field">
+                <div class="rb-field-label" id="rb-label-duration"><span id="rb-duration-label">消えていた時間</span>（時間で指定）</div>
+                <div class="rb-field-control">
+                    <div class="rb-dates rb-duration-range" role="group" aria-labelledby="rb-label-duration">
+                        <input type="number" id="rb-dmin" class="rb-num-input" min="0" max="87600" step="1" inputmode="numeric" aria-label="最小（時間）" placeholder="最小" value="<?php echo $dmin > 0 ? $dmin : '' ?>">
+                        <span class="rb-dates-sep" aria-hidden="true">〜</span>
+                        <input type="number" id="rb-dmax" class="rb-num-input" min="0" max="87600" step="1" inputmode="numeric" aria-label="最大（時間）" placeholder="最大" value="<?php echo $dmax > 0 ? $dmax : '' ?>">
+                        <span class="rb-num-unit">時間</span>
+                    </div>
+                    <p class="rb-field-hint" id="rb-duration-hint">上の「消えていた期間」を数値で細かく指定（例: 24=1日、72=3日、168=1週間。空欄＝指定なし）。プリセットと連動します</p>
                 </div>
             </div>
             </div>
         </details>
+        <div class="rb-submit-bar">
+            <button type="button" id="rb-submit" class="rb-submit-btn">この条件で表示</button>
+        </div>
 
         <!-- 詳しい使い方（上級者向け・SEOテキスト） -->
         <aside class="list-aside ranking-desc" style="margin: 1rem 0;">
@@ -284,6 +299,12 @@ viewComponent('head', compact('_css', '_meta')) ?>
             const clearBtn = document.getElementById('rb-keyword-clear');
             const sinceInput = document.getElementById('rb-since');
             const untilInput = document.getElementById('rb-until');
+            const dminInput = document.getElementById('rb-dmin');
+            const dmaxInput = document.getElementById('rb-dmax');
+            const periodLabel = document.getElementById('rb-period-label');
+            const durationLabel = document.getElementById('rb-duration-label');
+            const durationHint = document.getElementById('rb-duration-hint');
+            const submitBtn = document.getElementById('rb-submit');
 
             const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
             // 「ルームの変更内容」で絞り込めるキー（正準順）。PHP の UPDATE_ITEM_KEYS と一致させる
@@ -358,6 +379,28 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 if (keywordInput.value !== state.keyword) keywordInput.value = state.keyword;
                 if (sinceInput.value !== state.since) sinceInput.value = state.since;
                 if (untilInput.value !== state.until) untilInput.value = state.until;
+                // 数値入力（時間）。0/空＝指定なし。入力中の値と同じなら書き戻さない（カーソル飛び防止）
+                const dminStr = state.dmin > 0 ? String(state.dmin) : '';
+                const dmaxStr = state.dmax > 0 ? String(state.dmax) : '';
+                if (dminInput.value !== dminStr) dminInput.value = dminStr;
+                if (dmaxInput.value !== dmaxStr) dmaxInput.value = dmaxStr;
+                // 期間ラベルも掲載状況で変わる。消えたままは今も未掲載なので「だった（過去）」にしない
+                if (periodLabel) {
+                    periodLabel.textContent = state.publish === 1 ? '未掲載中の時期'
+                        : (state.publish === 0 ? '未掲載だった時期' : '未掲載の時期');
+                }
+                // 「消えていた時間」フォームの文言は掲載状況で変わる（消えている / 復活までの / 消えていた）
+                if (durationLabel) {
+                    durationLabel.textContent = state.publish === 1 ? '消えている時間'
+                        : (state.publish === 0 ? '復活までの時間' : '消えていた時間');
+                }
+                if (durationHint) {
+                    durationHint.textContent = state.publish === 0
+                        ? '消えてから復活までが指定の時間内だった部屋に絞ります（例: 24=1日以内。空欄＝指定なし）'
+                        : (state.publish === 1
+                            ? '指定の時間ぶん「今も消えたまま」の部屋に絞ります（例: 72=3日以上。空欄＝指定なし）'
+                            : '消えていた時間で絞ります（例: 24=1日、168=1週間。空欄＝指定なし）');
+                }
                 toggleClear();
                 // プリセットは publish/change/percent の選択。「消えていた期間」は直交する軸なので判定に含めない（同時選択できる）
                 document.querySelectorAll('.rb-preset:not(.rb-duration):not(.rb-filter):not(.rb-item)').forEach((b) => {
@@ -480,6 +523,44 @@ viewComponent('head', compact('_css', '_meta')) ?>
                     });
             };
 
+            // 数値入力（時間）→ state.dmin/dmax。0/空＝条件なし。矛盾範囲は下限優先（PHP normalizeDuration と同一）
+            const readDuration = () => {
+                const h = (el) => {
+                    const n = parseInt(el.value, 10);
+                    return (isNaN(n) || n < 0) ? 0 : Math.min(n, 87600);
+                };
+                state.dmin = h(dminInput);
+                state.dmax = h(dmaxInput);
+                if (state.dmin > 0 && state.dmax > 0 && state.dmin >= state.dmax) state.dmax = 0;
+            };
+
+            // 自由入力欄（キーワード・期間・時間）を送信時に state へ取り込む（未確定の入力も拾う）
+            const readInputsIntoState = () => {
+                state.keyword = keywordInput.value;
+                state.since = DATE_RE.test(sinceInput.value) ? sinceInput.value : '';
+                state.until = DATE_RE.test(untilInput.value) ? untilInput.value : '';
+                readDuration();
+            };
+
+            // 「この条件で表示」: 選択しただけでは読み込まず、ここで初めて取得する（DBの無駄打ちを防ぐ）
+            const submit = () => {
+                readInputsIntoState();
+                state.page = 1;
+                syncControls();
+                load({ push: true });
+            };
+
+            // クエリ空（URL に絞り込みが無い初回アクセス）は読み込まず、操作を促すだけにする
+            const showInitialEmpty = () => {
+                if (aborter) aborter.abort();
+                ++gen; // 進行中の取得があれば、その遅延描画を無効化する
+                setBusy(false);
+                results.innerHTML = '<div class="rb-empty-initial"><p>条件を選んで「この条件で表示」ボタンを押してください。</p></div>';
+            };
+
+            // 絞り込みの変更は「この条件で表示」を押すまで読み込まない（状態とUIだけ更新する）。
+            // ページ送り・結果内の操作（再試行・除外解除など）は従来どおり即時に取得する。
+
             // セグメント（radio・詳細設定内の掲載状況/ルーム内容の変更）
             document.querySelectorAll('.rb-seg input[type="radio"]').forEach((r) => {
                 r.addEventListener('change', () => {
@@ -487,9 +568,15 @@ viewComponent('head', compact('_css', '_meta')) ?>
                     state[r.name] = Number(r.value);
                     // 「変更なし」は変更内容の指定と矛盾するのでクリア
                     if (r.name === 'change' && state.change === 1) state.items = [];
-                    state.page = 1;
                     syncControls();
-                    load({ push: true });
+                });
+            });
+
+            // 消えていた時間の数値入力（時間）。確定（blur）で state へ反映し、プリセットの選択状態を同期
+            [dminInput, dmaxInput].forEach((input) => {
+                input.addEventListener('change', () => {
+                    readDuration();
+                    syncControls();
                 });
             });
 
@@ -500,9 +587,7 @@ viewComponent('head', compact('_css', '_meta')) ?>
                     const v = Number(b.dataset.value);
                     if (state[key] === v) return;
                     state[key] = v;
-                    state.page = 1;
                     syncControls();
-                    load({ push: true });
                 });
             });
 
@@ -515,9 +600,7 @@ viewComponent('head', compact('_css', '_meta')) ?>
                     state.since = '';
                     state.until = '';
                     state.items = [];
-                    state.page = 1;
                     syncControls();
-                    load({ push: true });
                 });
             });
 
@@ -526,9 +609,7 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 b.addEventListener('click', () => {
                     state.dmin = Number(b.dataset.dmin);
                     state.dmax = Number(b.dataset.dmax);
-                    state.page = 1;
                     syncControls();
-                    load({ push: true });
                 });
             });
 
@@ -542,24 +623,23 @@ viewComponent('head', compact('_css', '_meta')) ?>
                         state.items = ITEM_KEYS.filter((k) => k === key || state.items.includes(k)); // 追加（正準順を維持）
                         if (state.change !== 0) state.change = 0; // 変更あり
                     }
-                    state.page = 1;
                     syncControls();
-                    load({ push: true });
                 });
             });
 
-            // 期間（消えた時期）
+            // 期間（未掲載だった時期）
             [sinceInput, untilInput].forEach((input) => {
                 input.addEventListener('change', () => {
                     const v = DATE_RE.test(input.value) ? input.value : '';
                     const key = input === sinceInput ? 'since' : 'until';
                     if (state[key] === v) return;
                     state[key] = v;
-                    state.page = 1;
                     syncControls();
-                    load({ push: true });
                 });
             });
+
+            // 「この条件で表示」ボタン
+            submitBtn.addEventListener('click', submit);
 
             // キーワード（Enter確定のみ・IME変換確定は無視。iOS IMEゾンビ対策で変換中は×を隠す）
             let composing = false;
@@ -578,18 +658,13 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 if (e.key !== 'Enter') return;
                 if (e.isComposing || composing) return;
                 e.preventDefault();
-                if (keywordInput.value === state.keyword) return;
-                state.keyword = keywordInput.value;
-                state.page = 1;
-                load({ push: true });
+                // キーワードの確定（Enter）は「この条件で表示」と同じく取得する
+                submit();
             });
             clearBtn.addEventListener('click', () => {
                 keywordInput.value = '';
-                toggleClear();
-                if (state.keyword === '') return;
                 state.keyword = '';
-                state.page = 1;
-                load({ push: true });
+                syncControls();
             });
 
             // 結果コンテナへのイベント委譲（innerHTML差し替えでリスナーが消えるため）
@@ -641,11 +716,15 @@ viewComponent('head', compact('_css', '_meta')) ?>
                 load({ push: true, scroll: true });
             });
 
+            // クエリが空（絞り込み無し）なら読み込まない。あれば（共有リンク・再読込・戻る/進む）取得する
+            const hasQuery = () => location.search !== '' && location.search !== '?';
+
             // ブラウザバック/フォワード
             window.addEventListener('popstate', () => {
                 state = parseState(location.search);
                 syncControls();
-                load({ push: false });
+                if (hasQuery()) load({ push: false });
+                else showInitialEmpty();
             });
 
 
@@ -655,9 +734,10 @@ viewComponent('head', compact('_css', '_meta')) ?>
             if (scrollTopBtn) scrollTopBtn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
             if (scrollBottomBtn) scrollBottomBtn.addEventListener('click', () => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' }));
 
-            // 初回ロード
+            // 初回。クエリが空なら読み込まず操作を促す、あれば取得する（「空でいいのはクエリが空の場合」）
             syncControls();
-            load({ push: false });
+            if (hasQuery()) load({ push: false });
+            else showInitialEmpty();
         })();
     </script>
 </body>

--- a/public/style/pages/ranking_ban.css
+++ b/public/style/pages/ranking_ban.css
@@ -316,6 +316,46 @@ body > .google-auto-placed {
   color: var(--c-text-steel);
 }
 
+/* 消えていた時間の数値レンジ入力（詳細設定内・期間と同じ枠サイズに揃える） */
+.rb-num-input {
+  box-sizing: border-box;
+  flex: 1;
+  min-width: 0;
+  height: 44px;
+  margin: 0;
+  padding: 0 10px;
+  border: 1px solid var(--c-border-muted);
+  border-radius: 8px;
+  font-size: 16px; /* iOSズーム回避 */
+  color: var(--c-text-1);
+  background-color: var(--c-bg);
+  font-family: var(--font-family);
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.rb-num-input::-webkit-outer-spin-button,
+.rb-num-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.rb-num-input::placeholder {
+  color: var(--c-text-steel);
+  font-size: 13px;
+}
+
+.rb-num-input:focus {
+  border-color: var(--c-brand);
+  outline: none;
+}
+
+.rb-num-unit {
+  flex: none;
+  font-size: 13px;
+  color: var(--c-text-steel);
+}
+
 /* キーワード検索 */
 
 .rb-search {
@@ -376,6 +416,47 @@ body > .google-auto-placed {
 }
 
 /* ライブサマリーバー */
+
+/* ---------- 「この条件で表示」送信ボタン（絞り込みの一番下・押すまで読み込まない） ---------- */
+
+.rb-submit-bar {
+  margin-top: 16px;
+}
+
+.rb-submit-btn {
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 50px;
+  border-radius: 10px;
+  background-color: var(--c-brand);
+  color: #fff;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  font-family: var(--font-family);
+  transition: opacity 0.15s;
+}
+
+.rb-submit-btn:hover {
+  opacity: 0.88;
+}
+
+.rb-submit-btn:focus-visible {
+  outline: 2px solid var(--c-brand);
+  outline-offset: 2px;
+}
+
+/* 初回（クエリ空）の操作を促すプレースホルダ */
+.rb-empty-initial {
+  text-align: center;
+  color: var(--c-text-neutral);
+  padding: 2.5rem 0;
+  font-size: 14px;
+}
 
 /* ---------- ローディング（初回・2回目以降で共通。常に結果の先頭） ---------- */
 


### PR DESCRIPTION
オプチャ公式ランキング掲載の分析ページ（/labs/publication-analytics）の絞り込みを、目的に合うように3点改善しました。

## 1. 期間の意味を「その期間に未掲載だった部屋」に変更

これまでは「消えた日」がその期間内のレコードだけを表示していました。これを、未掲載だった区間（消えた日〜復活、または現在）が指定期間と重なる部屋を表示するように変更しました。

例: 6/1〜6/7 を指定すると、5月に消えて今も未掲載の部屋や、6/3に復活した部屋も含まれます（その週に未掲載だった部屋が漏れなく出ます）。

ラベルは掲載状況に合わせて出し分けます:
- 消えたまま → 未掲載中の時期
- 復活した → 未掲載だった時期
- すべて → 未掲載の時期

## 2. 「消えていた時間」を数値で範囲指定できるように

既存のプリセット（24時間以内・3日以上 など）に加え、詳細設定で最小〜最大（時間）を直接入力できるようにしました。プリセットと数値欄は連動します。文言は掲載状況で変化します（消えたまま＝消えている時間 / 復活＝復活までの時間 / すべて＝消えていた時間）。

## 3. 「この条件で表示」ボタンを追加（自動検索をやめる）

これまでは絞り込みを選ぶたびに自動で重い検索が走っていました。これを、「この条件で表示」ボタンを押したときだけ実行するように変更しました。サーバへの無駄な検索を減らせます。

- 絞り込み無しの初回アクセスは検索せず、操作を促すだけにします。
- 共有リンク・再読込・戻る/進む（条件が付いたURL）は従来どおり自動で表示します。
- ページ送りや結果内の操作（除外解除など）は従来どおり即時に動きます。

## 技術メモ

- 期間: `RankingBanPageRepository::buildDateClause` を区間オーバーラップ条件に変更（`COALESCE(end_datetime, now) >= since AND datetime <= until`、`now` は毎時クロールの基準時刻）。
- 数値入力・ボタン・動的ラベル: `app/Views/ranking_ban_content.php`（サーバ描画＋バニラJS）と `public/style/pages/ranking_ban.css`。
- 絞り込みの変更はクライアントの state とUIだけ更新し、送信時にのみ /list を取得。CDNキャッシュキーのクエリ順は従来と同一に維持。

## 確認

- PHP 構文・PHPStan OK。
- /list を新SQLで実行し、区間オーバーラップが意図どおり（消えたままは now>=since のときだけ期間に重なる）。
- ヘッドレスChromeで動作確認: 空状態で自動ロードしない / 選択しても読み込まない＋掲載状況で文言が切替 / ボタンで読み込む / 数値↔プリセット連動 / 期間ラベルの出し分け。

## スクリーンショット

詳細設定（期間ラベル「未掲載中の時期」・「消えている時間」の数値入力・「この条件で表示」ボタン・初回の操作プロンプト）

![詳細設定](https://raw.githubusercontent.com/Open-Chat-Graph/Open-Chat-Graph/assets/pr-screenshots/oc-publication-analytics-filters/detail-form.png)

「この条件で表示」を押した後の一覧

![表示後](https://raw.githubusercontent.com/Open-Chat-Graph/Open-Chat-Graph/assets/pr-screenshots/oc-publication-analytics-filters/results-after-submit.png)

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
