### PR TITLE
[PROD] 共有ボタンをトップ・ランキング・ブログにも設置・トップの読み物をよく読まれている2本に

### DIFF
--- a/.github/scripts/test-urls.sh
+++ b/.github/scripts/test-urls.sh
@@ -107,6 +107,34 @@ test_json_url() {
     fi
 }
 
+# PNG画像エンドポイントのテスト（ステータス200に加え、本文が実際にPNGであることを確認。
+# 生成失敗時のフォールバックもPNGなので「HTMLのエラーページが返る」劣化を検知できる）
+test_png_url() {
+    local url="$1"
+    local description="$2"
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+    echo -n "Testing PNG: ${url} ... " | tee -a "$LOG_FILE"
+
+    local body_file=$(mktemp)
+    local status_code=$(curl -k -s -o "$body_file" -w "%{http_code}" --max-time 30 -H "$API_CLIENT_HEADER" "$url")
+
+    # PNG シグネチャ(89 50 4E 47 0D 0A 1A 0A)で判定（text/html のエラーページを弾く）
+    local sig=$(head -c 8 "$body_file" | od -An -tx1 | tr -d ' \n')
+    if [ "$status_code" = "200" ] && [ "$sig" = "89504e470d0a1a0a" ]; then
+        echo -e "${GREEN}OK${NC}" | tee -a "$LOG_FILE"
+        rm -f "$body_file"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+        return 0
+    else
+        echo -e "${RED}FAILED (Status: ${status_code}, Body: $(head -c 60 "$body_file" | tr -d '\0'))${NC}" | tee -a "$LOG_FILE"
+        rm -f "$body_file"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        return 1
+    fi
+}
+
 # サイトマップにURLが含まれているかテスト
 test_sitemap_contains_url() {
     local sitemap_dir="$1"
@@ -440,6 +468,27 @@ main() {
     # レコメンドページ - 日本語
     log "レコメンドページのテスト（日本語）"
     test_url "${BASE_URL}/recommend/%E3%83%9D%E3%82%B1%E3%83%83%E3%83%88%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%EF%BC%88%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%EF%BC%89" "レコメンド（ポケモン）"
+    echo ""
+
+    # 動的OGP画像（シェアカード /card・検索用1:1サムネ /thumb）と言語別デフォルトOGP
+    # 200 かつ本文が実PNGであること（500やHTMLエラーページへの劣化を検知）。
+    # アイコン取得は外部(LINE CDN)依存だが、失敗してもプレースホルダで200のPNGを返す設計。
+    log "動的OGP画像のテスト"
+    if [ -n "$JA_OC_ID" ]; then
+        test_png_url "${BASE_URL}/oc/${JA_OC_ID}/card?d=ci" "OCシェアカード"
+        test_png_url "${BASE_URL}/oc/${JA_OC_ID}/thumb?d=ci" "OC 1:1サムネ"
+    fi
+    test_png_url "${BASE_URL}/recommend/%E3%83%9D%E3%82%B1%E3%83%83%E3%83%88%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%EF%BC%88%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%EF%BC%89/card?d=ci" "レコメンドシェアカード"
+    test_png_url "${BASE_URL}/recommend/%E3%83%9D%E3%82%B1%E3%83%83%E3%83%88%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%EF%BC%88%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%EF%BC%89/thumb?d=ci" "レコメンド1:1サムネ"
+    if [ -n "$TW_OC_ID" ]; then
+        test_png_url "${BASE_URL}/tw/oc/${TW_OC_ID}/card?d=ci" "OCシェアカード（繁体字）"
+    fi
+    if [ -n "$TH_OC_ID" ]; then
+        test_png_url "${BASE_URL}/th/oc/${TH_OC_ID}/card?d=ci" "OCシェアカード（タイ語）"
+    fi
+    test_png_url "${BASE_URL}/assets/ogp.png" "デフォルトOGP（ja）"
+    test_png_url "${BASE_URL}/assets/ogp_tw.png" "デフォルトOGP（tw）"
+    test_png_url "${BASE_URL}/assets/ogp_th.png" "デフォルトOGP（th）"
     echo ""
 
     # レコメンドページ - 繁体字

--- a/app/Views/blog_article_content.php
+++ b/app/Views/blog_article_content.php
@@ -26,6 +26,12 @@
                 <?php echo $_html ?>
             </div>
 
+            <?php // シェア導線（oc ページと共通のコンポーネント）。読み終えた直後・CTAの手前に置く ?>
+            <?php viewComponent('share_buttons', [
+                '_shareUrl' => url('blog/' . $article->slug),
+                '_shareGa' => ['content_type' => 'blog', 'item_id' => $article->slug],
+            ]) ?>
+
             <div class="blog-cta">
                 <div class="blog-cta-h">📈 オプチャグラフで<span class="em">実データ</span>を見る</div>
                 <div class="blog-cta-row">

--- a/app/Views/components/home_blog_shelf.php
+++ b/app/Views/components/home_blog_shelf.php
@@ -1,12 +1,26 @@
 <?php
 
 /**
- * ホームの「読み物（ブログ）」棚。最新記事を最大4本、最大の入口（トップ）から回遊させる。
+ * ホームの「読み物（ブログ）」棚。よく読まれている記事を最大2本、最大の入口（トップ）から回遊させる。
  * BlogService->list() は frontmatter のみの軽量読み（BlogSummaryDto[] を返す・本文なし）。ja 用。
  * viewComponent 経由なので自動エスケープは無く、表示値は h() でエスケープする。
  */
 
-$_posts = array_slice(app(\App\Services\Blog\BlogService::class)->list(), 0, 4);
+// トップ棚は GA4 の実測PV上位をハードコードで指名する（2026-07-04 時点・直近28日:
+// growing 161PV / kensaku-ranking-ochi 108PV / kyujosho 90PV / … / ninzu-jogen 33PV）。
+// ブログ全体のPVがまだ小さく上位の偏りも安定しているため自動集計はせず、
+// 順位が入れ替わったらここを手で更新する。指名記事が消えた場合は更新日順で埋める。
+$_pinnedSlugs = ['growing-openchat-features', 'openchat-kensaku-ranking-ochi'];
+$_limit = 2;
+
+$_all = app(\App\Services\Blog\BlogService::class)->list();
+$_bySlug = array_combine(array_map(fn($p) => $p->slug, $_all), $_all);
+$_posts = array_values(array_filter(array_map(fn($slug) => $_bySlug[$slug] ?? null, $_pinnedSlugs)));
+foreach ($_all as $_p) {
+    if (count($_posts) >= $_limit) break;
+    if (!in_array($_p, $_posts, true)) $_posts[] = $_p;
+}
+$_posts = array_slice($_posts, 0, $_limit);
 if (!$_posts) return;
 ?>
 <article class="home-blog-shelf">

--- a/app/Views/components/share_buttons.php
+++ b/app/Views/components/share_buttons.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * 共有ボタン列（OS ネイティブ共有・LINE・X・リンクコピー）＋コピー完了トースト。
+ * oc ページの共有導線を共通コンポーネント化したもの（oc・/recommend・トップで共用）。
+ * スタイル・挙動は自己完結（インライン style/script）。1ページ1回だけ設置する想定（id を使うため）。
+ *
+ * @var string     $_shareUrl 共有する URL（必須。`_`プレフィックスで自動エスケープを通さず、ここで明示エスケープする）
+ * @var array|null $_shareGa  GA4 計測(dataLayer)の share イベントに足す追加パラメータ（例 ['oc_id' => 1]）。省略可
+ *
+ * 共有本文は「ページタイトル(サイト名入り)＋改行＋URL」で統一（JS が document.title から組み立てる）。
+ * 共有リンクの og:image は各ページの動的カードで展開される。
+ */
+
+$_shareGa = $_shareGa ?? [];
+?>
+<div class="share-btns">
+  <span class="share-btns__label"><?php echo t('共有') ?></span>
+  <button type="button" class="share-btns__btn share-btns__btn--sub" id="share-btns-native" hidden aria-label="<?php echo t('共有') ?>">
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 16.1c-.8 0-1.5.3-2 .8l-7.1-4.2c0-.2.1-.5.1-.7s0-.5-.1-.7L16 7.2c.5.5 1.2.8 2 .8a3 3 0 1 0-3-3c0 .2 0 .5.1.7L8 9.8a3 3 0 1 0 0 4.4l7.1 4.2c0 .2-.1.4-.1.6a3 3 0 1 0 3-2.9z"/></svg>
+  </button>
+  <a class="share-btns__btn share-btns__btn--line" id="share-btns-line" href="https://social-plugins.line.me/lineit/share?url=<?php echo urlencode($_shareUrl) ?>" target="_blank" rel="noopener" aria-label="LINE">
+    <img src="<?php echo fileUrl('assets/line.svg', urlRoot: '') ?>" alt="" width="44" height="44">
+  </a>
+  <a class="share-btns__btn share-btns__btn--x" id="share-btns-x" href="https://x.com/intent/post?text=<?php echo urlencode($_shareUrl . "\n") ?>" target="_blank" rel="noopener" aria-label="X">
+    <svg viewBox="0 0 240 240" aria-hidden="true"><path d="M88.2 60.66L169.46 178.81H151.42L70.16 60.66H88.2ZM92.93 51.66H53.04L146.68 187.81H186.57L92.93 51.66Z"/><path d="M132.54 109.25L182.24 51.66H170.99L127.55 101.99L132.54 109.25Z"/><path d="M105.36 127.72L53.04 188.34H64.3L110.35 134.98L105.36 127.72Z"/></svg>
+  </a>
+  <button type="button" class="share-btns__btn share-btns__btn--sub" id="share-btns-copy" aria-label="<?php echo t('リンクをコピー') ?>">
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/></svg>
+  </button>
+</div>
+<div class="share-btns-toast" id="share-btns-toast" role="status" aria-live="polite"><?php echo t('コピーしました') ?></div>
+<style>
+  .share-btns { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin: var(--sp-section-gap) 1rem 0; }
+  .share-btns__label { font-size: 13px; font-weight: 700; letter-spacing: .04em; color: var(--c-text-4, #8b95a7); }
+  .share-btns__btn { width: 44px; height: 44px; flex: 0 0 44px; border-radius: 50%; overflow: hidden; display: inline-flex; align-items: center; justify-content: center; padding: 0; border: none; background: none; cursor: pointer; text-decoration: none; transition: transform .12s ease, filter .12s ease; }
+  .share-btns__btn:hover { transform: translateY(-2px); filter: brightness(1.08); }
+  .share-btns__btn:active { transform: translateY(0); }
+  .share-btns__btn:focus-visible { outline: 2px solid var(--c-grad-blue-btn, #5a8cff); outline-offset: 2px; }
+  .share-btns__btn svg { width: 22px; height: 22px; display: block; }
+  .share-btns__btn--line { background: #06C755; }
+  /* LINEアイコンは周囲に緑の余白を残す（円いっぱいに敷くと切り抜き感が強いため縮小して中央寄せ） */
+  .share-btns__btn--line img { width: 68%; height: 68%; display: block; }
+  /* X は真っ黒なのでダーク背景で溶ける。薄い枠で輪郭を出す */
+  .share-btns__btn--x { background: #000; border: 1px solid rgba(255, 255, 255, .22); }
+  .share-btns__btn--x svg { width: 20px; height: 20px; fill: #fff; }
+  .share-btns__btn--sub { background: var(--c-surface-2, rgba(127, 127, 127, .14)); border: 1px solid var(--c-border, rgba(127, 127, 127, .24)); }
+  .share-btns__btn--sub svg { fill: var(--c-text-3, #c2cad6); }
+  .share-btns__btn[hidden] { display: none; }
+  /* コピー完了の軽いトースト（すぐ消える） */
+  .share-btns-toast { position: fixed; left: 50%; bottom: 28px; transform: translateX(-50%) translateY(10px); z-index: 9999; padding: 10px 18px; border-radius: 10px; background: rgba(22, 26, 42, .96); color: #fff; font-size: 14px; font-weight: 700; box-shadow: 0 8px 28px rgba(0, 0, 0, .38); opacity: 0; pointer-events: none; transition: opacity .18s ease, transform .18s ease; }
+  .share-btns-toast.is-visible { opacity: 1; transform: translateX(-50%) translateY(0); }
+  @media (prefers-reduced-motion: reduce) { .share-btns-toast { transition: opacity .18s ease; transform: translateX(-50%); } }
+</style>
+<script>
+  (function () {
+    var url = <?php echo json_encode($_shareUrl, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>;
+    // ページ種別ごとの追加パラメータ（oc_id 等）を含めて GA4(GTM dataLayer経由)で計測。method で LINE/X/コピー/OS共有 を区別
+    var extras = <?php echo json_encode((object)$_shareGa, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>;
+    var d = (window.dataLayer = window.dataLayer || []);
+    function track(method) {
+      try {
+        var ev = { event: 'share', method: method };
+        for (var k in extras) ev[k] = extras[k];
+        d.push(ev);
+      } catch (e) {}
+    }
+    // 共有本文は「ページタイトル(サイト名入り)＋改行＋URL」で統一
+    function shareText() { return document.title + '\n' + url; }
+
+    var xBtn = document.getElementById('share-btns-x');
+    if (xBtn) {
+      // X はページタイトルを使い、URLの後にも改行を入れる（本文だけで組み立てる）
+      xBtn.href = 'https://x.com/intent/post?text=' + encodeURIComponent(shareText() + '\n');
+      xBtn.addEventListener('click', function () { track('x'); });
+    }
+    var lineBtn = document.getElementById('share-btns-line');
+    if (lineBtn) { lineBtn.addEventListener('click', function () { track('line'); }); }
+
+    var nativeBtn = document.getElementById('share-btns-native');
+    if (navigator.share) {
+      nativeBtn.hidden = false;
+      nativeBtn.addEventListener('click', function () {
+        track('native');
+        navigator.share({ title: document.title, url: url }).catch(function () {});
+      });
+    }
+
+    var toast = document.getElementById('share-btns-toast');
+    var toastTimer;
+    function showToast() {
+      if (!toast) return;
+      toast.classList.add('is-visible');
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(function () { toast.classList.remove('is-visible'); }, 1600);
+    }
+    var copyBtn = document.getElementById('share-btns-copy');
+    copyBtn.addEventListener('click', function () {
+      if (!navigator.clipboard) return;
+      navigator.clipboard.writeText(shareText()).then(function () {
+        track('copy');
+        showToast();
+      }).catch(function () {});
+    });
+  })();
+</script>

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -158,96 +158,12 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
         </div>
       </nav>
 
-      <?php // シェア導線（nav の外・全幅）。統一サイズの円形アイコンボタンで、LINE/X はブランド色にして
-            // 「どこへ共有するか」が一目で分かるようにする。モバイルは OS ネイティブ共有も出す。
+      <?php // シェア導線（nav の外・全幅）。共通コンポーネント（share_buttons・/recommend やトップと共用）。
             // 共有リンクの og:image は統計グラフ入りの動的カード(/oc/{id}/card)で展開される。 ?>
-      <div class="oc-share">
-        <span class="oc-share__label"><?php echo t('共有') ?></span>
-        <button type="button" class="oc-share__btn oc-share__btn--sub" id="oc-share-native" hidden aria-label="<?php echo t('共有') ?>">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 16.1c-.8 0-1.5.3-2 .8l-7.1-4.2c0-.2.1-.5.1-.7s0-.5-.1-.7L16 7.2c.5.5 1.2.8 2 .8a3 3 0 1 0-3-3c0 .2 0 .5.1.7L8 9.8a3 3 0 1 0 0 4.4l7.1 4.2c0 .2-.1.4-.1.6a3 3 0 1 0 3-2.9z"/></svg>
-        </button>
-        <a class="oc-share__btn oc-share__btn--line" id="oc-share-line" href="https://social-plugins.line.me/lineit/share?url=<?php echo urlencode(url('oc', $oc['id'])) ?>" target="_blank" rel="noopener" aria-label="LINE">
-          <img src="<?php echo fileUrl('assets/line.svg', urlRoot: '') ?>" alt="" width="44" height="44">
-        </a>
-        <a class="oc-share__btn oc-share__btn--x" id="oc-share-x" href="https://x.com/intent/post?text=<?php echo urlencode(htmlspecialchars_decode((string)$oc['name']) . "\n" . url('oc', $oc['id']) . "\n") ?>" target="_blank" rel="noopener" aria-label="X">
-          <svg viewBox="0 0 240 240" aria-hidden="true"><path d="M88.2 60.66L169.46 178.81H151.42L70.16 60.66H88.2ZM92.93 51.66H53.04L146.68 187.81H186.57L92.93 51.66Z"/><path d="M132.54 109.25L182.24 51.66H170.99L127.55 101.99L132.54 109.25Z"/><path d="M105.36 127.72L53.04 188.34H64.3L110.35 134.98L105.36 127.72Z"/></svg>
-        </a>
-        <button type="button" class="oc-share__btn oc-share__btn--sub" id="oc-share-copy" aria-label="<?php echo t('リンクをコピー') ?>">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/></svg>
-        </button>
-      </div>
-      <div class="oc-share-toast" id="oc-share-toast" role="status" aria-live="polite"><?php echo t('コピーしました') ?></div>
-      <style>
-        .oc-share { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin: var(--sp-section-gap) 1rem 0; }
-        .oc-share__label { font-size: 13px; font-weight: 700; letter-spacing: .04em; color: var(--c-text-4, #8b95a7); }
-        .oc-share__btn { width: 44px; height: 44px; flex: 0 0 44px; border-radius: 50%; overflow: hidden; display: inline-flex; align-items: center; justify-content: center; padding: 0; border: none; background: none; cursor: pointer; text-decoration: none; transition: transform .12s ease, filter .12s ease; }
-        .oc-share__btn:hover { transform: translateY(-2px); filter: brightness(1.08); }
-        .oc-share__btn:active { transform: translateY(0); }
-        .oc-share__btn:focus-visible { outline: 2px solid var(--c-grad-blue-btn, #5a8cff); outline-offset: 2px; }
-        .oc-share__btn svg { width: 22px; height: 22px; display: block; }
-        .oc-share__btn--line { background: #06C755; }
-        /* LINEアイコンは周囲に緑の余白を残す（円いっぱいに敷くと切り抜き感が強いため縮小して中央寄せ） */
-        .oc-share__btn--line img { width: 68%; height: 68%; display: block; }
-        /* X は真っ黒なのでダーク背景で溶ける。薄い枠で輪郭を出す */
-        .oc-share__btn--x { background: #000; border: 1px solid rgba(255, 255, 255, .22); }
-        .oc-share__btn--x svg { width: 20px; height: 20px; fill: #fff; }
-        .oc-share__btn--sub { background: var(--c-surface-2, rgba(127, 127, 127, .14)); border: 1px solid var(--c-border, rgba(127, 127, 127, .24)); }
-        .oc-share__btn--sub svg { fill: var(--c-text-3, #c2cad6); }
-        .oc-share__btn[hidden] { display: none; }
-        /* コピー完了の軽いトースト（すぐ消える） */
-        .oc-share-toast { position: fixed; left: 50%; bottom: 28px; transform: translateX(-50%) translateY(10px); z-index: 9999; padding: 10px 18px; border-radius: 10px; background: rgba(22, 26, 42, .96); color: #fff; font-size: 14px; font-weight: 700; box-shadow: 0 8px 28px rgba(0, 0, 0, .38); opacity: 0; pointer-events: none; transition: opacity .18s ease, transform .18s ease; }
-        .oc-share-toast.is-visible { opacity: 1; transform: translateX(-50%) translateY(0); }
-        @media (prefers-reduced-motion: reduce) { .oc-share-toast { transition: opacity .18s ease; transform: translateX(-50%); } }
-      </style>
-      <script>
-        (function () {
-          var url = <?php echo json_encode(url('oc', $oc['id'])) ?>;
-          var d = (window.dataLayer = window.dataLayer || []);
-          var ocId = <?php echo (int)$oc['id'] ?>;
-          var ocName = <?php echo json_encode((string)$oc['name'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?>;
-          // 共有ボタン押下を GA4(GTM dataLayer経由)で計測。method で LINE/X/コピー/OS共有 を区別
-          function track(method) {
-            try { d.push({ event: 'share', method: method, oc_id: ocId, oc_name: ocName }); } catch (e) {}
-          }
-          // 共有本文は「ページタイトル(サイト名入り)＋改行＋URL」で統一
-          function shareText() { return document.title + '\n' + url; }
-
-          var xBtn = document.getElementById('oc-share-x');
-          if (xBtn) {
-            // X はページタイトルを使い、URLの後にも改行を入れる（本文だけで組み立てる）
-            xBtn.href = 'https://x.com/intent/post?text=' + encodeURIComponent(shareText() + '\n');
-            xBtn.addEventListener('click', function () { track('x'); });
-          }
-          var lineBtn = document.getElementById('oc-share-line');
-          if (lineBtn) { lineBtn.addEventListener('click', function () { track('line'); }); }
-
-          var nativeBtn = document.getElementById('oc-share-native');
-          if (navigator.share) {
-            nativeBtn.hidden = false;
-            nativeBtn.addEventListener('click', function () {
-              track('native');
-              navigator.share({ title: document.title, url: url }).catch(function () {});
-            });
-          }
-
-          var toast = document.getElementById('oc-share-toast');
-          var toastTimer;
-          function showToast() {
-            if (!toast) return;
-            toast.classList.add('is-visible');
-            clearTimeout(toastTimer);
-            toastTimer = setTimeout(function () { toast.classList.remove('is-visible'); }, 1600);
-          }
-          var copyBtn = document.getElementById('oc-share-copy');
-          copyBtn.addEventListener('click', function () {
-            if (!navigator.clipboard) return;
-            navigator.clipboard.writeText(shareText()).then(function () {
-              track('copy');
-              showToast();
-            }).catch(function () {});
-          });
-        })();
-      </script>
+      <?php viewComponent('share_buttons', [
+        '_shareUrl' => url('oc', $oc['id']),
+        '_shareGa' => ['oc_id' => (int)$oc['id'], 'oc_name' => htmlspecialchars_decode((string)$oc['name'])],
+      ]) ?>
       <?php if (isset($_adminDto)) : ?>
         <?php viewComponent('oc_content_admin', compact('_adminDto')); ?>
       <?php endif ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -57,6 +57,13 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
         'recommend' => $recommend ?? null,
       ]) ?>
 
+      <?php // シェア導線（oc ページと共通のコンポーネント）。共有リンクの og:image は
+            // テーマ専用の動的カード(/recommend/{tag}/card)で展開される ?>
+      <?php viewComponent('share_buttons', [
+        '_shareUrl' => $canonical,
+        '_shareGa' => ['content_type' => 'recommend', 'item_id' => htmlspecialchars_decode($tag)],
+      ]) ?>
+
     </section>
     <section class="recommend-ranking-section">
       <?php if (isset($recommend)) : ?>

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -62,13 +62,6 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
                 <input type="hidden" name="sort" value="member">
                 <input type="hidden" name="order" value="desc">
             </form>
-
-            <?php // シェア導線（oc ページと共通のコンポーネント）。トップの共有はサイト紹介そのものなので
-                  // ヒーロー末尾に置く。og:image は言語別デフォルトOGP ?>
-            <?php viewComponent('share_buttons', [
-                '_shareUrl' => url(),
-                '_shareGa' => ['content_type' => 'top'],
-            ]) ?>
         </section>
         <script>
             /* クリア✕: テーマ検索と同じ挙動。変換(IME)確定前は✕を隠し、iOSで「消去後に入力できない」状態を防ぐ。 */
@@ -117,6 +110,14 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
 
         <?php viewComponent('recommend_list2', ['recommend' => $officialDto, 'id' => 0]) ?>
         <?php viewComponent('recommend_list2', ['recommend' => $officialDto2, 'id' => 0]) ?>
+
+        <?php // シェア導線（oc ページと共通のコンポーネント）。ヒーロー内だと検索→コンテンツの流れを
+              // 分断するため、コンテンツを見終えた後のページ末尾（フッター手前）に置く。
+              // og:image は言語別デフォルトOGP ?>
+        <?php viewComponent('share_buttons', [
+            '_shareUrl' => url(),
+            '_shareGa' => ['content_type' => 'top'],
+        ]) ?>
 
         <?php if ($enableAdsense): ?>
             <?php // フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -62,6 +62,13 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
                 <input type="hidden" name="sort" value="member">
                 <input type="hidden" name="order" value="desc">
             </form>
+
+            <?php // シェア導線（oc ページと共通のコンポーネント）。トップの共有はサイト紹介そのものなので
+                  // ヒーロー末尾に置く。og:image は言語別デフォルトOGP ?>
+            <?php viewComponent('share_buttons', [
+                '_shareUrl' => url(),
+                '_shareGa' => ['content_type' => 'top'],
+            ]) ?>
         </section>
         <script>
             /* クリア✕: テーマ検索と同じ挙動。変換(IME)確定前は✕を隠し、iOSで「消去後に入力できない」状態を防ぐ。 */


### PR DESCRIPTION
# 概要

stg で確認済みの以下を本番へ反映します（#593 / #594）。

- **共有ボタン（OS共有・LINE・X・リンクコピー）を共通コンポーネント化**し、部屋ページに加えて設置範囲を拡大:
  - トップページ（公式ランキングまで見終えたページ末尾・フッター手前）
  - ランキングページ /recommend/タグ（テーマの勢いグラフの下）
  - ブログ記事ページ（本文直後・CTAの手前）
  - GA4 の share イベントにページ種別（content_type / item_id）を付与
- **トップの「読み物」を最新4本→よく読まれている2本に**: GA4 実測PV（直近28日）で「伸びるオープンチャットの特徴」161PV・「検索・ランキングから消えた理由」108PV が突出しているため上位2本を指名表示。マイナー記事がトップに出続けるのを解消
- **CI にシェア画像（card/thumb・デフォルトOGP）の実PNGチェックを追加**

---
🤖 Generated with Claude Code
Posted from: vm:/home/user/Open-Chat-Graph

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYcCitMe23N53QDrxtF91j)_