### PR TITLE
[STG] fix: 管理者の広告ブロック検出スキップをサーバ検証に変更（クッキー偽造での回避を防止）

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -398,6 +398,20 @@ Route::path('admin/cookie')
         return redirect();
     });
 
+// 管理者かどうかをサーバ側で検証する軽量エンドポイント（広告ブロック検出 ad_guard から呼ぶ）。
+// admin-enable クッキー(JS可視・偽造可)を信用せず、HttpOnly の admin クッキーを auth() で検証する。
+// Cloudflare 側で X-Ocg-Client ヘッダ必須＋レート制限（直叩き・総当たり対策）を併用する。
+Route::path('admin-check')
+    ->match(function (AdminAuthService $adminAuthService) {
+        try {
+            $ok = $adminAuthService->auth();
+        } catch (\Throwable $e) {
+            $ok = false;
+        }
+        noStore();
+        return response($ok ? '1' : '0', $ok ? 200 : 403);
+    });
+
 // Admin Log Viewer
 Route::path('admin/log', [LogController::class, 'index'])
     ->match(function () {

--- a/app/Views/components/ad_guard.php
+++ b/app/Views/components/ad_guard.php
@@ -37,6 +37,7 @@ $names = [
     'dec', 'key', 'host', 'bkey', 'revt', 'cls', 'aAbg', 'aAds', 'vDone', 'vFilled', 'vUnfilled',
     'scriptId', 'adsUrl', 'crawlerUrl', 'msg',
     'findSlots', 'allIns', 'adsRender', 'detect', 'mark', 'pushDL', 'recover', 'whiteOut',
+    'run', 'showGear',
     'fired', 'observers', 'poll', 'stop', 'cleanup', 'tryD', 'attach', 'ro', 'watched',
     'ovId', 'cOverlay', 'cCard', 'cIcon', 'cTitle', 'cBody', 'cNote', 'cBtn',
 ];
@@ -120,6 +121,10 @@ $E = [
     'adsUrl' => $enc('https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'),
     'crawlerUrl' => $enc('https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json'),
     'msg' => $enc(json_encode($messages, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+    'admEnable' => $enc('admin-enable='),
+    'gearId' => $enc('admin-gear-btn'),
+    'checkUrl' => $enc('/admin-check'),
+    'ocgHdr' => $enc('X-Ocg-Client'),
 ];
 
 // 乱数ノンス（同一コードでもバイト列を変える保険）
@@ -151,11 +156,18 @@ $zindex = 2147483000 + random_int(0, 647);
     var <?php echo $N['scriptId']; ?> = <?php echo $E['scriptId']; ?>;
     var <?php echo $N['msg']; ?> = JSON.parse(<?php echo $E['msg']; ?>);
 
-    var adm = (document.cookie.split('; ').filter(function (r) { return r.indexOf('admin-enable=') === 0; })[0] || '').split('=')[1];
-    if (adm) {
-      var g = document.getElementById('admin-gear-btn');
+    function <?php echo $N['showGear']; ?>() {
+      var g = document.getElementById(<?php echo $E['gearId']; ?>);
       if (g) { g.style.display = 'flex'; }
-      return;
+    }
+    var adm = (document.cookie.split('; ').filter(function (r) { return r.indexOf(<?php echo $E['admEnable']; ?>) === 0; })[0] || '').split('=')[1];
+    if (adm) {
+      var hh = {}; hh[<?php echo $E['ocgHdr']; ?>] = '1';
+      fetch(<?php echo $E['checkUrl']; ?>, { headers: hh, cache: 'no-store' })
+        .then(function (r) { if (r.ok) { <?php echo $N['showGear']; ?>(); } else { <?php echo $N['run']; ?>(); } })
+        .catch(function () { <?php echo $N['run']; ?>(); });
+    } else {
+      <?php echo $N['run']; ?>();
     }
 
     function <?php echo $N['allIns']; ?>() {
@@ -268,6 +280,7 @@ $zindex = 2147483000 + random_int(0, 647);
       document.documentElement.style.overflow = 'hidden';
     }
 
+    function <?php echo $N['run']; ?>() {
     (async function () {
       try {
         var ctrl = new AbortController();
@@ -324,5 +337,6 @@ $zindex = 2147483000 + random_int(0, 647);
       setTimeout(<?php echo $N['recover']; ?>, 2000);
       setTimeout(<?php echo $N['recover']; ?>, 5000);
     });
+    }
   } catch (e) {}
 })();</script>


### PR DESCRIPTION
広告ブロック検出の管理者スキップが、クッキー偽造で誰でも回避できてしまう問題の修正です。

## 問題

広告ブロック検出（`ad_guard`）は、JSから読める `admin-enable` クッキーが「存在するか」だけで管理者と判断し、検出をスキップしていました。このクッキーは DevTools で `admin-enable=1` をセットするだけで誰でも作れるため、広告ブロック中でも案内をかんたんに回避できる状態でした。

`admin-enable` はもともと UI（管理ギア表示）用のフラグで、本物の権限は HttpOnly の `admin` クッキーを `AdminAuthService::auth()` がHKDF検証しています。

## 対処

- 軽量エンドポイント `GET /admin-check` を追加。HttpOnly の `admin` クッキーを `auth()` で検証し、本物の管理者だけ `200`、それ以外は `403`（`no-store`）。偽造 `admin-enable` では `200` になりません。
- `ad_guard`: `admin-enable` がある時だけ `/admin-check` に問い合わせ、`200` のときだけギア表示＋検出スキップ。それ以外（403/失敗）は通常どおり検出を実行。通常の利用者（`admin-enable` 無し）は追加リクエストを一切行いません。
- 呼び出しに `X-Ocg-Client` ヘッダを付与。Cloudflare 側でヘッダ必須＋レート制限を併用し、直叩き・総当たりを防ぎます（CF 設定は別途）。

エンドポイント名・ヘッダ名・クッキー名も従来どおり毎リクエストでエンコードして埋め込み、配信 HTML に平文を残しません。

## 検証

php -l / PHPStan / JS構文 / 平文リーク無し を確認済み。stg（openchat-review-dev.me）で `/admin-check` が非管理者に 403 を返すこと、偽造クッキーでも検出が走ることを実機（Chrome）で確認してからマージします。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
