### PR TITLE
[STG] 全画面広告（オファーウォール）の訪問者ごとの出し分けをやめて通常表示に戻す

### DIFF
--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -8,28 +8,6 @@ class GoogleAdsenseConfig
     static string $googleAdsenseClient = 'ca-pub-2330982526015125'; // 広告クライアントID
 
     /**
-     * Offerwall（全画面メッセージ）を「常に表示」にする /recommend タグ（ja の正規タグ名で一致判定）。
-     *
-     * 通常の /recommend ページは GoogleAdsense::gTag(smartOfferwall: true) でクライアント側の出し分けを行い、
-     * 「初回 × 検索エンジン流入」の初見訪問にだけ Offerwall を抑制して SEO ランディングの第一印象を守る。
-     * 一方ここに挙げたタグは、アダルト/大人系で（a）Offerwall の違和感が小さく（b）第一印象を守る必要性が低く
-     * （c）高収益なので、出し分けの例外として「初見でも常時表示」する。
-     *
-     * 判定は recommend_content.php で $_tagIndex（= 正規タグ = URLパス = Cloudflare のキャッシュキー）に対して行うため、
-     * 訪問者ごとに HTML が変わらず、エッジキャッシュと無衝突。タグを増減したいときはこの配列を編集するだけ。
-     */
-    static array $offerwallAlwaysOnTags = [
-        '下ネタ',
-        '大人',
-        'その先',
-        '40代',
-        '50代',
-        '60代',
-        '70代',
-        '全国 雑談', // 半角スペース（U+0020）。ja.json の正規タグと完全一致させること
-    ];
-
-    /**
      * Google AdSense広告スロット設定
      *
      * キー: スロット識別子（文字列）

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -84,30 +84,11 @@ class GoogleAdsense
     }
 
     /**
-     * このタグ（/recommend の正規タグ、または /oc の部屋タグ $oc['tag1']）が
-     * 「Offerwall 常時表示」対象か。GoogleAdsenseConfig::$offerwallAlwaysOnTags と照合する。
-     * tag1 等は DB から HTML エスケープされた形で来る場合があるので、内部で
-     * htmlspecialchars_decode してから厳密一致する（recommend_content.php と同じ正規化）。
-     * /recommend と /oc がこの1メソッドを共用し、判定がドリフトしないようにする。
-     */
-    public static function isOfferwallAlwaysOn(?string $tag): bool
-    {
-        if ($tag === null || $tag === '') return false;
-        return in_array(htmlspecialchars_decode($tag), GoogleAdsenseConfig::$offerwallAlwaysOnTags, true);
-    }
-
-    /**
      * @param bool $suppressOfferwall true でこのページの Offerwall（全画面メッセージ）のみ常時抑制する。
      *                                同意メッセージ・広告ブロック回復など他のメッセージ表示には影響しない。
      *                                （blog 記事など「初見読者に絶対 Offerwall を出さない」ページ用）
-     * @param bool $smartOfferwall    true で Offerwall を訪問者ごとに出し分ける（oc-pdca 2026-06）。
-     *                                「初回訪問 × 検索エンジンからの流入」のときだけ Offerwall を抑制して
-     *                                SEO ランディングの第一印象を守り、再訪・Direct/SNS・2ページ目以降は通常表示。
-     *                                判定はブラウザ JS（document.referrer + localStorage）で行うため、
-     *                                サーバが返す HTML は全訪問者で同一＝Cloudflare のエッジキャッシュと無衝突。
-     *                                $suppressOfferwall が true の場合はそちらが優先（常時抑制）。
      */
-    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false, bool $smartOfferwall = false)
+    public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false)
     {
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
 
@@ -120,53 +101,6 @@ class GoogleAdsense
                 googlefc.controlledMessagingFunction = function (message) {
                     message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
                 };
-            </script>
-            EOT;
-        } elseif ($smartOfferwall) {
-            // 訪問者ごとの出し分け。判定（初回×検索流入）はクライアント JS の実行時に行うので、
-            // キャッシュされる HTML 自体は全訪問者で同一。adsbygoogle.js より前に定義する必要があるため
-            // 文字列補間を避けて nowdoc で出力する。https://developers.google.com/funding-choices/fc-api-docs
-            echo <<<'EOT'
-            <script>
-                (function () {
-                    window.googlefc = window.googlefc || {};
-                    var suppress = false;
-                    try {
-                        var host = '';
-                        try { host = new URL(document.referrer).hostname; } catch (e) {}
-                        var fromSearch = /(^|\.)(google|bing|yahoo|duckduckgo|baidu|naver|daum|ecosia|brave|sogou)\./i.test(host);
-                        var firstVisit = true;
-                        try { firstVisit = !window.localStorage.getItem('ocReturning'); } catch (e) {}
-                        // 初回訪問 かつ 検索エンジンからの流入のときだけ Offerwall を抑制する
-                        suppress = firstVisit && fromSearch;
-                        // 「再訪」フラグは“ページを開いた瞬間”では立てない。即バック（無反応で離脱）した人は
-                        // 次回も初見扱いのまま壁を猶予する。簡単なエンゲージメント（スクロール / 操作 / 約10秒滞在）が
-                        // 起きたときだけ ocReturning を立て、以降の訪問は通常表示にする。
-                        if (firstVisit) {
-                            var marked = false, dwellTimer = 0;
-                            var mark = function () {
-                                if (marked) return;
-                                marked = true;
-                                try { window.localStorage.setItem('ocReturning', '1'); } catch (e) {}
-                                window.removeEventListener('scroll', mark);
-                                window.removeEventListener('pointerdown', mark);
-                                window.removeEventListener('keydown', mark);
-                                if (dwellTimer) { clearTimeout(dwellTimer); }
-                            };
-                            window.addEventListener('scroll', mark, { passive: true });
-                            window.addEventListener('pointerdown', mark, { passive: true });
-                            window.addEventListener('keydown', mark, { passive: true });
-                            try { dwellTimer = window.setTimeout(mark, 10000); } catch (e) {}
-                        }
-                    } catch (e) { suppress = false; }
-                    googlefc.controlledMessagingFunction = function (message) {
-                        if (suppress) {
-                            message.proceed(false, [window.googlefc.MessageTypeEnum.OFFERWALL]);
-                        } else {
-                            message.proceed(true);
-                        }
-                    };
-                })();
             </script>
             EOT;
         }

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -207,14 +207,7 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
 
     <?php if ($enableAdsense): ?>
       <?php // ocTopWide2(手動横長)は撤去済み: impRPM¥14/CTR0.21%で「関連ルーム」棚への回遊を遮るだけだった(2026-06実測)。gTag は自動広告に必要なので維持 ?>
-      <?php
-      // Offerwall 出し分け(oc-pdca): /oc も /recommend と同じ判定。初回×検索流入の初見だけ壁を抑制して
-      // SEO ランディングの第一印象を守り（再訪・Direct/SNS・2ページ目以降は表示）、長尾24万ページの初見体験を守る。
-      // 部屋の recommend タグ($oc['tag1'])が常時ON対象（例: 下ネタ）なら例外として常時表示。
-      // 判定は部屋単位＝全訪問者同一HTMLなので Cloudflare のエッジキャッシュと無衝突。判定ロジックは /recommend と共用。
-      $_ocOfferwallAlwaysOn = GAd::isOfferwallAlwaysOn((string)($oc['tag1'] ?? ''));
-      ?>
-      <?php GAd::gTag(smartOfferwall: !$_ocOfferwallAlwaysOn) ?>
+      <?php GAd::gTag() ?>
     <?php endif ?>
 
     <?php // 関連ルーム(類似サイズ/おすすめ)は recommend 静的キャッシュ(.dat)から都度組み立て（MySQL不使用） ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -61,14 +61,7 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
     <section class="recommend-ranking-section">
       <?php if (isset($recommend)) : ?>
         <?php if ($enableAdsense): ?>
-          <?php
-          // Offerwall 出し分け(oc-pdca): 初回×検索流入の初見だけ壁を抑制して SEO ランディングの第一印象を守り、
-          // 再訪・Direct/SNS・2ページ目以降は通常表示（判定はクライアント JS）。広告自体は常に通常表示。
-          // ただしアダルト/大人系の高収益タグ（GoogleAdsenseConfig::$offerwallAlwaysOnTags）は出し分けの例外＝常時表示。
-          // 判定はタグ（= 正規タグ = URLパス = CF キャッシュキー）単位なのでエッジキャッシュと無衝突。/oc と同じ判定を共用。
-          $_offerwallAlwaysOn = GAd::isOfferwallAlwaysOn($tag);
-          ?>
-          <?php GAd::gTag(smartOfferwall: !$_offerwallAlwaysOn) ?>
+          <?php GAd::gTag() ?>
         <?php endif ?>
         <?php // 手動広告(recommendSeparatorResponsive)は撤去済み: impRPM¥20=自動広告(¥220)の1/11なのに
               // リストを分断していた(2026-06実測)。広告挿入のためだけだったチャンク分割も廃止し30件を一本のリストで表示 ?>


### PR DESCRIPTION
全画面広告(オファーウォール)を「初回×検索流入の訪問者には出さない」「一部の高収益タグは常時表示」と訪問者ごとに出し分けていた仕組みを撤去し、Google 既定どおりの通常表示に戻します。

## 背景
出し分けの分岐が増えて挙動が分かりにくくなっていたため、一旦シンプルに戻す。

## 変更点
- /recommend・/oc を単純な `gTag()` 呼び出しに戻す
- `GoogleAdsense::gTag()` の smartOfferwall 経路と `isOfferwallAlwaysOn()` を削除
- `GoogleAdsenseConfig` の常時表示タグ一覧(`$offerwallAlwaysOnTags`)を削除
- ブログの常時非表示(`suppressOfferwall`)は維持

4ファイル -105/+3。php -l OK。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
