### PR TITLE
[PROD] fix: おすすめリスト内の広告をリストの左右余白の外に出して横幅いっぱいに表示

### DIFF
--- a/app/Views/recommend_content.php
+++ b/app/Views/recommend_content.php
@@ -90,8 +90,8 @@ viewComponent('head', compact('_css', '_schema', 'canonical') + ['_meta' => $_me
                   // currentCount で残りチャンクの連番を継続。広告オフ/5件以下では従来どおり一本のリスト。 ?>
             <?php if ($enableAdsense && count($listArray) > 5) : ?>
               <?php viewComponent('open_chat_list_recommend', ['recommend' => $recommend, 'listArray' => array_slice($listArray, 0, 5), 'showListMedal' => true, 'currentCount' => 0, 'showApiCreatedAt' => true]) ?>
-              <?php // リスト内はルーム行が左右1remインデントされているので、広告も画面幅へはみ出さず
-                    // コンテナ幅に収める（full-width-responsive=false）＝行と左右がそろう ?>
+              <?php // 広告だけはルーム行の左右1remインデントの外へ出し、コンテナ幅いっぱいで表示する
+                    // （CSS .top-ranking > .responsive-google-parent の負マージンで相殺）。full-width-responsive=false のまま。 ?>
               <?php GAd::output('recommendSeparatorResponsive', false) ?>
               <?php viewComponent('open_chat_list_recommend', ['recommend' => $recommend, 'listArray' => array_slice($listArray, 5), 'showListMedal' => false, 'currentCount' => 5, 'showApiCreatedAt' => true]) ?>
             <?php else : ?>

--- a/public/style/components/site_header.css
+++ b/public/style/components/site_header.css
@@ -754,6 +754,14 @@ ins.responsive-google[data-ad-status='unfilled'] {
   max-width: 812px;
 }
 
+/* recommend リスト内(top5 直下)の広告だけは、ルーム行の左右1remインデント
+   (.pad-side-top-ranking .top-ranking の margin)の外へ出し、コンテナ幅いっぱいに表示する。
+   行と左右をそろえる従来方針から「広告は横幅いっぱい」へ変更。負マージンでインデントを相殺。 */
+.top-ranking > .responsive-google-parent {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
 @media screen and (min-width: 512px) {
   .rectangle3-ads,
   .rectangle4-ads,


### PR DESCRIPTION
おすすめ(recommend)のトップ5直下に出しているディスプレイ広告が、リストの
左右1remの余白の内側に収まってしまい横幅いっぱいにならず内側に寄っていた。
広告の枠だけを余白の外へ出し、コンテンツ幅(最大812px)いっぱいに広げた。

- site_header.css: .top-ranking 直下の広告ラッパーに負マージン(-1rem)を当てて リストの左右インデントを相殺。既存の .google-auto-placed と同じ手法
- recommend_content.php: 挙動変更に合わせてコメントを更新

🤖 Generated with Claude Code (claude-opus-4-8[1m]) Committed from: user-B550M-Pro4:~/repos/Open-Chat-Graph