### PR TITLE
[STG] fix: 「関連テーマ」を右端までスクロールすると黒いフェードが残る問題を修正

### DIFF
--- a/frontend/ranking/src/components/RecommendThemeShelf.tsx
+++ b/frontend/ranking/src/components/RecommendThemeShelf.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from 'react'
+import { memo } from 'react'
 import useSWR from 'swr'
 import { Chip, Skeleton } from '@mui/material'
 import { useAtomValue } from 'jotai'
@@ -7,6 +7,7 @@ import { t } from '../config/translation'
 import { isSP } from '../utils/utils'
 import { listParamsState } from '../store/atom'
 import { useDraggableScroll } from '../hooks/useDraggableScroll'
+import { useRightFadeMask } from '../hooks/ScrollableHooks'
 
 // urlRoot: '' (ja) | '/tw' | '/th'。slug はサーバ側 urlencode 済みなので再エンコードしない。
 const recommendHref = (slug: string) => `${rankingArgDto.urlRoot}/recommend/${slug}`
@@ -17,10 +18,12 @@ const fetcher = (url: string): Promise<ThemeTag[]> =>
     r.ok ? r.json() : []
   )
 
-// 右端フェードは CSS の mask-image で出す（JS状態に紐づけない）。チップが右端まで届いたとき
-// だけ自然にフェードし、収まっていれば右端は空なので見えない。JSの実測 boolean を使うと
-// 「初期 false → 計測後 true」を必ず経由してスライド切替でちらつくため、CSS に寄せている。
-const RIGHT_FADE_MASK = 'linear-gradient(to right, #000 calc(100% - 36px), transparent 100%)'
+// 右端フェードは CSS の mask-image で出す（JS状態＝React再描画には紐づけない）。フェード幅だけ
+// CSS変数 --shelf-right-fade で持ち、useRightFadeMask が ref 経由で残スクロール量に追従させる
+// （再描画なし＝ちらつかない）。デフォルトは FADE_PX でフェードON、右端に達すると 0 になって消える。
+// 実測 boolean(state)を使うと「初期 false→計測後 true」を経由しスライド切替でちらつくため避ける。
+const FADE_PX = 36
+const RIGHT_FADE_MASK = `linear-gradient(to right, #000 calc(100% - var(--shelf-right-fade, ${FADE_PX}px)), transparent 100%)`
 
 // 取得前に高さを確保するチップ用スケルトン（pill 形・高さ32でチップと同寸）。
 const SKELETON_CHIP_WIDTHS = [76, 56, 92, 64, 84]
@@ -65,11 +68,13 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf({
   })
   const themes = data ?? []
 
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const { events } = useDraggableScroll(scrollRef)
-
   // 取得前はチップをスケルトンで埋める。取得後にタグが無ければ何も出さない（見出しごと畳む）。
   const loading = data === undefined
+
+  // チップ数が変わったら右端フェード幅を測り直す（取得直後・絞り込み変更時）。
+  const scrollRef = useRightFadeMask(loading ? -1 : themes.length, FADE_PX)
+  const { events } = useDraggableScroll(scrollRef)
+
   if (!loading && themes.length === 0) return null
 
   return (
@@ -107,7 +112,7 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf({
           paddingBottom: 2,
           cursor: sp ? 'auto' : 'grab',
           scrollbarWidth: 'none',
-          // 右端フェード（CSSのみ・JS状態に依存しないのでちらつかない）。
+          // 右端フェード（フェード幅は --shelf-right-fade で残スクロール量に追従＝右端で消える）。
           maskImage: RIGHT_FADE_MASK,
           WebkitMaskImage: RIGHT_FADE_MASK,
         }}

--- a/frontend/ranking/src/hooks/ScrollableHooks.ts
+++ b/frontend/ranking/src/hooks/ScrollableHooks.ts
@@ -32,6 +32,51 @@ export function useIsRightScrollable(
   return [isRightScrollable, ref]
 }
 
+/**
+ * 横スクロール領域の「右端フェード幅」を残スクロール量に追従させる。
+ * CSS変数 `--shelf-right-fade` を ref 経由で直接書き換えるだけで、React state を使わない
+ * （= 再描画もちらつきも起きない）。残量が fadePx 未満になるとフェードが縮み、右端に到達すると
+ * 0 になって自然に消える。あふれていない時も残量0で最初から消える。
+ *
+ * 静的な mask（常に右36pxをフェード）だと「右端までスクロールしても最後のチップが暗いまま」に
+ * なるため、残量に連動させてこれを解消する。state を使う useIsRightScrollable はスライド切替の
+ * 再マウントで初期 false→true を経由してちらつくので、棚ではこちらの imperative 版を使う。
+ *
+ * @param trigger 中身（チップ数など）が変わったら再計測するためのトリガ値
+ * @param fadePx  フェード最大幅(px)。CSS側のデフォルト値と一致させること
+ */
+export function useRightFadeMask(
+  trigger: unknown,
+  fadePx = 36
+): React.RefObject<HTMLDivElement | null> {
+  const ref = useRef<HTMLDivElement>(null)
+
+  // useLayoutEffect: ペイント前に残量を計測してフェード幅を確定（チップ取得直後も先に反映）。
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const update = () => {
+      const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft
+      const w = Math.max(0, Math.min(fadePx, remaining))
+      el.style.setProperty('--shelf-right-fade', `${w}px`)
+    }
+
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    // コンテナ幅の変化（リサイズ・スライド幅変動）でも測り直す。
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro.disconnect()
+    }
+  }, [trigger, fadePx])
+
+  return ref
+}
+
 export function useIsLeftRightScrollable(
   useEffectTrigerValue: unknown
 ): [boolean, boolean, React.RefObject<HTMLDivElement | null>] {


### PR DESCRIPTION
## 問題

ランキングページの「関連テーマ」を横スクロールして一番右まで送ると、本来は「まだ右に続きがある」ことを示す黒いフェードが、続きが無いのに最後のテーマの上に残ったままになっていました。

## 原因

右端フェードを「常に右端36pxを暗くする」固定の CSS mask で出していたため、スクロール位置に関係なく一番右のチップが暗くなっていました。

## 対処

フェード幅を CSS 変数 `--shelf-right-fade` に切り出し、残りのスクロール量に追従させました（新フック `useRightFadeMask`・[ScrollableHooks.ts](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/d3814d838ba591f8147cafa5e4e4e07ae1bed965/frontend/ranking/src/hooks/ScrollableHooks.ts#L35-L80)、[RecommendThemeShelf.tsx](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/d3814d838ba591f8147cafa5e4e4e07ae1bed965/frontend/ranking/src/components/RecommendThemeShelf.tsx#L20-L26)）。

- 値は `ref` 経由で DOM に直接書き込むため React の再描画は起きず、先の修正の狙いだった**スライド切替のちらつきも維持**されます。
- 残スクロール量が 36px を切るとフェードが自然に縮み、**右端に到達すると 0 になって消えます**。あふれていない文脈でも最初からフェードは出ません。

## スクリーンショット（右端までスクロールした状態）

![関連テーマ右端フェード before/after](https://raw.githubusercontent.com/Open-Chat-Graph/Open-Chat-Graph/assets/pr-screenshots/oc-theme-shelf-fade-right-end/fade_compare.png)

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/oc-graph-3`
