### PR TITLE
[PROD] 見られない下部の広告(視認率15%)を撤去し、収益を効果の高い位置に集約

### DIFF
--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -11,8 +11,12 @@ class GoogleAdsense
      * 広告を出力
      *
      * @param string $slotKey スロット識別子（例: 'ocTopRectangle'）
+     * @param bool $fullWidthResponsive レスポンシブ枠を端末幅いっぱいに広げるか（既定 true）。
+     *                                  リスト内など横インデントされた文脈では false にすると、
+     *                                  画面幅への「はみ出し」をやめてコンテナ幅（＝周囲の行と同じ位置）に収まる。
+     *                                  固定サイズ（cssClass 有り）の枠には影響しない。
      */
-    public static function output(string $slotKey)
+    public static function output(string $slotKey, bool $fullWidthResponsive = true)
     {
         if (AppConfig::$isStaging) return;
 
@@ -25,7 +29,7 @@ class GoogleAdsense
 
         // レスポンシブ広告（CSSクラスがnull）
         if ($cssClass === null) {
-            self::responsive($slotId, 'responsive-google');
+            self::responsive($slotId, 'responsive-google', $fullWidthResponsive);
         } else {
             self::rectangle($slotId, $cssClass);
         }
@@ -48,16 +52,17 @@ class GoogleAdsense
         EOT;
     }
 
-    private static function responsive(string $adSlot, string $cssClass)
+    private static function responsive(string $adSlot, string $cssClass, bool $fullWidthResponsive = true)
     {
         $adClient = GoogleAdsenseConfig::$googleAdsenseClient;
+        $fullWidth = $fullWidthResponsive ? 'true' : 'false';
 
         echo <<<EOT
         <div class="{$cssClass}-parent">
         EOT;
 
         echo <<<EOT
-            <ins class="adsbygoogle manual {$cssClass}" data-ad-client="{$adClient}" data-ad-slot="{$adSlot}" data-ad-format="auto" data-full-width-responsive="true"></ins>
+            <ins class="adsbygoogle manual {$cssClass}" data-ad-client="{$adClient}" data-ad-slot="{$adSlot}" data-ad-format="auto" data-full-width-responsive="{$fullWidth}"></ins>
         EOT;
 
         echo <<<EOT

--- a/app/Views/oc_content.php
+++ b/app/Views/oc_content.php
@@ -246,11 +246,8 @@ viewComponent('oc_head', compact('_css', '_meta', '_schema') + ['dataOverlays' =
       </section>
     <?php endif ?>
 
-    <?php if ($enableAdsense): ?>
-      <?php // コメントの下・フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。
-            // 広告ブロック検出(ad_guard)はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-      <?php GAd::output('ocTopHorizontal') ?>
-    <?php endif ?>
+    <?php // コメント下の横長枠は撤去: 視認率15%/CTR0.03%（AdSense実測）＝ここまでスクロール到達0.9%で「見られない死に枠」。
+          // 収益はグラフ直後の枠（本題直後・高視認）に集約する。 ?>
     <?php viewComponent('footer_inner') ?>
 
   </div>

--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -90,7 +90,9 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
                   // currentCount で残りチャンクの連番を継続。広告オフ/5件以下では従来どおり一本のリスト。 ?>
             <?php if ($enableAdsense && count($listArray) > 5) : ?>
               <?php viewComponent('open_chat_list_recommend', ['recommend' => $recommend, 'listArray' => array_slice($listArray, 0, 5), 'showListMedal' => true, 'currentCount' => 0, 'showApiCreatedAt' => true]) ?>
-              <?php GAd::output('recommendSeparatorResponsive') ?>
+              <?php // リスト内はルーム行が左右1remインデントされているので、広告も画面幅へはみ出さず
+                    // コンテナ幅に収める（full-width-responsive=false）＝行と左右がそろう ?>
+              <?php GAd::output('recommendSeparatorResponsive', false) ?>
               <?php viewComponent('open_chat_list_recommend', ['recommend' => $recommend, 'listArray' => array_slice($listArray, 5), 'showListMedal' => false, 'currentCount' => 5, 'showApiCreatedAt' => true]) ?>
             <?php else : ?>
               <?php viewComponent('open_chat_list_recommend', compact('recommend', 'listArray') + ['showListMedal' => true, 'currentCount' => 0, 'showApiCreatedAt' => true]) ?>
@@ -118,11 +120,8 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
       <?php viewComponent('theme_discovery', ['discovery' => $_discovery]) ?>
     <?php endif ?>
 
-    <?php if ($enableAdsense && isset($recommend)): ?>
-      <?php // フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。
-            // 広告ブロック検出(ad_guard)はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-      <?php GAd::output('ocTopHorizontal') ?>
-    <?php endif ?>
+    <?php // フッター前の横長枠は撤去: 視認率15%/CTR0.03%（AdSense実測）＝90%到達0.7%で「見られない死に枠」。
+          // 収益は top5 直下の枠（本題直後・到達7.1%）に集約する。 ?>
 
     <?php viewComponent('footer_inner') ?>
 

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -119,12 +119,8 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
             '_shareGa' => ['content_type' => 'top'],
         ]) ?>
 
-        <?php if ($enableAdsense): ?>
-            <?php // フッター直前にOC横長1枠（固定。高さ確保済みでCLSなし）。
-                  // 広告ブロック検出(ad_guard)はページに ins.adsbygoogle が1つも無いと動作しないため、その維持も兼ねる ?>
-            <?php \App\Views\Ads\GoogleAdsense::output('ocTopHorizontal') ?>
-        <?php endif ?>
-
+        <?php // フッター前の横長枠は撤去: 視認率15%/CTR0.03%/RPM¥12（AdSense実測）で「見られない死に枠」。
+              // トップは下も上もスクロール到達が壊滅的（30%到達2.6%）＝埋め込み広告に不向きなため置かない。 ?>
         <?php viewComponent('footer_inner') ?>
         <div class="refresh-time" style="width: fit-content; margin: auto; padding-bottom: 0.5rem; margin-top: -9px;">
             <div class="refresh-icon"></div><time style="font-size: 11px; color: var(--c-text-5); margin-left:3px" datetime="<?php echo $_updatedAt->format(\DateTime::ATOM) ?>"><?php echo $_updatedAt->format('Y/n/j G:i') ?></time>


### PR DESCRIPTION
stg の広告整理を本番へ昇格。

- #610 見られない下部横長広告(視認率15%)を撤去し、収益を高視認位置に集約（おすすめtop5直下の左右ズレ修正も含む）

---
🤖 Generated with Claude Code (claude-opus-4-8[1m])
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
