### PR TITLE
[PROD] fix: コメント投稿後にトップページの最近コメントが即時反映されない不具合を修正

### DIFF
--- a/.claude/skills/coding-guide/SKILL.md
+++ b/.claude/skills/coding-guide/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: coding-guide
+description: 実装ガイド。新規ページ追加（ルーティング/コントローラ/ビュー）、DB アクセスパターン、スキーマ変更、DI/ServiceProvider、クローラ設定、フロントエンド（React）のビルドと翻訳、ページ系キャッシュ生成アーキテクチャと genetop の詳細。PHP・フロントのコードを書く/変更する前に読む。
+---
+
+# 実装ガイド
+
+> 前提: CLAUDE.md の必守ルール（MimimalCMS 本体改造禁止・Repository は Interface とセット・スキーマ変更は schema SQL 編集だけ・キャッシュ生成の genetop/ドキュメント同期）に従う。本ガイドはその詳細と実装手順。
+
+## アーキテクチャ
+
+- **Framework**: 自作 MimimalCMS（軽量 MVC・DI）
+- **Language**: PHP 8.5
+- **Database**: 主データは MySQL/MariaDB、ランキング・統計は SQLite。生 SQL（ORM 無し）
+- **Frontend**: サーバサイド PHP テンプレート＋React 埋め込み（TypeScript, MUI, Chart.js, Swiper.js）
+
+主要ディレクトリ:
+
+- `/app/` - アプリ本体（MVC）
+  - `Config/` - ルーティング・アプリ設定
+  - `Controllers/` - HTTP ハンドラ（Api/ と Pages/）
+  - `Models/` - データアクセス層（Repository）
+  - `Services/` - ビジネスロジック
+    - `Crawler/Config/` - クローラ設定（OpenChatCrawlerConfig）
+  - `ServiceProvider/` - DI 用サービスプロバイダ
+  - `Views/` - テンプレートと React コンポーネント
+- `/shadow/` - MimimalCMS フレームワーク本体（改造禁止）
+- `/batch/` - バックグラウンド処理・cron ジョブ
+- `/shared/` - フレームワーク設定・DI マッピング
+- `/storage/` - 多言語データファイル・SQLite データベース
+
+設定ファイル:
+
+- 環境固有の設定は `local-secrets.php`（gitignore 済・DB 接続情報もここ）
+- フレームワーク設定は `/shared/MimimalCMS_*.php`
+- Autoload (PSR-4): `Shadow\` → `shadow/`、`App\` → `app/`、`Shared\` → `shared/`、`App\Views\` → `app/Views/Classes`
+- ヘルパー関数の定義場所: `meta()` / `t()` / `getFilePath()` は `app/Helpers/functions.php`、`view()` / `url()` / `fileUrl()` は `shared/MimimalCMS_HelperFunctions.php`（本体側・改造禁止）
+
+## DB アクセス
+
+```php
+use Shadow\DB;
+
+DB::connect(); // 必ず最初に接続する
+
+// 複数行 SELECT
+$stmt = DB::$pdo->prepare("SELECT * FROM table WHERE condition = ?");
+$stmt->execute([$value]);
+$results = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+// 1行 SELECT
+$stmt = DB::$pdo->prepare("SELECT * FROM table WHERE id = ?");
+$stmt->execute([$id]);
+$result = $stmt->fetch(\PDO::FETCH_ASSOC);
+```
+
+SQLite はランキング・統計データの読み取り最適化用で、データ種別ごとに `/storage/` に分かれている。
+
+### スキーマ変更（テーブル・カラム追加）
+
+`setup/schema/mysql/*.sql` を編集するだけ。デプロイ時に `batch/exec/sync_mysql_schema.php` が各 DB へ
+不足分を「追加だけ」自動反映する（既存データは壊さない。削除・型変更はしない）。`deploy.yml` もコードも触らない。
+
+- 反映前に確認: `docker compose exec app php batch/exec/sync_mysql_schema.php --dry-run`
+- 詳細・注意点: [`app/Services/Schema/README.md`](../../../app/Services/Schema/README.md)
+
+## DI（Dependency Injection）
+
+- Interface ベースの DI を `/shared/MimimalCmsConfig.php` で設定
+- 動的なバインドは `/app/ServiceProvider/` のサービスプロバイダで行う
+- 例: `OpenChatCrawlerConfigServiceProvider` は `AppConfig::$isMockEnvironment` に応じて本番/Mock 設定を切り替える
+
+Repository を新規作成するときは必ず `XxxRepositoryInterface` を作り DI バインドする（CLAUDE.md 必守ルール）。
+読み取り経路を別所（例: 既存クエリへの JOIN）に寄せて Repository を書き込み専用に縮められる場合もあるが、
+その判断とは無関係に Interface は最初から作る。
+
+### MimimalCMS のアプリ側拡張点
+
+横断的な振る舞いは本体（`shadow/`）ではなくアプリ側の拡張点で実現する:
+
+- 例外→HTTP コード対応: `MimimalCmsConfig::$httpErrors` ＋ `app/Exceptions/`
+- アプリ固有の例外ハンドリング: `app/Exceptions/Handlers/ApplicationExceptionHandler`（`$exceptionMap`）
+- DI 差し替え: `app/ServiceProvider/`
+- DB 接続の解放など: app 側の Repository にメソッドを生やしてコントローラから呼ぶ
+
+## 新規ページ追加（MVC）
+
+### 1. ルート追加 — `/app/Config/routing.php`
+
+```php
+Route::path('your-path', [\App\Controllers\Pages\YourController::class, 'method']);
+```
+
+### 2. コントローラ作成 — `/app/Controllers/Pages/`
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace App\Controllers\Pages;
+
+use Shadow\Kernel\Reception;
+use App\Models\Repositories\DB;
+
+class YourController
+{
+    public function index(Reception $reception)
+    {
+        DB::connect();
+        $stmt = DB::$pdo->prepare("SELECT ...");
+        $stmt->execute();
+        $data = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        $_meta = meta();
+        $_meta->title = 'Page Title';
+
+        return view('view_name', ['data' => $data, '_meta' => $_meta]);
+    }
+}
+```
+
+### 3. ビュー作成 — `/app/Views/`
+
+- 拡張子は `.php`
+- 変数に直接アクセス: `$data`, `$_meta`
+- ヘルパー関数: `url()`, `t()`, `fileUrl()`
+
+## クローリングシステム
+
+- `OpenChatCrawlerConfig` - 本番環境（実際の LINE URL を使用）
+- `MockOpenChatCrawlerConfig` - Mock 環境（`line-mock-api` サービスを使用）
+- サービスプロバイダが `AppConfig::$isMockEnvironment` に応じて自動で切り替える
+
+User Agent:
+
+```
+Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/Open-Chat-Graph/Open-Chat-Graph)
+```
+
+## フロントエンド（React）
+
+React ソースは**このリポ内 `frontend/`**（別リポではない）。各サブ dir が Vite+TS: `ranking`(ランキング) / `oc-app`(個別ルーム) / `all-room-stats`(全室統計)。
+
+- **ビルド**: `cd frontend/<name> && npm run build` → `public/js/...` にハッシュ付きバンドル出力（成果物は **gitignore**、コミット不要）。手ビルドはローカル確認用。
+- **PHP 参照**: `getFilePath('js/react','main-*.js')`（内部 glob、`app/Helpers/functions.php`）でハッシュ名を解決 → HTML 側の手修正は不要。
+- **翻訳**: フロント側の翻訳 TS（`ranking` は `src/config/translation.ts`、`oc-app` は `src/graph/util/translation.ts`）は PHP の `storage/translation.json` と**別物**。両方直す。
+- **デプロイ**: `deploy.yml` が `frontend/<name>/**` の変更を検知し自動で `npm ci && npm run build` → 配信。
+
+## ページ系キャッシュ生成・genetop（必須ルールの詳細）
+
+### 毎時・日次にキャッシュ生成を足したら genetop で全件実行できるようにする
+
+毎時/日次の cron（`SyncOpenChat` の hourlyTask/dailyTask 等）にキャッシュ生成系の処理を追加したら、
+必ず管理画面の **genetop**（`batch/exec/admin/genetop_exec.php`、AdminPageController から起動）からも
+**全ルーム分を一括で再生成（全件）** できるようにする。genetop は「全キャッシュを全件作り直す」入口なので、
+新しいキャッシュを足したらここにも全件モードで追加し、常に完全な状態を保つ。
+
+理由: 毎時/日次は「変動した部屋・新規部屋」など一部しか回さないため、処理を足しただけでは既存の
+大多数の部屋にキャッシュが行き渡らない（埋まるまで遅い、または未生成部屋がフォールバックの重い経路に
+なる）。genetop があればデプロイ後に全件バックフィルできる。例: グラフ可用性メタ `chart_meta`
+（oc_page_cache）は毎時/日次で増分生成しつつ、genetop が `UpdateOcPageCacheService::handle('')`
+（mode=''＝全ルーム）で全件再生成する。
+
+### ページ系キャッシュを変えたら README と管理画面フロー(log_index.php) も対で更新する
+
+`oc_page_cache`（個別ルームの分析文・`chart_meta`）／おすすめ `.dat`／毎時・日次の cron フロー
+（`SyncOpenChat`・`OcPageCacheGenerator`・`ChartMetaBuilder`・`RecommendStaticDataGenerator` 等）の
+コードを変えたら、必ず次の2つも**同時に・対で**更新して齟齬を残さない:
+
+- `README.md` の「ページ系キャッシュの生成アーキテクチャ」（Mermaid 図）
+- 管理画面の処理フロー説明 `app/Views/admin/log_index.php`（毎時・日次の各ステップと GitHub リンク）
+
+理由: これらは実装と対になる「正本ドキュメント」で、片方だけ更新すると現状を読み違える原因になる
+（実際にこの周りはドキュメントが実装から取り残されやすい）。

--- a/.claude/skills/dev-env/SKILL.md
+++ b/.claude/skills/dev-env/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: dev-env
+description: 開発環境の起動・操作ガイド。Docker/Makefile コマンド、Mock 環境（LINE Mock API）、Shared mode（別リポと DB 共有）、ポート一覧、Codespaces、CI 環境とプリビルドイメージの詳細。環境の起動・再構築・ローカル確認・CI デバッグの前に読む。
+---
+
+# 開発環境ガイド
+
+> 前提: CLAUDE.md の環境保護ルールに従う。`DATA_PROTECTION=true` のとき `make up-mock` / `make ci-test` 等の mock 環境操作はユーザーの明示的な指示なしに実行しない。
+
+## Docker Setup
+
+**IMPORTANT**: `docker compose`（スペース区切り）を使う。`docker-compose`（ハイフン）は不可。
+
+Makefile で Docker を管理する:
+
+```bash
+# 初期セットアップ
+make init               # 対話形式（非対話は make init-y）
+
+# 起動（どの環境かは up 系ターゲットで決まる）
+make up                 # 基本環境（実際の LINE サーバーにアクセスする）
+make up-mock            # Mock 環境（LINE Mock API 同梱）
+make up-shared          # Shared mode（別リポの DB/storage を共有・下記）
+
+# 操作（down / restart / rebuild / ssh は起動中の環境を自動判定して効く）
+make down / restart / rebuild / ssh
+
+# クローリング cron の起動・停止
+make cron / cron-stop
+
+# 現在の設定を表示・全ターゲット一覧（phpstan, css-check, build-frontend 等もある）
+make show / help
+```
+
+Mock のデータ件数・遅延は `.env` の `MOCK_RANKING_COUNT` / `MOCK_RISING_COUNT` / `MOCK_DELAY_ENABLED` で制御する（`up-mock-slow` のような専用ターゲットは無い）。
+
+## Shared Mode（共有モード）
+
+別ディレクトリにある既存リポジトリの **MariaDB / storage / comment-img を実体共有**しつつ、コードはこのリポジトリで動かす2つ目のインスタンス。
+
+- `make up-shared` … 初回は参照先リポジトリのパスを対話で尋ね `.shared.local.mk`（gitignore済・環境ごとに異なる）に保存。ポートが参照先と衝突する場合はプリセット（9000/9443 等）から選択して `.env` に保存。2回目以降は尋ねない。
+- 参照先の docker ネットワークに app を直結し、storage/comment-img を bind mount する（`docker-compose.shared.yml`）。`translation.json` だけはこのリポジトリ側を使う。
+- `DATA_PROTECTION=true` で動く（実データ共有のため）。詳細は [`README.shared.md`](../../../README.shared.md)。
+
+## 環境詳細・ポート
+
+> **接続先ポート(URL)は必ず `.env` を見て判断する**。`HTTPS_PORT` / `WEB_PORT` 等。下記の `8443` は
+> 基本/Mock環境のデフォルト値にすぎず、**shared mode や複数インスタンスでは別ポートになる**（実際の
+> 共有環境では `HTTPS_PORT=10443` 等）。ハードコードされたポートを信用してローカルを叩くと、別リポの
+> インスタンスを見て「コードが効かない」等と誤判断する（実際に起きた）。curl・ブラウザ確認の前に `.env` を見る。
+
+**基本環境:**
+
+- HTTPS: https://localhost:8443
+- MySQL: localhost:3306
+- phpMyAdmin: http://localhost:8080
+- 実際の LINE サーバーにアクセスする
+
+**Mock 環境:**
+
+- HTTPS: https://localhost:8443（基本環境と同じポートを使う）
+- LINE Mock API: http://localhost:9000（外部アクセス）、http://line-mock-api（内部）
+- MySQL: localhost:3306（共有）
+- phpMyAdmin: http://localhost:8080
+
+**Mock API の機能:**
+
+- 内部通信は Docker Compose のサービス名（`line-mock-api`）を使用
+- データ件数を設定可能（MOCK_RANKING_COUNT, MOCK_RISING_COUNT）
+- 本番相当の遅延シミュレーション（MOCK_DELAY_ENABLED）
+- 多言語対応（日本語・繁体字・タイ語）
+
+**Cron 自動実行（CRON=1）:**
+
+- 30分: 日本語クローリング
+- 35分: 繁体字（/tw）
+- 40分: タイ語（/th）
+
+## 必要ツール
+
+- Docker（Compose V2）
+- `mkcert`（SSL証明書生成。CI では不要）
+
+## GitHub Codespaces
+
+Codespaces 環境はローカル開発環境と完全に同じ:
+
+- 独立した Ubuntu コンテナ内で Docker 環境を起動
+- ローカルと同じ Makefile コマンドが使用可能
+- `make ci-test` などの全てのスクリプトが正常に動作
+
+セットアップ:
+
+1. post-create で Claude CLI / GitHub CLI 等がインストールされる（`make init-y` は自動実行されない）
+2. `make init-y` → `make up-mock` で Mock 環境を起動
+3. ポート転送タブから各サービスにアクセス
+
+構成:
+
+- `.devcontainer/Dockerfile`: Ubuntu + Docker + mkcert
+- `.devcontainer/devcontainer.json`: シンプルな devcontainer 設定
+- `.devcontainer/post-create-command.sh`: 初期セットアップスクリプト
+
+## CI 環境
+
+CI 専用の設定を使用:
+
+- `docker-compose.ci.yml`: CI 専用のオーバーライド設定
+- SSL 証明書生成をスキップ（HTTP 通信のみ）
+- Xdebug インストール無効
+- phpMyAdmin 除外
+
+GitHub Actions:
+
+- `.github/workflows/ci.yml`: 自動テスト実行（Mock 環境のクローリング＋URLテスト。**phpunit は実行しない**。ユニットテストはローカルで `docker compose exec app vendor/bin/phpunit <path>`）
+- `.github/workflows/build-images.yml`: プリビルドイメージのビルド＆プッシュ（main push または手動実行）
+- プリビルドイメージ: GitHub Container Registry (ghcr.io) に CI 用イメージを保存
+  - `ghcr.io/{owner}/oc-review-mock-app:latest`: アプリケーションイメージ
+  - `ghcr.io/{owner}/oc-review-mock-line-mock-api:latest`: LINE Mock API イメージ
+- CI 実行時の動作:
+  - Dockerfile/composer 関連ファイルに変更がある場合: 必ずビルド（最新の変更を反映）
+  - 変更がない場合: プリビルドイメージを pull（高速化）
+  - プリビルドイメージが存在しない場合: ビルド（フォールバック）
+- Docker Layer Caching: `docker/build-push-action@v6` で GitHub Actions キャッシュを使用
+- `cache-from/cache-to type=gha,scope={app|line-mock-api}`: 各イメージに一意の scope を設定
+- プリビルドイメージ使用でビルド時間を大幅短縮（34秒 → 5-10秒）
+
+ローカルで CI テストを実行（`DATA_PROTECTION=true` では禁止）:
+
+```bash
+make ci-test
+```

--- a/.claude/skills/pr-guide/SKILL.md
+++ b/.claude/skills/pr-guide/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: pr-guide
+description: PR・コミット作法の詳細。タイトル/本文の書き方（一般人向け・用語の言い換え）、UI スクリーンショットの撮り方と添付、skip-ci/skip-post の挙動と例外、本番デプロイの確認手順、環境署名フォーマット。PR 作成・コミット・マージ・デプロイ確認の前に読む。
+---
+
+# PR・コミットガイド
+
+> 前提: CLAUDE.md の必守ルール（スクショ添付・デプロイ見届け・署名・skip-ci デフォルト方針）に従う。本ガイドはその具体的な手順と書き方。
+
+## 画面(UI)を変えた PR はスクリーンショットを本文に必ず添付する
+
+画面に機能を追加・改修した PR は、**実装後の各画面のスクリーンショットを PR 本文に貼る**。文章だけだと
+レビュー側がどんな見た目になるか判断できないため。
+
+- 撮り方: 実環境（`.env` の `HTTPS_PORT`）を headless Chrome（`google-chrome --headless=new
+  --ignore-certificate-errors --screenshot=...`）かブラウザで開いて撮る。エラー画面・5xx・空状態など特殊な
+  状態は、対象エンドポイントに一時的に例外を throw する等で再現してから撮り、**撮影後に必ず元へ戻す**。
+- 添付方法: GitHub web UI へのドラッグ&ドロップで添付する（CLI から GitHub の画像 CDN へ直接アップロードは
+  できない）。**スクショホスティング用のブランチ（`assets/pr-screenshots` 等）は作らない**（2026-06-27 ユーザー指示）。
+
+## 報告は本番デプロイ完了まで待つ
+
+PR をマージして終わりにしない。**本番デプロイ（`deploy.yml` の Deploy job）が success になるまで見届けてから「完了」と報告する**。マージ＝デプロイ成功ではない（別 PR が `deploy.yml` 等に残した不整合で本番デプロイだけが落ちることがある）。
+
+- main マージ後、`gh run list --workflow=deploy.yml --limit 4` で該当 Deploy run を特定し、`gh run view <id> --json status,conclusion` を completed/success までポーリングする。本番かどうかの確実な見分け方は env `IS_STG: false`（run タイトルの `[PROD]` は `pr-title-prefix.yml` が main 向け PR タイトルに自動付与したもの）。
+- 失敗したら原因を直して再デプロイし、success を確認してから報告する。
+- 本番 SSH はしない（確認は Actions の結果まで）。
+
+## 環境署名（全コミット・全 GitHub 投稿）
+
+GitHub に投稿する本文（PR 本文・issue・PR/issue コメント等）の**末尾**に、区切り線を入れて以下の署名ブロックを付ける。どのマシン・ディレクトリから、どのモデル・ツールで投稿されたかを残すため。
+
+```markdown
+---
+🤖 Generated with Claude Code (<モデルID>)
+Posted from: `<hostname>:<作業ディレクトリ>`
+```
+
+- モデルはその時のセッションの実際のモデル ID を書く（表示名は省く。例: Opus 4.8 → `claude-opus-4-8[1m]`）
+- `<hostname>` は `hostname`、`<作業ディレクトリ>` は `pwd` の値だが**ホームディレクトリは `~` に短縮**する（例: `/home/user/repos/Open-Chat-Graph` → `user-B550M-Pro4:~/repos/Open-Chat-Graph`）
+- **コミットメッセージにも毎回 環境署名を入れる**（PR/issue/コメント本文だけでなく、全コミット）。末尾に署名2行を付ける。`Co-Authored-By: Claude ...` は 🤖 行とモデル情報が重複するので**付けない**（全廃）:
+
+  ```
+  <コミット本文>
+
+  🤖 Generated with Claude Code (claude-opus-4-8[1m])
+  Committed from: user-B550M-Pro4:~/repos/Open-Chat-Graph
+  ```
+
+  - モデル・hostname・ディレクトリの書き方は上記と同じ（ホームは `~` 短縮、リポごとに実ディレクトリを書く）。
+  - **このルールは infra リポ(oc-infra)など他リポのコミットにも全て適用する**。
+
+## タイトルの書き方
+
+**IMPORTANT**: PR タイトルは SNS に自動投稿されるため、一般人に伝わる書き方にする。
+
+❌ BAD:
+
+```
+perf: dailyTask処理時間の大幅短縮とタイムアウト問題の解決
+fix: getMemberChangeWithinLastWeekCacheArray()の重複実行を防止
+```
+
+✅ GOOD:
+
+```
+perf: 日次データ更新処理のタイムアウト問題を解決（9〜11時間→1〜2時間）
+fix: 統計データ抽出クエリの重複実行を防止してDB負荷を軽減
+```
+
+ガイドライン:
+
+- コード用語（クラス名・メソッド名・変数名）を避ける
+- 具体的な数値を入れる（処理時間・データ量）
+- 技術詳細ではなく業務影響を説明する
+
+## 本文の書き方
+
+構成:
+
+1. 業務・ユーザーへの影響から始める
+2. 技術的な問題を平易な言葉で説明する
+3. 該当コード箇所へリンクする
+4. 実装の詳細を書く
+
+例:
+
+```markdown
+## 問題の概要
+
+オープンチャットの日次データ更新処理が9〜11時間かかり完了しない
+
+### 具体的な問題
+
+全statisticsテーブル（8700万行）から「メンバー数が変動している部屋」を抽出する処理が、
+以下の2箇所で重複実行されている:
+
+- クローリング対象の絞り込み処理 ([`DailyUpdateCronService::getTargetOpenChatIdArray()`](link))
+- ランキング用キャッシュ保存処理 ([`UpdateHourlyMemberRankingService::saveFiltersCacheAfterDailyTask()`](link))
+
+## 対処内容
+
+クエリ結果をプロパティに保存し、2回目で再利用
+```
+
+### 用語の言い換え
+
+- dailyTask → オープンチャットの日次データ更新処理（毎日23:30実行）
+- hourlyTask → オープンチャットの毎時ランキング更新処理（毎時30分実行）
+- getMemberChangeWithinLastWeekCacheArray → 統計データ抽出処理（メンバー数が変動している部屋を取得）
+
+## skip-ci / skip-post
+
+### skip-ci
+
+CI Test (`ci.yml`) は Mock 環境のクローリング＋URLテストのみで、**phpunit は実行しない**。
+これらが意味を持たない変更（typo・ドキュメント・デプロイ時にだけ動くロジック等）では CI を飛ばせる:
+
+- PR に `skip-ci` ラベルを付ける
+- または PR タイトルを `skip-ci:` 始まりにする（例: `skip-ci: Fix typo in README`）
+
+**デフォルト方針（PHP を触らない PR は skip-ci）:**
+CI(`ci.yml`)は Mock 環境のクローリング＋URLテストなので、その挙動は基本的に PHP 側で決まる。
+そのため **PHP コードを一切変更していない PR は、デフォルトで skip-ci にする**（フロント JS/CSS・
+ドキュメント・翻訳 JSON 等だけの変更）。確実に効かせるため **PR タイトルを `skip-ci:` 始まりにする**
+（ラベルだけは PR 作成時にレースして効かないことがある。既存 PR に後付けする場合は、ラベルを
+付けてから次の push をすると `synchronize` で再評価されて効く）。
+
+注意: stg/main 向け PR はタイトル先頭に `[STG]`/`[PROD]` が自動付与される（`pr-title-prefix.yml`）ため、
+付与後の push ではタイトル判定が効かなくなる。確実なのは「タイトル `skip-ci:` 始まり（opened 時に判定される）
+＋ `skip-ci` ラベル（deploy ゲート用）」の併用。
+
+**例外（PHP を触っていなくても skip-ci を付けない）:**
+
+- ルーティング・ページ表示に影響しうる View テンプレート/JS の変更（URLテストで表示崩れ・500 を拾える）
+- mock 環境・クローラ設定・依存（composer/npm）・CI 設定(`ci.yml`/`docker-compose.ci.yml`)自体の変更
+- 挙動への影響に少しでも不安がある変更
+
+**skip-ci 使用時の挙動:**
+
+- CI テスト（`ci.yml` の Mock クローリング＋URLテスト）がスキップされる
+- `deploy.yml` の「Check CI status」ゲートも飛ばされる（CI 成功を要求しなくなる）
+- **デプロイは止まらない**。PR がマージされれば deploy job は通常どおり走り、stg/本番へ反映される
+  （deploy job の発火条件はマージ/手動実行だけで、skip-ci はデプロイを止めない）
+- 補足: `stg` を head にした PR は skip-ci 無しでも CI が自動スキップされる（`ci.yml`）
+
+### skip-post
+
+マージ後の X (Twitter) 自動投稿だけをスキップする（CI とデプロイは走る）:
+
+- PR に `skip-post` ラベルを付ける
+- または PR タイトルを `skip-post:` 始まりにする（例: `skip-post: Internal configuration update`）
+
+X 自動投稿はリリース履歴を兼ねるため、**skip-post を自己判断で付けない**（ユーザー指示があるときだけ）。

--- a/.gitignore
+++ b/.gitignore
@@ -83,8 +83,9 @@ frontend/*/dist/
 test-logs/
 .playwright-mcp
 
-# Claude Code
-.claude/
+# Claude Code（プロジェクトスキル .claude/skills/ だけはコミットする）
+.claude/*
+!.claude/skills/
 
 # 例外: .gitkeepは含める
 !*.gitkeep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,516 +2,95 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## プロジェクト概要
 
-オプチャグラフ (OpenChat Graph) is a web application that tracks and displays growth trends for LINE OpenChat communities. It crawls the official LINE OpenChat site hourly to collect member statistics and displays rankings, search functionality, and growth analytics.
+オプチャグラフ (OpenChat Graph) — LINE オープンチャットの統計を毎時クロールし、ランキング・検索・成長グラフを提供する Web アプリ。
 
-- **Live Site**: https://openchat-review.me
-- **Language**: Primarily Japanese
-- **License**: MIT
+- 本番: https://openchat-review.me（日本語・MIT ライセンス）
+- PHP 8.5 + 自作 MimimalCMS（軽量MVC・DI・生SQL）+ MySQL/MariaDB（主データ）+ SQLite（ランキング・統計）+ React（`frontend/`）
+- 主要ディレクトリ: `app/`（MVC）・`shadow/`（フレームワーク本体）・`batch/`（cron/バッチ）・`shared/`（設定・DIバインド）・`storage/`（SQLite・多言語データ）
 
-## 重要: 環境保護ルール
+## 詳細ガイド（プロジェクトスキル）
 
-- `.env` の `DATA_PROTECTION=true` のときは本番データを使用した環境。**`make up-mock` / `make ci-test` 等の mock環境操作はユーザーの明示的な指示なしに実行してはいけない**（本番DBが破壊される）
-- ただし禁止対象は「本番DBを壊す mock環境操作」だけ。**phpunit（`docker compose exec app vendor/bin/phpunit <path>`）や curl でローカル環境を叩く類のテストは普通に実行してよい**（「テスト全般がNG」ではない）
-- `DATA_PROTECTION=false` のときはテスト実行も mock環境の操作も自己判断で自由に行ってよい
+手順・コマンド・書き方の詳細は `.claude/skills/` のスキルに分離してある。該当する作業を始める前に読む:
+
+- **dev-env** — 環境の起動・操作（Docker/Makefile・Mock・Shared mode・Codespaces・CI・ポート一覧）
+- **coding-guide** — 実装（ページ追加MVC・DBアクセス・スキーマ変更・DI/ServiceProvider・クローラ設定・フロントビルド・キャッシュ生成/genetop の詳細）
+- **pr-guide** — PR・コミット（タイトル/本文の書き方・スクショの撮り方/添付・skip-ci/skip-post・デプロイ確認手順・署名の詳細）
 
 ## インフラ操作（oc-infra スキル・本人のみ）
 
-GA4 / GTM / Search Console / AdSense・Cloudflare・本番/stg の SSH・MySQL など、このリポの外側にある
-インフラを操作する必要が出たら、プライベートリポ `oc-infra` をクローンして Claude Code スキルとして
-登録して使う。1 つのトークン/設定束で各サービスを叩ける（詳細は oc-infra の `SKILL.md`）。
+GA4/GTM/Search Console/AdSense・Cloudflare・本番/stg の SSH・MySQL など、このリポの外側のインフラは
+private リポ `oc-infra` をスキルとして登録して操作する（本人 mimimiku778 のみアクセス可。詳細は oc-infra の `SKILL.md`）:
 
 ```bash
 git clone https://github.com/mimimiku778/oc-infra.git ~/repos/oc-infra
 ln -sfn ~/repos/oc-infra ~/.claude/skills/oc-infra   # /oc-infra スキルとして登録
-TOK=$(python3 ~/repos/oc-infra/token.py)             # Google API アクセストークン
 ```
 
-- 中身: Google OAuth トークン(write/manage 可) / Cloudflare API トークン(prod・stg) / 本番・stg の
-  SSH 接続情報・MySQL 認証・SSH 秘密鍵 / 本番 secrets / `cf_sync.py`(CF 設定 stg⇄prod 同期) 等。
-- `batch/sh/prod-sync` の機密(`secrets/`)もこのリポから取得する（Makefile の `PROD_SYNC_CONFIG_URL`）。
-- **このリポは private で本人(mimimiku778)しかアクセスできない**。他の利用者は使えない（=インフラ操作は本人環境限定）。
+`batch/sh/prod-sync` の機密(`secrets/`)もこのリポから取得する（Makefile の `PROD_SYNC_CONFIG_URL`）。
 
-## Development Environment
+## 必守ルール（憲法）
 
-### Docker Setup
+### 環境保護（最重要）
 
-**IMPORTANT**: Use `docker compose` (with space), not `docker-compose` (with hyphen).
+- `.env` の `DATA_PROTECTION=true` のときは本番データを使用した環境。**`make up-mock` / `make ci-test` 等の mock環境操作はユーザーの明示的な指示なしに実行してはいけない**（本番DBが破壊される）
+- ただし禁止対象は「本番DBを壊す mock環境操作」だけ。phpunit（`docker compose exec app vendor/bin/phpunit <path>`）や curl でローカル環境を叩く類のテストは普通に実行してよい（「テスト全般がNG」ではない）
+- `DATA_PROTECTION=false` のときはテスト実行も mock環境の操作も自己判断で自由に行ってよい
 
-This project uses Makefile for easy Docker management:
+### MimimalCMS フレームワーク本体は改造しない
 
-```bash
-# Initial setup
-make init
+本体はアプリと別管理で、改変すると本体アップデートと衝突し保守不能になる。
 
-# Basic environment (accesses real LINE servers)
-make up / down / restart / rebuild / ssh
+- 改造禁止: `shadow/` 配下すべて、`shared/MimimalCMS_ExceptionHandler.php` / `_HelperFunctions.php` / `_Settings.php` / `_Enums.php`
+- 編集可: `shared/MimimalCmsConfig.php`（DIバインド・`$httpErrors` 等の拡張点）、`shared/bootstrap.php`、`app/` 配下すべて
+- 横断的な振る舞いはアプリ側の拡張点で実現する（拡張点の一覧は coding-guide）
+- 本体に手を入れないと解決できない／本体側の問題だと判断したら、勝手に直さず必ずユーザーに提案する
 
-# Mock environment (includes LINE Mock API)
-make up-mock / down-mock / restart-mock / rebuild-mock / ssh-mock
-make up-mock-slow       # 100k items with production-like delay
-make up-mock-cron       # Auto-crawling enabled
+### Repository は必ず Interface とセットで作る
 
-# Show current configuration
-make show / help
+新規 Repository は必ず `XxxRepositoryInterface` を作り `/shared/MimimalCmsConfig.php` で DI バインドする。
+具象クラスを直接 use／type-hint しない。ストレージ差し替え（SQLite↔MySQL 等）・テスト用モック化を容易に
+するため（具象直結による影響拡大が実際に起きた）。
 
-# Shared mode (share another repo's DB/storage; run this repo's code as a 2nd instance)
-make up-shared / shared-setup / down-shared
-```
+### 接続先ポート・URL は必ず .env を見る
 
-### Shared Mode（共有モード）
+curl・ブラウザ確認の前に `.env` の `HTTPS_PORT` / `WEB_PORT` 等を確認する。8443 はデフォルト値に
+すぎず、shared mode や複数インスタンスでは別ポートになる。ハードコードされたポートを信用すると
+別リポのインスタンスを見て「コードが効かない」と誤診する（実際に起きた）。
 
-別ディレクトリにある既存リポジトリの **MariaDB / storage / comment-img を実体共有**しつつ、コードはこのリポジトリで動かす2つ目のインスタンス。
+### スキーマ変更は setup/schema/mysql/*.sql の編集だけ
 
-- `make up-shared` … 初回は参照先リポジトリのパスを対話で尋ね `.shared.local.mk`（gitignore済・環境ごとに異なる）に保存。ポートが参照先と衝突する場合はプリセット（9000/9443 等）から選択して `.env` に保存。2回目以降は尋ねない。
-- 参照先の docker ネットワークに app を直結し、storage/comment-img を bind mount する（`docker-compose.shared.yml`）。`translation.json` だけはこのリポジトリ側を使う。
-- `DATA_PROTECTION=true` で動く（実データ共有のため）。詳細は [`README.shared.md`](README.shared.md)。
+テーブル・カラムを追加したいときはスキーマ SQL を編集するだけ。デプロイ時に
+`batch/exec/sync_mysql_schema.php` が不足分を「追加だけ」自動反映する（削除・型変更はしない）。
+`deploy.yml` もコードも触らない。dry-run・注意点は coding-guide と `app/Services/Schema/README.md`。
 
-### Environment Details
+### ドキュメント・スキルを実態と同期する
 
-> **接続先ポート(URL)は必ず `.env` を見て判断する**。`HTTPS_PORT` / `WEB_PORT` 等。下記の `8443` は
-> 基本/Mock環境のデフォルト値にすぎず、**shared mode や複数インスタンスでは別ポートになる**（実際の
-> 共有環境では `HTTPS_PORT=10443` 等）。ハードコードされたポートを信用してローカルを叩くと、別リポの
-> インスタンスを見て「コードが効かない」等と誤判断する（実際に起きた）。curl・ブラウザ確認の前に `.env` を見る。
+CLAUDE.md と `.claude/skills/` は実装・環境と対の正本ドキュメント。コマンド・ポート・ディレクトリ構成・
+CI/デプロイの挙動など実態を変えたら、対応する記述も同じ PR で更新して齟齬を残さない。
 
-**Basic Environment:**
+### キャッシュ生成を足したら genetop・ドキュメントを同期する
 
-- HTTPS: https://localhost:8443
-- MySQL: localhost:3306
-- phpMyAdmin: http://localhost:8080
-- Accesses external LINE servers
+- 毎時・日次 cron にキャッシュ生成を追加したら、必ず管理画面 genetop からも全ルーム一括再生成（全件）できるようにする（毎時/日次は一部の部屋しか回らず、genetop が無いとデプロイ後に全件バックフィルできない）
+- ページ系キャッシュ（`oc_page_cache`・おすすめ `.dat`・毎時/日次 cron フロー）を変えたら、`README.md` の生成アーキテクチャ図と `app/Views/admin/log_index.php` を同時に対で更新する（正本ドキュメントの齟齬を残さない）
 
-**Mock Environment:**
+対象クラス・具体例は coding-guide。
 
-- HTTPS (Basic): https://localhost:8443
-- HTTPS (Mock): https://localhost:8543
-- LINE Mock API: http://localhost:9000 (external access), http://line-mock-api (internal)
-- MySQL: localhost:3306 (shared)
-- phpMyAdmin: http://localhost:8080
+### PR・コミット
 
-**Mock API Features:**
-
-- Uses Docker Compose service name (`line-mock-api`) for internal communication
-- Configurable data counts (MOCK_RANKING_COUNT, MOCK_RISING_COUNT)
-- Production-like delay simulation (MOCK_DELAY_ENABLED)
-- Multi-language support (Japanese, Traditional Chinese, Thai)
-
-**Cron Auto-Execution (CRON=1):**
-
-- 30 min: Japanese crawling
-- 35 min: Traditional Chinese (/tw)
-- 40 min: Thai (/th)
-
-### Requirements
-
-- Docker with Compose V2
-- `mkcert` for SSL certificate generation (not required for CI)
-
-### GitHub Codespaces Environment
-
-**Codespaces環境はローカル開発環境と完全に同じ:**
-
-- 独立したUbuntuコンテナ内でDocker環境を起動
-- ローカルと同じMakefileコマンドが使用可能
-- `make ci-test`などの全てのスクリプトが正常に動作
-
-**セットアップ:**
-
-1. Codespacesが起動すると自動的に`make init-y`が実行される
-2. `make up-mock`でMock環境を起動
-3. ポート転送タブから各サービスにアクセス
-
-**構成:**
-
-- `.devcontainer/Dockerfile`: Ubuntu + Docker + mkcert
-- `.devcontainer/devcontainer.json`: シンプルなdevcontainer設定
-- `.devcontainer/post-create-command.sh`: 初期セットアップスクリプト
-
-### CI Environment
-
-**CI環境では専用の設定を使用:**
-
-- `docker-compose.ci.yml`: CI専用のオーバーライド設定
-- SSL証明書生成をスキップ（HTTP通信のみ）
-- Xdebugインストール無効
-- PHPMyAdmin除外
-
-**GitHub Actions:**
-
-- `.github/workflows/ci.yml`: 自動テスト実行
-- `.github/workflows/build-images.yml`: プリビルドイメージのビルド＆プッシュ（main pushまたは手動実行）
-- プリビルドイメージ: GitHub Container Registry (ghcr.io) にCI用イメージを保存
-  - `ghcr.io/{owner}/oc-review-mock-app:latest`: アプリケーションイメージ
-  - `ghcr.io/{owner}/oc-review-mock-line-mock-api:latest`: LINE Mock APIイメージ
-- CI実行時の動作:
-  - Dockerfile/composer関連ファイルに変更がある場合: 必ずビルド（最新の変更を反映）
-  - 変更がない場合: プリビルドイメージをpull（高速化）
-  - プリビルドイメージが存在しない場合: ビルド（フォールバック）
-- Docker Layer Caching: `docker/build-push-action@v6`でGitHub Actionsキャッシュを使用
-- `cache-from/cache-to type=gha,scope={app|line-mock-api}`: 各イメージに一意のscopeを設定
-- プリビルドイメージ使用でビルド時間を大幅短縮（34秒 → 5-10秒）
-
-**ローカルでCIテストを実行:**
-
-```bash
-make ci-test
-```
-
-## Architecture
-
-### Backend
-
-- **Framework**: Custom MimimalCMS (lightweight MVC framework)
-- **Language**: PHP 8.5
-- **Database**: MySQL/MariaDB for main data, SQLite for rankings/statistics
-- **Pattern**: Traditional MVC with dependency injection
-
-### Frontend
-
-- Server-side PHP templating + embedded React components
-- TypeScript, JavaScript, React
-- Libraries: MUI, Chart.js, Swiper.js
-
-### Key Directories
-
-- `/app/` - Main application (MVC structure)
-  - `Config/` - Routing and application config
-  - `Controllers/` - HTTP handlers (Api/ and Page/)
-  - `Models/` - Data access layer with repositories
-  - `Services/` - Business logic
-    - `Crawler/Config/` - Crawler configuration (OpenChatCrawlerConfig)
-  - `ServiceProvider/` - Service provider for DI
-  - `Views/` - Templates and React components
-- `/shadow/` - Custom MimimalCMS framework
-- `/batch/` - Background processing, cron jobs
-- `/shared/` - Framework configuration and DI mappings
-- `/storage/` - Multi-language data files, SQLite databases
-
-## Database Architecture
-
-### MySQL/MariaDB
-
-- Primary storage for OpenChat data
-- Complex queries using raw SQL (no ORM)
-
-### スキーマ変更（テーブル・カラム追加）
-
-テーブルやカラムを追加したいときは **`setup/schema/mysql/*.sql` を編集するだけ**。デプロイ時に
-`batch/exec/sync_mysql_schema.php` が各DBへ不足分を「追加だけ」自動反映する（既存データは壊さない。
-削除・型変更はしない）。`deploy.yml` もコードも触らなくてよい。
-
-- 反映前に確認: `docker compose exec app php batch/exec/sync_mysql_schema.php --dry-run`
-- 詳細・注意点: [`app/Services/Schema/README.md`](app/Services/Schema/README.md)
-
-### SQLite
-
-- Rankings and statistics data
-- Performance optimization for read-heavy operations
-- Separate databases per data type in `/storage/`
-
-### Database Access in Controllers
-
-```php
-use Shadow\DB;
-
-DB::connect(); // Always connect first
-
-// SELECT multiple rows
-$stmt = DB::$pdo->prepare("SELECT * FROM table WHERE condition = ?");
-$stmt->execute([$value]);
-$results = $stmt->fetchAll(\PDO::FETCH_ASSOC);
-
-// SELECT single row
-$stmt = DB::$pdo->prepare("SELECT * FROM table WHERE id = ?");
-$stmt->execute([$id]);
-$result = $stmt->fetch(\PDO::FETCH_ASSOC);
-```
-
-Note: Database configuration is loaded from `local-secrets.php`
-
-## Development Patterns
-
-### MimimalCMS フレームワーク本体は改造しない（最重要・原則）
-
-アプリ都合で **MimimalCMS 本体を書き換えてはいけない**。本体はアプリと別管理で、改変すると本体アップデートと衝突し、アプリ固有の改変が埋もれて保守不能になる。
-
-- **改造禁止（本体）**: `shadow/` 配下すべて、`shared/MimimalCMS_ExceptionHandler.php` / `shared/MimimalCMS_HelperFunctions.php` / `shared/MimimalCMS_Settings.php` / `shared/MimimalCMS_Enums.php`。
-- **編集してよい**: `shared/MimimalCmsConfig.php`（設定・DIバインド・`$httpErrors` 等の拡張点）、`shared/bootstrap.php`、`app/` 配下すべて。
-- 横断的な振る舞いは本体ではなくアプリ側の拡張点で実現する: 例外→HTTPコード対応は `MimimalCmsConfig::$httpErrors` ＋ `app/Exceptions/`、アプリ固有の例外ハンドリングは `app/Exceptions/Handlers/ApplicationExceptionHandler`（`$exceptionMap`）、DI差し替えは `app/ServiceProvider/`、DB接続の解放などは app のリポジトリにメソッドを生やしてコントローラから呼ぶ。
-- **本体に手を入れないと解決できない／本体側の問題だと判断したら、勝手に直さず必ずユーザーに提案する。**
-
-### Dependency Injection
-
-- Interface-based DI configured in `/shared/MimimalCmsConfig.php`
-- Service providers in `/app/ServiceProvider/` for dynamic binding
-- Example: `OpenChatCrawlerConfigServiceProvider` switches between production and mock configs based on `AppConfig::$isMockEnvironment`
-
-### Repository は必ず Interface とセットで作る（重要）
-
-Repository を新規作成するときは**必ず `XxxRepositoryInterface` を作り、`/shared/MimimalCmsConfig.php`
-で DI バインドする**。具象クラスを直接 `use`／type-hint しない（依存側は Interface を type-hint する）。
-
-理由: ストレージ実装（SQLite ↔ MySQL、ファイル ↔ DB 等）の差し替え・テスト用モック化を容易にするため。
-具象直結だと差し替え時に呼び出し側を総当たりで直すことになり影響が広がる（`OcPageCacheRepository` を
-SQLite から MySQL へ移す際に実際にこの問題が起きた）。読み取り経路を別所（例: 既存クエリへの JOIN）に
-寄せて Repository を書き込み専用に縮められる場合もあるが、その判断とは無関係に Interface は最初から作る。
-
-### Autoloading
-
-```php
-"psr-4": {
-    "Shadow\\": "shadow/",
-    "App\\": "app/",
-    "Shared\\": "shared/"
-}
-```
-
-### Configuration
-
-- Environment-specific config in `local-secrets.php` (gitignored)
-- Framework config in `/shared/MimimalCMS_*.php` files
-- OpenChatCrawlerConfig in `/app/Services/Crawler/Config/`
-
-### 毎時・日次にキャッシュ生成を足したら genetop で全件実行できるようにする（必須）
-
-毎時/日次の cron（`SyncOpenChat` の hourlyTask/dailyTask 等）にキャッシュ生成系の処理を追加したら、
-必ず管理画面の **genetop**（`batch/exec/admin/genetop_exec.php`、AdminPageController から起動）からも
-**全ルーム分を一括で再生成（全件）** できるようにする。genetop は「全キャッシュを全件作り直す」入口なので、
-新しいキャッシュを足したらここにも全件モードで追加し、常に完全な状態を保つ。
-
-理由: 毎時/日次は「変動した部屋・新規部屋」など一部しか回さないため、処理を足しただけでは既存の
-大多数の部屋にキャッシュが行き渡らない（埋まるまで遅い、または未生成部屋がフォールバックの重い経路に
-なる）。genetop があればデプロイ後に全件バックフィルできる。例: グラフ可用性メタ `chart_meta`
-（oc_page_cache）は毎時/日次で増分生成しつつ、genetop が `UpdateOcPageCacheService::handle('')`
-（mode=''＝全ルーム）で全件再生成する。
-
-### ページ系キャッシュを変えたら README と管理画面フロー(log_index.php) も対で更新する（必須）
-
-`oc_page_cache`（個別ルームの分析文・`chart_meta`）／おすすめ `.dat`／毎時・日次の cron フロー
-（`SyncOpenChat`・`OcPageCacheGenerator`・`ChartMetaBuilder`・`RecommendStaticDataGenerator` 等）の
-コードを変えたら、必ず次の2つも**同時に・対で**更新して齟齬を残さない:
-
-- `README.md` の「ページ系キャッシュの生成アーキテクチャ」（Mermaid 図）
-- 管理画面の処理フロー説明 `app/Views/admin/log_index.php`（毎時・日次の各ステップと GitHub リンク）
-
-理由: これらは実装と対になる「正本ドキュメント」で、片方だけ更新すると現状を読み違える原因になる
-（実際にこの周りはドキュメントが実装から取り残されやすい）。
-
-## Crawling System
-
-### Configuration Classes
-
-- `OpenChatCrawlerConfig` - Production environment (uses real LINE URLs)
-- `MockOpenChatCrawlerConfig` - Mock environment (uses `line-mock-api` service)
-- Service provider automatically switches based on `AppConfig::$isMockEnvironment`
-
-### User Agent
-
-```
-Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 (compatible; OpenChatStatsbot; +https://github.com/Open-Chat-Graph/Open-Chat-Graph)
-```
-
-## Frontend Components
-
-React ソースは**このリポ内 `frontend/`**（別リポではない）。各サブdirが Vite+TS: `ranking`(ランキング) / `oc-app`(個別ルーム) / `all-room-stats` / `stats-graph` / `comments`。
-
-- **ビルド**: `cd frontend/<name> && npm run build` → `public/js/...` にハッシュ付きバンドル出力（成果物は **gitignore**、コミット不要）。手ビルドはローカル確認用。
-- **PHP参照**: `getFilePath('js/react','main-*.js')`（内部 glob、`app/Helpers/functions.php`）でハッシュ名を解決 → HTML側の手修正は不要。
-- **翻訳**: 各 `frontend/<name>/src/config/translation.ts` は PHP の `storage/translation.json` と**別物**。両方直す。
-- **デプロイ**: `deploy.yml` が `frontend/<name>/**` の変更を検知し自動で `npm ci && npm run build` → 配信。
-
-## Creating New Pages (MVC Pattern)
-
-### 1. Add Route
-
-In `/app/Config/routing.php`:
-
-```php
-Route::path('your-path', [\App\Controllers\Pages\YourController::class, 'method']);
-```
-
-### 2. Create Controller
-
-Controllers go in `/app/Controllers/Pages/`:
-
-```php
-<?php
-declare(strict_types=1);
-
-namespace App\Controllers\Pages;
-
-use Shadow\Kernel\Reception;
-use App\Models\Repositories\DB;
-
-class YourController
-{
-    public function index(Reception $reception)
-    {
-        DB::connect();
-        $stmt = DB::$pdo->prepare("SELECT ...");
-        $stmt->execute();
-        $data = $stmt->fetchAll(\PDO::FETCH_ASSOC);
-
-        $_meta = meta();
-        $_meta->title = 'Page Title';
-
-        return view('view_name', ['data' => $data, '_meta' => $_meta]);
-    }
-}
-```
-
-### 3. Create View
-
-Views go in `/app/Views/`:
-
-- Use `.php` extension
-- Access variables directly: `$data`, `$_meta`
-- Helper functions: `url()`, `t()`, `fileUrl()`
-
-## Pull Request Guidelines
-
-### 画面(UI)を変えた PR はスクリーンショットを本文に必ず添付する（必須）
-
-画面に機能を追加・改修した PR は、**実装後の各画面のスクリーンショットを PR 本文に貼る**。文章だけだと
-レビュー側がどんな見た目になるか判断できないため。
-
-- 撮り方: 実環境（`.env` の `HTTPS_PORT`）を headless Chrome（`google-chrome --headless=new
-  --ignore-certificate-errors --screenshot=...`）かブラウザで開いて撮る。エラー画面・5xx・空状態など特殊な
-  状態は、対象エンドポイントに一時的に例外を throw する等で再現してから撮り、**撮影後に必ず元へ戻す**。
-- 添付方法（CLI から GitHub の画像CDNへ直接アップロードはできない）: 画像をホスティング用ブランチ
-  （例 `assets/pr-screenshots`・**main にはマージしない**）にコミットして push し、PR 本文に
-  `![説明](https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>.png)` の raw URL を貼る
-  （public リポなので raw URL がそのまま描画される）。または GitHub web UI にドラッグ&ドロップ。
-
-### 報告は本番デプロイ完了まで待つ（必須）
-
-PR をマージして終わりにしない。**本番デプロイ（`deploy.yml` の Deploy job）が success になるまで見届けてから「完了」と報告する**。マージ＝デプロイ成功ではない（別 PR が `deploy.yml` 等に残した不整合で本番デプロイだけが落ちることがある）。
-
-- main マージ後、`gh run list --workflow=deploy.yml --limit 4` で該当 Deploy run（`[PROD]` 付き・env `IS_STG: false` が本番）を特定し、`gh run view <id> --json status,conclusion` を completed/success までポーリングする。
-- 失敗したら原因を直して再デプロイし、success を確認してから報告する。
-- 本番 SSH はしない（確認は Actions の結果まで）。
-
-### Signing GitHub Posts（必須）
-
-GitHubに投稿する本文（PR本文・issue・PR/issueコメント等）の**末尾**に、区切り線を入れて以下の署名ブロックを付ける。どのマシン・ディレクトリから、どのモデル・ツールで投稿されたかを残すため。
-
-```markdown
----
-🤖 Generated with Claude Code (<モデルID>)
-Posted from: `<hostname>:<作業ディレクトリ>`
-```
-
-- モデルはその時のセッションの実際のモデルIDを書く（表示名は省く。例: Opus 4.8 → `claude-opus-4-8[1m]`、Sonnet 4.6 → そのID）
-- `<hostname>` は `hostname`、`<作業ディレクトリ>` は `pwd` の値だが**ホームディレクトリは `~` に短縮**する（例: `/home/user/repos/Open-Chat-Graph` → `user-B550M-Pro4:~/repos/Open-Chat-Graph`）
-- **コミットメッセージにも毎回 環境署名を入れる**（PR/issue/コメント本文だけでなく、全コミット）。末尾に署名2行を付ける。`Co-Authored-By: Claude ...` は 🤖 行とモデル情報が重複するので**付けない**（全廃）:
+- `docker compose`（スペース区切り）を使う。`docker-compose` は不可
+- UI を変えた PR は実装後のスクショを本文に必ず添付する
+- PR タイトルは一般人に伝わる書き方（コード用語を避け、具体数値と業務影響。SNS に自動投稿される）
+- PHP 非変更の PR はデフォルトで skip-ci（確実に効かせるため PR タイトルを `skip-ci:` 始まりに。例外条件あり）
+- マージで終わりにしない。本番 Deploy job（`deploy.yml`）が success になるまで見届けてから完了報告する。本番 SSH はしない
+- 全コミット・全 GitHub 投稿（PR本文・issue・コメント）の末尾に環境署名を付ける（`Co-Authored-By` は付けない。他リポにも適用）:
 
   ```
-  <コミット本文>
-
-  🤖 Generated with Claude Code (claude-opus-4-8[1m])
-  Committed from: user-B550M-Pro4:~/repos/Open-Chat-Graph
+  🤖 Generated with Claude Code (<モデルID>)
+  Committed from: <hostname>:<作業ディレクトリ(~短縮)>
   ```
 
-  - モデル・hostname・ディレクトリの書き方は上記と同じ（ホームは `~` 短縮、リポごとに実ディレクトリを書く）。
-  - **このルールは infra リポ(oc-infra)など他リポのコミットにも全て適用する**。
+  GitHub 投稿では `Committed from:` を `Posted from:` にし、本文と `---` で区切る。
 
-### Writing Clear Titles
-
-**IMPORTANT**: PR titles appear on social media and should be understandable by the general public.
-
-**❌ BAD:**
-
-```
-perf: dailyTask処理時間の大幅短縮とタイムアウト問題の解決
-fix: getMemberChangeWithinLastWeekCacheArray()の重複実行を防止
-```
-
-**✅ GOOD:**
-
-```
-perf: 日次データ更新処理のタイムアウト問題を解決（9〜11時間→1〜2時間）
-fix: 統計データ抽出クエリの重複実行を防止してDB負荷を軽減
-```
-
-**Guidelines:**
-
-- Avoid code terminology (class/method/variable names)
-- Include concrete numbers (processing time, data volume)
-- Explain business impact, not technical details
-
-### Writing Clear Descriptions
-
-**Structure:**
-
-1. Start with business/user impact
-2. Explain technical problem in plain language
-3. Link to specific code locations
-4. Provide implementation details
-
-**Example:**
-
-```markdown
-## 問題の概要
-
-オープンチャットの日次データ更新処理が9〜11時間かかり完了しない
-
-### 具体的な問題
-
-全statisticsテーブル（8700万行）から「メンバー数が変動している部屋」を抽出する処理が、
-以下の2箇所で重複実行されている:
-
-- クローリング対象の絞り込み処理 ([`DailyUpdateCronService::getTargetOpenChatIdArray()`](link))
-- ランキング用キャッシュ保存処理 ([`UpdateHourlyMemberRankingService::saveFiltersCacheAfterDailyTask()`](link))
-
-## 対処内容
-
-クエリ結果をプロパティに保存し、2回目で再利用
-```
-
-### Common Terms Translation
-
-- dailyTask → オープンチャットの日次データ更新処理（毎日23:30実行）
-- hourlyTask → オープンチャットの毎時ランキング更新処理（毎時30分実行）
-- getMemberChangeWithinLastWeekCacheArray → 統計データ抽出処理（メンバー数が変動している部屋を取得）
-
-### Bypassing CI/CD
-
-**Skip CI Tests:**
-CI Test (`ci.yml`) は Mock環境のクローリング+URLテストのみで、**phpunit は実行しない**。
-これらが意味を持たない変更（typo・ドキュメント・デプロイ時にだけ動くロジック等）では CI を飛ばせる:
-
-- Add `skip-ci` label to the PR
-- Or prefix the PR title with `skip-ci:`
-
-Example: `skip-ci: Fix typo in README`
-
-**デフォルト方針（PHPを触らない PR は skip-ci）:**
-CI(`ci.yml`)は Mock環境のクローリング+URLテストなので、その挙動は基本的に PHP 側で決まる。
-そのため **PHP コードを一切変更していない PR は、デフォルトで skip-ci にする**（フロントJS/CSS・
-ドキュメント・翻訳JSON 等だけの変更）。確実に効かせるため **PR タイトルを `skip-ci:` 始まりにする**
-（ラベルだけは PR 作成時にレースして効かないことがある。既存 PR に後付けする場合は、ラベルを
-付けてから次の push をすると `synchronize` で再評価されて効く）。
-
-**例外（PHP を触っていなくても skip-ci を付けない）:**
-PHP 非変更でも CI を通した方がよいと判断したら付けない。例:
-
-- ルーティング・ページ表示に影響しうる View テンプレート/JS の変更（URLテストで表示崩れ・500 を拾える）
-- mock 環境・クローラ設定・依存（composer/npm）・CI 設定(`ci.yml`/`docker-compose.ci.yml`)自体の変更
-- 挙動への影響に少しでも不安がある変更
-
-**Important**: When `skip-ci` is used:
-
-- CI tests (`ci.yml` の Mock クローリング+URLテスト) are skipped
-- `deploy.yml` の「Check CI status」ゲートも飛ばされる（CI 成功を要求しなくなる）
-- **デプロイは止まらない**。PR がマージされれば deploy job は通常どおり走り、stg/本番へ反映される
-  （deploy job の発火条件はマージ/手動実行だけで、skip-ci はデプロイを止めない）
-- 補足: `stg` を head にした PR は skip-ci 無しでも CI が自動スキップされる（`ci.yml`）
-
-**Skip Social Media Post:**
-To skip the automatic X (Twitter) post after merge (but still run CI and deploy):
-
-- Add `skip-post` label to the PR
-- Or prefix the PR title with `skip-post:`
-
-Example: `skip-post: Internal configuration update`
+撮り方・skip-ci の例外・デプロイ確認手順など詳細はすべて pr-guide。

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -263,7 +263,7 @@ function purgeCacheCloudFlare(
     $zoneID = $zoneID ?? SecretsConfig::$cloudFlareZoneId;
     $apiKey = $apiKey ?? SecretsConfig::$cloudFlareApiKey;
 
-    if (!AppConfig::$enableCloudflare || !$zoneID || !$apiKey || !AppConfig::$isDevlopment) {
+    if (!AppConfig::$enableCloudflare || !$zoneID || !$apiKey) {
         return 'Cloudflareは無効化されています';
     }
 


### PR DESCRIPTION
stg で検証済みの内容を本番へ反映します。

## 問題の概要

コメントを投稿しても、トップページ「最近のコメント投稿」欄に新しいコメントがすぐ表示されず、**最大で約1時間**（CDNキャッシュの有効期限が切れるまで）反映されない状態でした。

## 原因

コメント投稿時のCloudflareキャッシュ削除処理（`purgeCacheCloudFlare()`）の入口ガードに、ローカル開発環境かどうかの判定 `$isDevlopment` が混入していました。本番・ステージングでは `false` のため `!$isDevlopment` が常に真となり、**本番ではキャッシュ削除が一度も実行されていませんでした**（2026-06-22 の該当変更以降）。

## 対処内容

`app/Helpers/functions.php` のガードから `|| !AppConfig::$isDevlopment` を削除。ステージング／ローカルはCloudflareのZoneID・APIキーが空のため、既存の `!$zoneID || !$apiKey` で従来どおり無効化されます。

```php
if (!AppConfig::$enableCloudflare || !$zoneID || !$apiKey) {
    return 'Cloudflareは無効化されています';
}
```

本修正で、コメント投稿直後にトップページへ即時反映されるようになります。

※ この他、stg に先行マージ済みの CLAUDE.md 整理コミット（#583）を含みます。

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `vm:~/Open-Chat-Graph`

---
_Generated by [Claude Code](https://claude.ai/code/session_011Bc9MwhsfbfE3jVe91v9jp)_