### PR TITLE
[STG] 全画面メッセージの表示中はアンカー広告を自動で隠して操作の邪魔をなくす

### DIFF
--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -111,5 +111,57 @@ class GoogleAdsense
         echo <<<EOT
         <script async {$dataOverlaysAttr}id="ads-by-google-script" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={$adClient}" crossorigin="anonymous"></script>
         EOT;
+
+        self::anchorGuard();
+    }
+
+    /**
+     * オファーウォール（全画面メッセージ）表示中だけアンカー広告を隠す。
+     *
+     * 全画面のオファーウォールとアンカー広告が同時に出ると重なって操作を阻害するため、
+     * Funding Choices が描画するオファーウォールのコンテナ（.fc-message-root /
+     * fundingchoicesmessages の iframe）が「画面を覆うサイズで存在する間」だけ、
+     * アンカー広告（data-anchor-status 属性を持つ ins）を display:none にする。
+     * 閉じられたら即座に復帰。Vignette・記事内広告など他フォーマットには触れない。
+     *
+     * 判定は全てクライアント JS（MutationObserver + rAF で1フレームに1回に集約）で行うため、
+     * サーバが返す HTML は全訪問者で同一＝Cloudflare のエッジキャッシュと無衝突。
+     * 広告ブロック環境では fc スクリプト自体が動かないので何もしない（無害）。
+     */
+    private static function anchorGuard()
+    {
+        echo <<<'EOT'
+        <style>html.oc-ow-open ins.adsbygoogle[data-anchor-status]{display:none !important;}</style>
+        <script>
+            (function () {
+                var root = document.documentElement;
+                function owOpen() {
+                    var el = document.querySelector('.fc-message-root, iframe[src*="fundingchoicesmessages"]');
+                    if (!el) return false;
+                    var r = el.getBoundingClientRect();
+                    return r.width > 200 && r.height > 200;
+                }
+                var scheduled = false;
+                function update() {
+                    scheduled = false;
+                    root.classList.toggle('oc-ow-open', owOpen());
+                }
+                // 連続する mutation を30msに1回の判定へ集約（rAFはバックグラウンドや
+                // headless で発火しないことがあるため使わない）
+                function schedule() {
+                    if (scheduled) return;
+                    scheduled = true;
+                    window.setTimeout(update, 30);
+                }
+                function start() {
+                    new MutationObserver(schedule)
+                        .observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class', 'style'] });
+                    schedule();
+                }
+                if (document.body) start();
+                else document.addEventListener('DOMContentLoaded', start);
+            })();
+        </script>
+        EOT;
     }
 }


### PR DESCRIPTION
## 問題

全画面メッセージ（オファーウォール）とアンカー広告（画面下部に貼り付く帯広告）が同時に表示されると、2つが重なってページが操作しづらくなる。

## 対処

オファーウォールが画面に出ている間だけアンカー広告を自動で非表示にし、閉じられたら即座に元へ戻す。

- 対象はアンカー広告のみ（`data-anchor-status` 属性を持つ広告枠だけを特定して隠す）。全画面広告(Vignette)・記事内広告・リワード広告には一切影響しない
- 判定はすべてブラウザ側JS：オファーウォールの描画コンテナ（`.fc-message-root` / fundingchoicesmessages の iframe）が「画面を覆うサイズで存在するか」を MutationObserver で監視（判定は30msに1回に集約）
- サーバが返すHTMLは全訪問者で同一のまま → Cloudflare のエッジキャッシュと無衝突
- 広告ブロック環境ではオファーウォール自体が描画されないため何もしない（無害）

## 動作確認（テストハーネス・headless Chrome）

実装が出力するガードJSそのものを抜き出したハーネスで検証：

```
initial:            アンカー表示 (block)
オファーウォール出現: アンカー非表示 (none) / 通常広告は表示のまま (block)
クローズ:            アンカー復帰 (block)
```

| 通常時（アンカー表示） | オファーウォール表示中（アンカー自動非表示） |
|---|---|
| ![通常時](https://raw.githubusercontent.com/Open-Chat-Graph/Open-Chat-Graph/assets/pr-screenshots/oc-anchor-offerwall-guard/anchor_normal.png) | ![表示中](https://raw.githubusercontent.com/Open-Chat-Graph/Open-Chat-Graph/assets/pr-screenshots/oc-anchor-offerwall-guard/anchor_during_ow.png) |

※ 本番のオファーウォールは Google の配信頻度制御下にあるためローカルで実物は再現できず、同一JSでのシミュレーションで検証。デプロイ後に実環境で挙動を確認する。

---
🤖 Generated with Claude Code (claude-fable-5)
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
