### PR TITLE
[STG] 共有ボタンをトップはページ末尾に移動・ブログ記事にも設置

### DIFF
--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -26,6 +26,12 @@
                 <?php echo $_html ?>
             </div>
 
+            <?php // シェア導線（oc ページと共通のコンポーネント）。読み終えた直後・CTAの手前に置く ?>
+            <?php viewComponent('share_buttons', [
+                '_shareUrl' => url('blog/' . $article->slug),
+                '_shareGa' => ['content_type' => 'blog', 'item_id' => $article->slug],
+            ]) ?>
+
             <div class="blog-cta">
                 <div class="blog-cta-h">📈 オプチャグラフで<span class="em">実データ</span>を見る</div>
                 <div class="blog-cta-row">

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -62,13 +62,6 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
                 <input type="hidden" name="sort" value="member">
                 <input type="hidden" name="order" value="desc">
             </form>
-
-            <?php // シェア導線（oc ページと共通のコンポーネント）。トップの共有はサイト紹介そのものなので
-                  // ヒーロー末尾に置く。og:image は言語別デフォルトOGP ?>
-            <?php viewComponent('share_buttons', [
-                '_shareUrl' => url(),
-                '_shareGa' => ['content_type' => 'top'],
-            ]) ?>
         </section>
         <script>
             /* クリア✕: テーマ検索と同じ挙動。変換(IME)確定前は✕を隠し、iOSで「消去後に入力できない」状態を防ぐ。 */
@@ -117,6 +110,14 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
         <?php viewComponent('recommend_list2', ['recommend' => $officialDto, 'id' => 0]) ?>
         <?php viewComponent('recommend_list2', ['recommend' => $officialDto2, 'id' => 0]) ?>
+
+        <?php // シェア導線（oc ページと共通のコンポーネント）。ヒーロー内だと検索→コンテンツの流れを
+              // 分断するため、コンテンツを見終えた後のページ末尾（フッター手前）に置く。
+              // og:image は言語別デフォルトOGP ?>
+        <?php viewComponent('share_buttons', [
+            '_shareUrl' => url(),
+            '_shareGa' => ['content_type' => 'top'],
+        ]) ?>
 
         <?php if ($enableAdsense): ?>
             <?php // フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。


### PR DESCRIPTION
# 概要

#593 の調整＋追加です。

1. **トップページの共有ボタンを移動**: 検索フォーム直下だと「検索→コンテンツ」の流れを分断して不自然だったため、公式ランキングまで見終えた後の**ページ末尾（フッター手前）**に移動
2. **ブログ記事ページにも共有ボタンを設置**: 記事本文の直後（CTAの手前）に共通コンポーネントを設置。GA4 計測は content_type=blog / item_id=記事スラッグ

ランキングページ・部屋ページの位置は変更ありません。

---
🤖 Generated with Claude Code
Posted from: vm:/home/user/Open-Chat-Graph