### PR TITLE
[PROD] 広告をページになじむ控えめなレスポンシブ表示に整理（全画面の広告ブロック警告も廃止）

### DIFF
--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -8,6 +8,15 @@ class GoogleAdsenseConfig
     static string $googleAdsenseClient = 'ca-pub-2330982526015125'; // 広告クライアントID
 
     /**
+     * アンチアドブロック（ad_guard: 未表示検出→全画面オーバーレイ）の有効/無効。
+     *
+     * 運用方針転換により一旦 false（無効）。各 View の viewComponent('ad_guard') 呼び出しは
+     * 残すが、false の間 ad_guard.php は冒頭で return し何も出力しない。復活させたいときは
+     * true に戻すだけでよい。
+     */
+    static bool $enableAdBlockGuard = false;
+
+    /**
      * Google AdSense広告スロット設定
      *
      * キー: スロット識別子（文字列）
@@ -17,8 +26,8 @@ class GoogleAdsenseConfig
      * 'newSlotKey' => ['slotId' => '1234567890', 'cssClass' => 'rectangle3-ads'],
      */
     static array $googleAdsenseSlots = [
-        // OCトップ-horizontal
-        'ocTopHorizontal' => ['slotId' => '9641198670', 'cssClass' => 'horizontal-ads'],
+        // OCトップ-horizontal（方針転換で横長固定→幅いっぱいのレスポンシブ表示に変更・cssClass=null）
+        'ocTopHorizontal' => ['slotId' => '9641198670', 'cssClass' => null],
         // OCトップ-rectangle
         'ocTopRectangle' => ['slotId' => '8037531176', 'cssClass' => 'rectangle3-ads'],
         // OCトップ2-rectangle
@@ -49,8 +58,8 @@ class GoogleAdsenseConfig
         'siteSeparatorResponsive' => ['slotId' => '4243068812', 'cssClass' => null],
         // サイトセパレーター-rectangle
         'siteSeparatorRectangle' => ['slotId' => '9793281538', 'cssClass' => 'rectangle-ads'],
-        // サイトセパレーター-横長
-        'siteSeparatorWide' => ['slotId' => '7150203685', 'cssClass' => 'rectangle2-ads'],
+        // サイトセパレーター-横長（jump ページの最高単価枠。固定→幅いっぱいのレスポンシブ表示に変更・cssClass=null）
+        'siteSeparatorWide' => ['slotId' => '7150203685', 'cssClass' => null],
         // サイト-bottom-wide
         'siteBottomWide' => ['slotId' => '8637392164', 'cssClass' => 'rectangle2-ads'],
         // おすすめトップ-rectangle

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -57,7 +57,7 @@ class GoogleAdsense
         EOT;
 
         echo <<<EOT
-            <ins class="adsbygoogle manual {$cssClass}" data-ad-client="{$adClient}" data-ad-slot="{$adSlot}" data-ad-format="auto" data-full-width-responsive="false"></ins>
+            <ins class="adsbygoogle manual {$cssClass}" data-ad-client="{$adClient}" data-ad-slot="{$adSlot}" data-ad-format="auto" data-full-width-responsive="true"></ins>
         EOT;
 
         echo <<<EOT

--- a/app/Views/components/ad_guard.php
+++ b/app/Views/components/ad_guard.php
@@ -28,6 +28,13 @@
  *  no fill(unfilled)・iframe無し枠は除外し、誤検知ゼロを維持。
  */
 
+// 運用方針転換により一旦無効化（GoogleAdsenseConfig::$enableAdBlockGuard）。
+// 各 View の viewComponent('ad_guard') 呼び出しは残すが、フラグが false の間は何も出力しない。
+// 復活させたいときは同フラグを true に戻すだけでよい。
+if (!\App\Config\GoogleAdsenseConfig::$enableAdBlockGuard) {
+    return;
+}
+
 // --- 乱数識別子（毎リクエスト） ---
 $rid = static function (): string {
     return 'o' . substr(bin2hex(random_bytes(8)), 0, 10);

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -215,6 +215,9 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
     <?php if ($enableAdsense): ?>
       <?php // ocTopWide2(手動横長)は撤去済み: impRPM¥14/CTR0.21%で「関連ルーム」棚への回遊を遮るだけだった(2026-06実測)。gTag は自動広告に必要なので維持 ?>
       <?php GAd::gTag() ?>
+      <?php // グラフ直後・関連ルームの前にレスポンシブ1枠（中盤に紛れ込ませ）。既存の未使用スロットを流用。
+            // 下部のコメント下枠(ocTopHorizontal)とは関連ルームを挟むので2枠が近接しない ?>
+      <?php GAd::output('ocSeparatorResponsive') ?>
     <?php endif ?>
 
     <?php // 関連ルーム(類似サイズ/おすすめ)は recommend 静的キャッシュ(.dat)から都度組み立て（MySQL不使用） ?>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -85,7 +85,16 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
             </header>
             <?php $listArray = $recommend->getList(false, AppConfig::LIST_LIMIT_RECOMMEND) ?>
 
-            <?php viewComponent('open_chat_list_recommend', compact('recommend', 'listArray') + ['showListMedal' => true, 'currentCount' => 0, 'showApiCreatedAt' => true]) ?>
+            <?php // top5 の下（高視認位置）に広告を1枠。自動広告オフに伴い、以前ここにあった枠を復活させる。
+                  // リストを top5 と残りに分割し間に挿入する（未使用スロット recommendSeparatorResponsive を流用）。
+                  // currentCount で残りチャンクの連番を継続。広告オフ/5件以下では従来どおり一本のリスト。 ?>
+            <?php if ($enableAdsense && count($listArray) > 5) : ?>
+              <?php viewComponent('open_chat_list_recommend', ['recommend' => $recommend, 'listArray' => array_slice($listArray, 0, 5), 'showListMedal' => true, 'currentCount' => 0, 'showApiCreatedAt' => true]) ?>
+              <?php GAd::output('recommendSeparatorResponsive') ?>
+              <?php viewComponent('open_chat_list_recommend', ['recommend' => $recommend, 'listArray' => array_slice($listArray, 5), 'showListMedal' => false, 'currentCount' => 5, 'showApiCreatedAt' => true]) ?>
+            <?php else : ?>
+              <?php viewComponent('open_chat_list_recommend', compact('recommend', 'listArray') + ['showListMedal' => true, 'currentCount' => 0, 'showApiCreatedAt' => true]) ?>
+            <?php endif ?>
 
             <?php if (isset($_dto->tagRecordCounts[$_tagIndex]) && ((int)$_dto->tagRecordCounts[$_tagIndex]) > $count) : ?>
               <a class="top-ranking-readMore unset ranking-url white-btn" style="margin-top: 1rem;" href="<?php echo url('ranking?keyword=' . urlencode('tag:' . $_tagIndex)) ?>">

--- a/public/style/components/site_header.css
+++ b/public/style/components/site_header.css
@@ -724,6 +724,22 @@ html.is-ios .site_header_outer.header-hidden {
   box-sizing: border-box;
 }
 
+/* レスポンシブ広告(data-ad-format="auto" + full-width-responsive)は配信サイズが可変。
+   読み込み前に高さを予約しておかないとレイアウトがガタつく(CLS)ため、既存の
+   rectangle 枠と同じ約280pxを min-height で確保する（大きめディスプレイを誘導）。 */
+.responsive-google {
+  min-height: 280px;
+}
+
+/* no fill(在庫なし)のときは予約した高さを畳み、空の余白を残さない。
+   Google が data-ad-status="unfilled" を付けた枠だけを対象にするので、
+   フィル済み(filled)の枠には影響しない。 */
+ins.responsive-google[data-ad-status='unfilled'] {
+  min-height: 0 !important;
+  height: 0 !important;
+  display: none !important;
+}
+
 .openchat-item-list .google-auto-placed {
   margin: 0 -1rem;
   width: 100vw !important;


### PR DESCRIPTION
stg の広告最適化を本番へ昇格。

- #606 埋め込みディスプレイ広告をレスポンシブ化＋高視認位置へ再配置、ad_guard を無効化

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
