### PR TITLE
[STG] skip-ci: スクロール中にスワイプすると消えるリストがトップへ押し戻される問題を修正

### DIFF
--- a/frontend/ranking/src/components/OcListMainTabs.tsx
+++ b/frontend/ranking/src/components/OcListMainTabs.tsx
@@ -74,14 +74,6 @@ function OcListSwiper({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  if (tIndex && !scrollY.current) {
-    scrollY.current = window.scrollY
-  }
-
-  if (!tIndex && scrollY.current) {
-    scrollY.current = 0
-  }
-
   useLayoutEffect(() => {
     if (tIndex && scrollY.current) {
       scrollToTop()
@@ -92,11 +84,22 @@ function OcListSwiper({
     <Swiper
       initialSlide={initialIndex.current}
       simulateTouch={true}
+      // スワイプ開始時点の縦スクロール量を保持する。これを使い、遷移中に「消えていく側スライド」を
+      // position:absolute + top:-scrollY で補正し、スクロール状態を保ったまま滑らかに退場させる。
+      // ※ transitionStart で window.scrollY を読むと、先に発火する onSlideChange の scrollToTop() で
+      //   すでに 0 にリセットされていて補正値が 0 になり、消えるリストが一瞬トップへ押し戻されてガタつく
+      //   （Swiper のイベント順: onSlideChange → onSlideChangeTransitionStart）。リセット前のここで取る。
+      onTouchStart={() => {
+        scrollY.current = window.scrollY
+      }}
       onSlideChange={onSlideChange}
       onSlideChangeTransitionStart={() =>
         setTIndex([cateIndex, getQuery(cateIndex, cateIndex, params)])
       }
-      onSlideChangeTransitionEnd={() => setTIndex(null)}
+      onSlideChangeTransitionEnd={() => {
+        setTIndex(null)
+        scrollY.current = 0
+      }}
       onSwiper={onSwiper}
       speed={260}
     >


### PR DESCRIPTION
スクロールした状態で隣のカテゴリにスワイプした時、消えていくリストが一瞬トップへ押し戻されてちらつく問題を修正。

## 原因
スクロール状態を保ったまま消えていく仕組みは「消えていく側スライドを `position:absolute` + `top:-スクロール量` で補正」している。そのスクロール量を遷移開始(`onSlideChangeTransitionStart`)で `window.scrollY` から取得していたが、Swiper のイベント順が `onSlideChange → onSlideChangeTransitionStart` のため、先に走る `onSlideChange` の `scrollToTop()` でスクロールが 0 にリセットされ、補正値が 0px になっていた（消えるリストがトップへ押し戻される）。Swiper 更新(CRA→Vite移行)でイベント順が変わって表面化したもの。

## 対処
スクロール量をリセット前＝スワイプ開始時(`onTouchStart`)に取得して使うように変更。消えていく側が `top:-スクロール量` で正しく補正され、元のスクロール位置を保ったまま退場する。

## 確認（ローカル）
- スクロール800の状態で実機タッチドラッグ→消える側スライドが `top:-800px` に補正され、先頭アイテムが元位置(-467)に留まる（トップへ押し戻されない）。型・lint・テスト24件・ビルドOK。

skip-ci: PHP非変更（ランキングのフロント TSX のみ）。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
