### PR TITLE
[PROD] ランキングページの共有ボタンの上下余白を28px/28pxに均等化

### DIFF
--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -59,11 +59,12 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
 
       <?php // シェア導線（oc ページと共通のコンポーネント）。共有リンクの og:image は
             // テーマ専用の動的カード(/recommend/{tag}/card)で展開される。
-            // 直前の勢いグラフ(.recommend-growth)が下マージンを持つため、二重にならないよう上マージンは消す ?>
+            // 余白は実測で上下とも28pxに揃える: 上=勢いグラフの margin-bottom 28px（自前の上マージンは0）、
+            // 下=見出しまで素で8pxしか無いので margin-bottom 20px を足して 28px にする ?>
       <?php viewComponent('share_buttons', [
         '_shareUrl' => $canonical,
         '_shareGa' => ['content_type' => 'recommend', 'item_id' => htmlspecialchars_decode($tag)],
-        '_shareStyle' => 'margin-top: 0',
+        '_shareStyle' => 'margin: 0 1rem 20px',
       ]) ?>
 
     </section>


### PR DESCRIPTION
# 概要

stg 確認済みの #600 を本番へ反映します。共有ボタンの余白が「上28px・下8px」と非対称だったのを、実レンダリング計測に基づき**上下とも28px**に均等化しました（修正後の実測で28/28確認済み）。

---
🤖 Generated with Claude Code
Posted from: vm:/home/user/Open-Chat-Graph

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYcCitMe23N53QDrxtF91j)_