### PR TITLE
[PROD] fix: 管理者の広告ブロック検出スキップをサーバ検証に変更（クッキー偽造での回避を防止）

### DIFF
--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -398,6 +398,20 @@ Route::path('admin/cookie')
         return redirect();
     });
 
+// 管理者かどうかをサーバ側で検証する軽量エンドポイント（広告ブロック検出 ad_guard から呼ぶ）。
+// admin-enable クッキー(JS可視・偽造可)を信用せず、HttpOnly の admin クッキーを auth() で検証する。
+// Cloudflare 側で X-Ocg-Client ヘッダ必須＋レート制限（直叩き・総当たり対策）を併用する。
+Route::path('admin-check')
+    ->match(function (AdminAuthService $adminAuthService) {
+        try {
+            $ok = $adminAuthService->auth();
+        } catch (\Throwable $e) {
+            $ok = false;
+        }
+        noStore();
+        return response($ok ? '1' : '0', $ok ? 200 : 403);
+    });
+
 // Admin Log Viewer
 Route::path('admin/log', [LogController::class, 'index'])
     ->match(function () {

--- a/app/Views/components/ad_guard.php
+++ b/app/Views/components/ad_guard.php
@@ -37,6 +37,7 @@ $names = [
     'dec', 'key', 'host', 'bkey', 'revt', 'cls', 'aAbg', 'aAds', 'vDone', 'vFilled', 'vUnfilled',
     'scriptId', 'adsUrl', 'crawlerUrl', 'msg',
     'findSlots', 'allIns', 'adsRender', 'detect', 'mark', 'pushDL', 'recover', 'whiteOut',
+    'run', 'showGear',
     'fired', 'observers', 'poll', 'stop', 'cleanup', 'tryD', 'attach', 'ro', 'watched',
     'ovId', 'cOverlay', 'cCard', 'cIcon', 'cTitle', 'cBody', 'cNote', 'cBtn',
 ];
@@ -120,6 +121,10 @@ $E = [
     'adsUrl' => $enc('https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'),
     'crawlerUrl' => $enc('https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json'),
     'msg' => $enc(json_encode($messages, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+    'admEnable' => $enc('admin-enable='),
+    'gearId' => $enc('admin-gear-btn'),
+    'checkUrl' => $enc('/admin-check'),
+    'ocgHdr' => $enc('X-Ocg-Client'),
 ];
 
 // 乱数ノンス（同一コードでもバイト列を変える保険）
@@ -151,11 +156,18 @@ $zindex = 2147483000 + random_int(0, 647);
     var <?php echo $N['scriptId']; ?> = <?php echo $E['scriptId']; ?>;
     var <?php echo $N['msg']; ?> = JSON.parse(<?php echo $E['msg']; ?>);
 
-    var adm = (document.cookie.split('; ').filter(function (r) { return r.indexOf('admin-enable=') === 0; })[0] || '').split('=')[1];
-    if (adm) {
-      var g = document.getElementById('admin-gear-btn');
+    function <?php echo $N['showGear']; ?>() {
+      var g = document.getElementById(<?php echo $E['gearId']; ?>);
       if (g) { g.style.display = 'flex'; }
-      return;
+    }
+    var adm = (document.cookie.split('; ').filter(function (r) { return r.indexOf(<?php echo $E['admEnable']; ?>) === 0; })[0] || '').split('=')[1];
+    if (adm) {
+      var hh = {}; hh[<?php echo $E['ocgHdr']; ?>] = '1';
+      fetch(<?php echo $E['checkUrl']; ?>, { headers: hh, cache: 'no-store' })
+        .then(function (r) { if (r.ok) { <?php echo $N['showGear']; ?>(); } else { <?php echo $N['run']; ?>(); } })
+        .catch(function () { <?php echo $N['run']; ?>(); });
+    } else {
+      <?php echo $N['run']; ?>();
     }
 
     function <?php echo $N['allIns']; ?>() {
@@ -268,6 +280,7 @@ $zindex = 2147483000 + random_int(0, 647);
       document.documentElement.style.overflow = 'hidden';
     }
 
+    function <?php echo $N['run']; ?>() {
     (async function () {
       try {
         var ctrl = new AbortController();
@@ -324,5 +337,6 @@ $zindex = 2147483000 + random_int(0, 647);
       setTimeout(<?php echo $N['recover']; ?>, 2000);
       setTimeout(<?php echo $N['recover']; ?>, 5000);
     });
+    }
   } catch (e) {}
 })();</script>


### PR DESCRIPTION
管理者の広告ブロック検出スキップを、偽造クッキーで回避できないようサーバ検証に変更する対処を本番へ反映します。

詳細・検証内容: #578

stg（openchat-review-dev.me）で `/admin-check` が正しく動作（管理者ブラウザで 200）、インライン版が配信されていることを確認済み。

🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
