### PR TITLE
[STG] fix: 最新の広告ブロッカーで広告ブロックの案内が表示されない問題を修正

### DIFF
--- a/public/js/security.js
+++ b/public/js/security.js
@@ -207,16 +207,24 @@ function whiteOut() {
 }
 
 async function blockblock() {
-  const agentsJsonUrl =
-    'https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json'
-
-  const response = await fetch(agentsJsonUrl)
-  const items = await response.json()
-  const patterns = items.map((item) => item.pattern)
-  const REGEX_CRAWLER = patterns.join('|')
-  const ua = window.navigator.userAgent
-  const result = ua.match(REGEX_CRAWLER)
-  if (result !== null) return
+  // クローラ(bot)には案内を出さないための UA 判定。判定用リストの取得が
+  // 失敗・タイムアウトしても、広告ブロック検出本体(下の HEAD fetch)は必ず走らせる。
+  //   ※ 以前はこの取得を素の await で行っていたため、リスト取得が失敗/ハングすると
+  //     関数ごと止まり、ホストブロック(hosts/DNS で googlesyndication を遮断)時に
+  //     whiteOut まで到達しなかった。try/catch + タイムアウトで素通りさせて修正。
+  try {
+    const agentsJsonUrl =
+      'https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json'
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), 4000)
+    const response = await fetch(agentsJsonUrl, { signal: ctrl.signal })
+    clearTimeout(timer)
+    const items = await response.json()
+    const REGEX_CRAWLER = items.map((item) => item.pattern).join('|')
+    if (window.navigator.userAgent.match(REGEX_CRAWLER) !== null) return
+  } catch (e) {
+    // リスト取得失敗時は通常ユーザーとして扱い、検出を継続する
+  }
 
   fetch('https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', {
     method: 'HEAD',
@@ -299,7 +307,21 @@ function detectAdBlock() {
       /(^|[;\s])width:\s*1px\s*!important/.test(styleAttr) &&
       /(^|[;\s])height:\s*1px\s*!important/.test(styleAttr)
 
-    if (collapsedByComputed || collapsedByInline) {
+    // (C) uBlock Origin / uBO Lite が 2026-06-15 のシム刷新(uBOLite 2026.621〜・
+    //     Chromium版。gorhill/uBlock コミット f5be2bbed + 89655c3f8)で導入した
+    //     新サロゲートへの対策。旧来の「iframe を 1px に潰す」手法をやめ、通常サイズの
+    //     空 iframe を作って data-ad-status="filled" を立て「配信済み広告」に偽装する
+    //     ようになった(中身は空の data: URL、iframe には src 属性も inline style も
+    //     付けない)。本物の AdSense は filled なら必ず googleads/doubleclick の src を
+    //     持ち、iframe に inline style(border・サイズ等)も付与する。その両方を欠いた
+    //     「filled を名乗る空 iframe」はこの新サロゲート以外に存在しないので検出する。
+    //     ※ no fill(unfilled)は上で除外済み。誤検知防止のため「filled 明示」を必須にする。
+    const fakeFilledBySurrogate =
+      adElement.getAttribute('data-ad-status') === 'filled' &&
+      (iframe.getAttribute('src') || '') === '' &&
+      styleAttr.trim() === ''
+
+    if (collapsedByComputed || collapsedByInline || fakeFilledBySurrogate) {
       blockedCount++
     }
   })


### PR DESCRIPTION
最新の広告ブロッカーを使っている閲覧者に、広告ブロック中の案内（オーバーレイ）が表示されなくなっていた問題を修正します。広告ブロック中だと収益が出ないため、案内が機能することは運営上重要です。

## 何が起きていたか

uBlock Origin / uBlock Origin Lite が 2026-06-15 に AdSense 用の差し替えスクリプト（シム）を全面刷新しました。Chrome 版では 2026-06-21 配信の uBOLite 2026.621 以降でこの新シムが有効になり、当サイトの検出をすり抜けるようになりました。

- 旧シム: 広告枠の iframe を 1px に潰す → その指紋（描画 1px / inline の `width:1px!important`+`height:1px!important`）で検出できていた
- 新シム: 1px 潰しをやめ、通常サイズの空 iframe を作って枠に `data-ad-status="filled"` を立て「配信済み広告」に偽装する（中身は空の `data:` URL、iframe に `src` 属性も inline style も付けない）→ 既存の 1px 指紋では検出不能

参考: gorhill/uBlock のコミット `f5be2bbed`（Improve googlesyndication_adsbygoogle shim）+ `89655c3f8`（Use a data: URI to prevent cross origin access）、起点 issue は uAssets#33303（tempmail.ninja 対策の汎用シム改善で、当サイトは巻き添え）。

## 対処

1. 検出ロジックに判定 (C) を追加（`public/js/security.js` の `detectAdBlock()`）
   - 「`data-ad-status="filled"` を名乗るのに iframe が実リソースの `src` を持たず、inline style も無い枠」を新シムと判定。
   - 本物の AdSense は filled なら必ず googleads/doubleclick の `src` を持ち、iframe に inline style（border・サイズ等）も付けるので、その両方を欠く枠はこの新シム以外に存在しない。未配信(no fill / unfilled)は従来どおり除外し、誤検知ゼロを維持。

2. `blockblock()` のホストブロック経路を堅牢化
   - クローラ判定用 UA リスト（GitHub）の取得を try/catch + 4秒タイムアウトで囲み、取得が失敗・ハングしても広告検出本体（`adsbygoogle.js` への HEAD fetch）が必ず走るようにした。hosts/DNS で googlesyndication を遮断するホストブロック時に案内が出ないケースの保険。

## 検証

Chrome 実機（headless, CDP）で実際の `detectAdBlock()` を 6 パターンに対して実行し、全て期待どおりを確認:

- 新 uBOL シム（filled・src無し・style無し） → 検出
- 本物の配信広告（src + style あり） → 非検出（誤検知なし）
- 未配信（unfilled・iframe無し） → 非検出
- 旧 uBOL 1px シム（Firefox 版は現行も 1px） → 検出（後方互換）
- filled・src無しだが style あり → 非検出（(C) は src無しと style無しの両方が必要）
- filled・src ありで style 無し → 非検出（同上）

通常ユーザーの画面表示には変化はなく（広告ブロック中の閲覧者にのみ既存オーバーレイが出るだけ）、UI の見た目自体は変更していません。

## 既知の残課題（本PR対象外）

- AdGuard/full uBO などのコスメティック除去（iframe 自体を削除 / `display:none` 単独）は別系統で、誤検知リスクがあるため本PRでは扱わない。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
