### PR TITLE
[STG] ルームページの構造化データ更新日を「内容が実際に変わった日」に統一

### DIFF
--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -140,11 +140,19 @@ class OpenChatPageController
             $oc['tag1'] ?: $category,
         );
 
+        // dateModified は「ページ内容が実際に変わった日」を使う。open_chat.updated_at は
+        // メタ情報(タイトル/説明/ステータス)変更時しか動かず、人数・推移など主役コンテンツの
+        // 変化を反映しないため Google に誤った再クロールヒントを送ってしまう。sitemap と同じ
+        // 内容ベースの lastmod (oc_sitemap_lastmod) を getOpenChatByIdWithTag が
+        // COALESCE(sl.lastmod, oc.updated_at) として返すので、それを使う（未登録 room は
+        // updated_at にフォールバック済み。念のため content_lastmod 欠落時も updated_at へ）。
+        $_dateModified = new \DateTime($oc['content_lastmod'] ?? $oc['updated_at']);
+
         $_schema = $ocPageSchema->generateSchema(
             $_meta->title,
             $_meta->description,
             new \DateTime($oc['created_at']),
-            new \DateTime($oc['updated_at']),
+            $_dateModified,
             $oc,
         );
 

--- a/app/Models/Repositories/OpenChatPageRepository.php
+++ b/app/Models/Repositories/OpenChatPageRepository.php
@@ -72,7 +72,8 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
                 tg2.tag AS tag2,
                 tg3.tag AS tag3,
                 pc.narrative_data AS narrative_data,
-                pc.chart_meta AS chart_meta
+                pc.chart_meta AS chart_meta,
+                COALESCE(sl.lastmod, oc.updated_at) AS content_lastmod
             FROM
                 open_chat AS oc
                 LEFT JOIN statistics_ranking_hour AS rh ON oc.id = rh.open_chat_id
@@ -82,6 +83,7 @@ class OpenChatPageRepository implements OpenChatPageRepositoryInterface
                 LEFT JOIN oc_tag AS tg2 ON oc.id = tg2.id
                 LEFT JOIN oc_tag2 AS tg3 ON oc.id = tg3.id
                 LEFT JOIN oc_page_cache AS pc ON oc.id = pc.open_chat_id
+                LEFT JOIN oc_sitemap_lastmod AS sl ON oc.id = sl.open_chat_id
             WHERE
                 oc.id = :id";
 


### PR DESCRIPTION
個別ルームページ(/oc/{id})の構造化データの更新日(dateModified)が、タイトルや説明などメタ情報を編集したときしか動かず、人数や推移といった主役コンテンツが変わっても更新されなかった。Google に古い再クロールヒントを送ってしまうため、sitemap が既に使っている「内容が実際に変わった日」(`oc_sitemap_lastmod`)に揃えます。

## 変更点
- `OpenChatPageRepository` の1クエリ集約版に `oc_sitemap_lastmod` を LEFT JOIN し `COALESCE(lastmod, updated_at)` を返す(同一DB・追加クエリなし)
- コントローラはその値を dateModified に使用。未登録ルームは `updated_at` にフォールバック

php -l / PHPStan OK。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
