### PR TITLE
[PROD] スクロール中スワイプのちらつき修正＋関連テーマ右端フェード改善を本番反映

### DIFF
--- a/frontend/ranking/src/components/OcListMainTabs.tsx
+++ b/frontend/ranking/src/components/OcListMainTabs.tsx
@@ -74,14 +74,6 @@ function OcListSwiper({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  if (tIndex && !scrollY.current) {
-    scrollY.current = window.scrollY
-  }
-
-  if (!tIndex && scrollY.current) {
-    scrollY.current = 0
-  }
-
   useLayoutEffect(() => {
     if (tIndex && scrollY.current) {
       scrollToTop()
@@ -92,11 +84,22 @@ function OcListSwiper({
     <Swiper
       initialSlide={initialIndex.current}
       simulateTouch={true}
+      // スワイプ開始時点の縦スクロール量を保持する。これを使い、遷移中に「消えていく側スライド」を
+      // position:absolute + top:-scrollY で補正し、スクロール状態を保ったまま滑らかに退場させる。
+      // ※ transitionStart で window.scrollY を読むと、先に発火する onSlideChange の scrollToTop() で
+      //   すでに 0 にリセットされていて補正値が 0 になり、消えるリストが一瞬トップへ押し戻されてガタつく
+      //   （Swiper のイベント順: onSlideChange → onSlideChangeTransitionStart）。リセット前のここで取る。
+      onTouchStart={() => {
+        scrollY.current = window.scrollY
+      }}
       onSlideChange={onSlideChange}
       onSlideChangeTransitionStart={() =>
         setTIndex([cateIndex, getQuery(cateIndex, cateIndex, params)])
       }
-      onSlideChangeTransitionEnd={() => setTIndex(null)}
+      onSlideChangeTransitionEnd={() => {
+        setTIndex(null)
+        scrollY.current = 0
+      }}
       onSwiper={onSwiper}
       speed={260}
     >

--- a/frontend/ranking/src/components/RecommendThemeShelf.tsx
+++ b/frontend/ranking/src/components/RecommendThemeShelf.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from 'react'
+import { memo } from 'react'
 import useSWR from 'swr'
 import { Chip, Skeleton } from '@mui/material'
 import { useAtomValue } from 'jotai'
@@ -7,6 +7,7 @@ import { t } from '../config/translation'
 import { isSP } from '../utils/utils'
 import { listParamsState } from '../store/atom'
 import { useDraggableScroll } from '../hooks/useDraggableScroll'
+import { useRightFadeMask } from '../hooks/ScrollableHooks'
 
 // urlRoot: '' (ja) | '/tw' | '/th'。slug はサーバ側 urlencode 済みなので再エンコードしない。
 const recommendHref = (slug: string) => `${rankingArgDto.urlRoot}/recommend/${slug}`
@@ -17,10 +18,12 @@ const fetcher = (url: string): Promise<ThemeTag[]> =>
     r.ok ? r.json() : []
   )
 
-// 右端フェードは CSS の mask-image で出す（JS状態に紐づけない）。チップが右端まで届いたとき
-// だけ自然にフェードし、収まっていれば右端は空なので見えない。JSの実測 boolean を使うと
-// 「初期 false → 計測後 true」を必ず経由してスライド切替でちらつくため、CSS に寄せている。
-const RIGHT_FADE_MASK = 'linear-gradient(to right, #000 calc(100% - 36px), transparent 100%)'
+// 右端フェードは CSS の mask-image で出す（JS状態＝React再描画には紐づけない）。フェード幅だけ
+// CSS変数 --shelf-right-fade で持ち、useRightFadeMask が ref 経由で残スクロール量に追従させる
+// （再描画なし＝ちらつかない）。デフォルトは FADE_PX でフェードON、右端に達すると 0 になって消える。
+// 実測 boolean(state)を使うと「初期 false→計測後 true」を経由しスライド切替でちらつくため避ける。
+const FADE_PX = 36
+const RIGHT_FADE_MASK = `linear-gradient(to right, #000 calc(100% - var(--shelf-right-fade, ${FADE_PX}px)), transparent 100%)`
 
 // 取得前に高さを確保するチップ用スケルトン（pill 形・高さ32でチップと同寸）。
 const SKELETON_CHIP_WIDTHS = [76, 56, 92, 64, 84]
@@ -65,11 +68,13 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf({
   })
   const themes = data ?? []
 
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const { events } = useDraggableScroll(scrollRef)
-
   // 取得前はチップをスケルトンで埋める。取得後にタグが無ければ何も出さない（見出しごと畳む）。
   const loading = data === undefined
+
+  // チップ数が変わったら右端フェード幅を測り直す（取得直後・絞り込み変更時）。
+  const scrollRef = useRightFadeMask(loading ? -1 : themes.length, FADE_PX)
+  const { events } = useDraggableScroll(scrollRef)
+
   if (!loading && themes.length === 0) return null
 
   return (
@@ -107,7 +112,7 @@ const RecommendThemeShelf = memo(function RecommendThemeShelf({
           paddingBottom: 2,
           cursor: sp ? 'auto' : 'grab',
           scrollbarWidth: 'none',
-          // 右端フェード（CSSのみ・JS状態に依存しないのでちらつかない）。
+          // 右端フェード（フェード幅は --shelf-right-fade で残スクロール量に追従＝右端で消える）。
           maskImage: RIGHT_FADE_MASK,
           WebkitMaskImage: RIGHT_FADE_MASK,
         }}

--- a/frontend/ranking/src/hooks/ScrollableHooks.ts
+++ b/frontend/ranking/src/hooks/ScrollableHooks.ts
@@ -32,6 +32,51 @@ export function useIsRightScrollable(
   return [isRightScrollable, ref]
 }
 
+/**
+ * 横スクロール領域の「右端フェード幅」を残スクロール量に追従させる。
+ * CSS変数 `--shelf-right-fade` を ref 経由で直接書き換えるだけで、React state を使わない
+ * （= 再描画もちらつきも起きない）。残量が fadePx 未満になるとフェードが縮み、右端に到達すると
+ * 0 になって自然に消える。あふれていない時も残量0で最初から消える。
+ *
+ * 静的な mask（常に右36pxをフェード）だと「右端までスクロールしても最後のチップが暗いまま」に
+ * なるため、残量に連動させてこれを解消する。state を使う useIsRightScrollable はスライド切替の
+ * 再マウントで初期 false→true を経由してちらつくので、棚ではこちらの imperative 版を使う。
+ *
+ * @param trigger 中身（チップ数など）が変わったら再計測するためのトリガ値
+ * @param fadePx  フェード最大幅(px)。CSS側のデフォルト値と一致させること
+ */
+export function useRightFadeMask(
+  trigger: unknown,
+  fadePx = 36
+): React.RefObject<HTMLDivElement | null> {
+  const ref = useRef<HTMLDivElement>(null)
+
+  // useLayoutEffect: ペイント前に残量を計測してフェード幅を確定（チップ取得直後も先に反映）。
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const update = () => {
+      const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft
+      const w = Math.max(0, Math.min(fadePx, remaining))
+      el.style.setProperty('--shelf-right-fade', `${w}px`)
+    }
+
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    // コンテナ幅の変化（リサイズ・スライド幅変動）でも測り直す。
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro.disconnect()
+    }
+  }, [trigger, fadePx])
+
+  return ref
+}
+
 export function useIsLeftRightScrollable(
   useEffectTrigerValue: unknown
 ): [boolean, boolean, React.RefObject<HTMLDivElement | null>] {


### PR DESCRIPTION
stg を本番(main)へ昇格。今回 main へ載るのは2件:

- #567 スクロール中スワイプで消えるリストがトップへ押し戻される問題を修正（消えていく側スライドの scrollToTop 補正値を onTouchStart で取得しイベント順レースを解消）
- #565 関連テーマ右端フェードを残スクロール量に追従させ右端到達で消えるよう改善（fix/oc-theme-shelf-fade-right-end・stg側で先行マージ済み）

base=main / head=stg
---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
