### PR TITLE
[PROD] サイト内の広告を一旦すべて停止し、AIアシスタント向けにデータを開放（公開MCPサーバー・llms.txt を追加）

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -5,6 +5,46 @@
 - エンドポイント: `POST /database/{username}/query`
 - **Basic認証**（`{username}` / `{password}` をそのまま）を付け、POSTボディに `stmt`（SQL）と `password` を渡す。結果は JSON。
 - POSTボディの `password` は申請時に渡すパスワードの **SHA256（16進）**。`{username}` はパスに入れる（[認証情報の取得](#認証情報の取得)）。
+- **認証不要で使いたい場合は [MCP サーバー](#mcp-サーバー認証不要ai-アシスタント向け)** もある（AI アシスタント向け・レートリミットあり）。
+
+---
+
+## MCP サーバー（認証不要・AI アシスタント向け）
+
+Claude・ChatGPT などの AI アシスタントやエージェントから、申請なしでこのデータベースへアクセスできる
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io/) サーバーを公開している。
+
+- エンドポイント: `https://openchat-review.me/mcp`（Streamable HTTP・POST・レスポンスは常に JSON。SSE/セッション管理なしのステートレス実装）
+- 認証: 不要
+- ツール:
+  | ツール | 内容 |
+  | --- | --- |
+  | `search_openchat` | 部屋名・説明文のキーワード検索（メンバー数順・最大20件） |
+  | `get_openchat_stats` | 部屋の基本情報＋直近30日のメンバー数推移＋LINE公式ランキング順位 |
+  | `get_database_schema` | テーブル定義（DDL・日本語コメント付き）を取得 |
+  | `query_database` | 読み取り専用 SQL（SELECT / WITH のみ・1クエリ20行まで） |
+- レートリミット: 1クエリ20行まで／IPごとに5分間で合計1000行まで／サイト全体の同時実行2件まで（非力なサーバーなので手加減してほしい）
+- 非公開テーブル: `ban_user`・`comment_log`・`ban_room`（IPアドレス等を含む運営用データ）にはアクセスできない
+- 出典表記のお願い: データを引用する際は「オプチャグラフ (openchat-review.me)」と部屋ページ URL（`https://openchat-review.me/oc/{id}`）を添えてほしい
+
+Claude Code / Claude Desktop での接続例:
+
+```bash
+claude mcp add --transport http openchat-graph https://openchat-review.me/mcp
+```
+
+```json
+{
+  "mcpServers": {
+    "openchat-graph": {
+      "type": "http",
+      "url": "https://openchat-review.me/mcp"
+    }
+  }
+}
+```
+
+サイト概要の機械可読版は [`https://openchat-review.me/llms.txt`](https://openchat-review.me/llms.txt) にもある。
 
 ---
 

--- a/app/Config/AppConfig.php
+++ b/app/Config/AppConfig.php
@@ -191,14 +191,12 @@ class AppConfig
     static bool $isMockEnvironment = false;
     static bool $isStaging = false;
     static bool $disableStaticDataFile = false;
-    static bool $disableAds = false;
     static bool $verboseCronLog = true;
     static bool $enableCloudflare = false;
 
     /** GitHubリポジトリ（ログのソースコードリンク用） */
     static string $githubRepo = 'Open-Chat-Graph/Open-Chat-Graph';
     static string $githubBranch = 'main';
-    static bool $disableAdTags = true;
 
     // 重複通報の受付をスキップ（管理者が既に対応している通報をさらに通報されるのを防止）
     static bool $skipDuplicateReport = false;

--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -8,6 +8,15 @@ class GoogleAdsenseConfig
     static string $googleAdsenseClient = 'ca-pub-2330982526015125'; // 広告クライアントID
 
     /**
+     * AdSense 広告全体（display広告ユニット・adsbygoogle.js タグ・アンカー広告）の有効/無効。
+     *
+     * 運用方針転換により一旦 false（全停止）。各 View の GoogleAdsense::output() / gTag() /
+     * loadAdsTag() 呼び出しは残すが、false の間はクラス側の冒頭ガードで何も出力しない。
+     * 復活させたいときは true に戻すだけでよい。ads.txt はアカウント維持のため出力を続ける。
+     */
+    static bool $enableAds = false;
+
+    /**
      * アンチアドブロック（ad_guard: 未表示検出→全画面オーバーレイ）の有効/無効。
      *
      * 運用方針転換により一旦 false（無効）。各 View の viewComponent('ad_guard') 呼び出しは

--- a/app/Config/routing.php
+++ b/app/Config/routing.php
@@ -9,6 +9,7 @@ use App\Controllers\Api\CommentPostApiController;
 use App\Controllers\Api\CommentImageThumbnailController;
 use App\Controllers\Api\CommentReportApiController;
 use App\Controllers\Api\DatabaseApiController;
+use App\Controllers\Api\McpApiController;
 use Shadow\Kernel\Route;
 use App\Services\Admin\AdminAuthService;
 use App\Controllers\Api\OpenChatRankingPageApiController;
@@ -753,6 +754,20 @@ Route::path(
     [DatabaseApiController::class, 'schema']
 )
     ->match($databaseApiPostAuth);
+
+// 公開 MCP エンドポイント（AI アシスタント向け・認証なし）
+// レートリミット・SQLガード・非公開テーブルの遮断は McpServerService 側。
+// CORS/OPTIONS・405 はコントローラ側で処理するため GET/OPTIONS もルートに含める。
+// Cloudflare の bot チャレンジ除外(/mcp)とセット（oc-infra 参照）。
+Route::path(
+    'mcp@post@get@options',
+    [McpApiController::class, 'index']
+)
+    ->match(function () {
+        if (MimimalCmsConfig::$urlRoot !== '') {
+            return false;
+        }
+    });
 
 cache();
 Route::run();

--- a/app/Controllers/Api/McpApiController.php
+++ b/app/Controllers/Api/McpApiController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers\Api;
+
+use App\Services\Api\McpServerService;
+
+/**
+ * 公開 MCP エンドポイント /mcp（POST・認証なし）
+ *
+ * MCP (Model Context Protocol) の Streamable HTTP トランスポート。SSE ストリームは
+ * 提供せず、常に単一の application/json レスポンスを返すステートレス実装
+ * （セッションIDは発行しない）。プロトコル処理・ツール実装・レートリミットは
+ * McpServerService 側。使い方は API_README.md / https://openchat-review.me/llms.txt。
+ *
+ * 注意: Cloudflare の bot チャレンジ除外（firewall_custom `bot` ルールの
+ * `not starts_with(http.request.uri.path, "/mcp")`）とセットで公開されている。
+ * パスを変える場合は CF ルール（oc-infra）も対で更新すること。
+ */
+class McpApiController
+{
+    function index(McpServerService $mcp)
+    {
+        // MCP クライアントはブラウザ外が主だが、Web ベースのクライアント向けに CORS を許可
+        header('Access-Control-Allow-Origin: *');
+        header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
+        header('Access-Control-Allow-Headers: Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version');
+        if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+            exit;
+        }
+
+        header('Content-Type: application/json; charset=UTF-8');
+
+        // GET は SSE 非対応のため 405（MCP 仕様）。人間向けに案内だけ返す
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            header('Allow: POST, OPTIONS');
+            http_response_code(405);
+            echo json_encode([
+                'message' => 'This is the OpenChat Graph MCP endpoint (Streamable HTTP, JSON responses only). '
+                    . 'Connect with an MCP client via POST. Docs: https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/main/API_README.md',
+            ], JSON_UNESCAPED_SLASHES);
+            exit;
+        }
+
+        $body = json_decode(file_get_contents('php://input') ?: '', true);
+        if ($body === null) {
+            http_response_code(400);
+            echo json_encode([
+                'jsonrpc' => '2.0',
+                'id' => null,
+                'error' => ['code' => -32700, 'message' => 'Parse error: invalid JSON'],
+            ]);
+            exit;
+        }
+
+        $response = $mcp->handleMessage($body);
+
+        // 通知のみ（レスポンス不要）は 202 Accepted
+        if ($response === null) {
+            http_response_code(202);
+            exit;
+        }
+
+        echo json_encode($response, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        exit;
+    }
+}

--- a/app/Controllers/Pages/RobotsController.php
+++ b/app/Controllers/Pages/RobotsController.php
@@ -54,6 +54,8 @@ TXT;
     private function getProductionRobotsTxt(): string
     {
         return <<<TXT
+# AI/LLM: サイト概要とデータアクセス方法(MCP/API)は https://openchat-review.me/llms.txt を参照
+
 # Google AdSenseクローラーのみ許可
 User-agent: Mediapartners-Google
 Allow: /oc/*/jump

--- a/app/Services/Api/McpServerService.php
+++ b/app/Services/Api/McpServerService.php
@@ -1,0 +1,517 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Api;
+
+use App\Config\AppConfig;
+use App\Models\SQLite\SQLiteOcgraphSqlapi;
+use App\Services\Storage\FileStorageInterface;
+
+/**
+ * 公開 MCP サーバー（Model Context Protocol / Streamable HTTP・ステートレス）
+ *
+ * AI アシスタント（Claude・ChatGPT 等）がオプチャグラフの統計データ（SQLite・
+ * /database API と同じ読み取り専用DB）へ認証なしでアクセスするための JSON-RPC 2.0
+ * エンドポイント。SSE は使わず、1リクエスト=1レスポンスの application/json のみ。
+ *
+ * 公開エンドポイントのため /database API より厳しいガードを掛ける:
+ *  - SELECT / WITH 文のみ・LIMIT 20 強制・フェッチ行数もサーバ側で20行に打ち切り
+ *  - 個人情報を含むテーブル（ban_user, comment_log）と運営内部テーブル（ban_room）は
+ *    テーブル名の部分一致で拒否（SQLite の識別子はコメントや連結で分割表記できないため、
+ *    コメント除去なしの単純な部分一致で到達経路を塞げる）
+ *  - ATTACH / PRAGMA / load_extension は拒否（別DBファイルへの接続・内部設定の読み出し防止）
+ *  - 同時実行はサイト全体で MAX_GLOBAL_SLOTS 件まで（非力なサーバの保護）
+ *  - IPごとに /database API と同じレコード数クォータ（5分1000件・DatabaseApiRateLimiter）
+ */
+class McpServerService
+{
+    /** サポートする MCP プロトコルバージョン（新しい順） */
+    private const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'];
+
+    private const SERVER_NAME = 'openchat-graph';
+    private const SERVER_TITLE = 'オプチャグラフ (OpenChat Graph) 統計データ';
+    private const SERVER_VERSION = '1.0.0';
+
+    private const MAX_LIMIT = 20;
+    private const MAX_GLOBAL_SLOTS = 2;
+
+    /** 公開MCPからのアクセスを拒否するテーブル（IP等の個人情報・運営内部データ） */
+    private const BLOCKED_TABLES = ['ban_user', 'comment_log', 'ban_room'];
+
+    /** @var resource[] 保持中のグローバル同時実行ロック */
+    private array $globalLockHandles = [];
+
+    public function __construct(
+        private FileStorageInterface $fileStorage,
+    ) {}
+
+    /**
+     * JSON-RPC メッセージ（単体 or バッチ配列）を処理してレスポンス構造を返す。
+     * 通知のみ（レスポンス不要）の場合は null を返す。
+     */
+    public function handleMessage(mixed $body): ?array
+    {
+        // バッチ（2025-03-26 まで許容）
+        if (is_array($body) && array_is_list($body)) {
+            $responses = [];
+            foreach ($body as $msg) {
+                $res = $this->handleSingle($msg);
+                if ($res !== null) {
+                    $responses[] = $res;
+                }
+            }
+            return $responses === [] ? null : $responses;
+        }
+
+        return $this->handleSingle($body);
+    }
+
+    private function handleSingle(mixed $msg): ?array
+    {
+        if (!is_array($msg) || !isset($msg['jsonrpc']) || $msg['jsonrpc'] !== '2.0' || !isset($msg['method'])) {
+            return $this->errorResponse($msg['id'] ?? null, -32600, 'Invalid Request: expected a JSON-RPC 2.0 message');
+        }
+
+        $method = $msg['method'];
+        $id = $msg['id'] ?? null;
+        $params = $msg['params'] ?? [];
+
+        // 通知（id なし）はレスポンスを返さない
+        if ($id === null) {
+            return null;
+        }
+
+        try {
+            return match ($method) {
+                'initialize' => $this->resultResponse($id, $this->initialize($params)),
+                'ping' => $this->resultResponse($id, new \stdClass()),
+                'tools/list' => $this->resultResponse($id, ['tools' => $this->toolDefinitions()]),
+                'tools/call' => $this->resultResponse($id, $this->callTool($params)),
+                default => $this->errorResponse($id, -32601, "Method not found: {$method}"),
+            };
+        } catch (McpToolException $e) {
+            // ツール実行エラーは JSON-RPC エラーではなく result.isError で返す（MCP仕様）
+            return $this->resultResponse($id, [
+                'content' => [['type' => 'text', 'text' => $e->getMessage()]],
+                'isError' => true,
+            ]);
+        } catch (\Throwable $e) {
+            return $this->errorResponse($id, -32603, 'Internal error: ' . $e->getMessage());
+        }
+    }
+
+    private function initialize(array $params): array
+    {
+        $requested = $params['protocolVersion'] ?? '';
+        $version = in_array($requested, self::SUPPORTED_PROTOCOL_VERSIONS, true)
+            ? $requested
+            : self::SUPPORTED_PROTOCOL_VERSIONS[0];
+
+        return [
+            'protocolVersion' => $version,
+            'capabilities' => ['tools' => ['listChanged' => false]],
+            'serverInfo' => [
+                'name' => self::SERVER_NAME,
+                'title' => self::SERVER_TITLE,
+                'version' => self::SERVER_VERSION,
+            ],
+            'instructions' => 'オプチャグラフ (https://openchat-review.me) が毎時クロールしている LINE オープンチャット '
+                . '(日本) の統計データベースです。部屋の検索は search_openchat、個別の部屋の詳細とメンバー数推移は '
+                . 'get_openchat_stats、自由な集計は get_database_schema でスキーマを確認してから query_database で '
+                . '読み取り専用 SQL (SELECT・LIMIT 20 まで) を実行してください。部屋のページ URL は '
+                . 'https://openchat-review.me/oc/{openchat_id} です。回答で部屋を紹介するときはこの URL を添えてください。',
+        ];
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function toolDefinitions(): array
+    {
+        return [
+            [
+                'name' => 'search_openchat',
+                'title' => 'オープンチャット検索',
+                'description' => 'LINEオープンチャット(日本)を部屋名・説明文のキーワードで検索し、現在のメンバー数順に返す。'
+                    . '結果の url は人間に紹介できる部屋ページ(統計グラフ付き)のURL。',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'keyword' => ['type' => 'string', 'description' => '検索キーワード（部屋名・説明文に部分一致）'],
+                        'limit' => ['type' => 'integer', 'description' => '取得件数 (1〜20・省略時10)', 'minimum' => 1, 'maximum' => 20],
+                    ],
+                    'required' => ['keyword'],
+                ],
+            ],
+            [
+                'name' => 'get_openchat_stats',
+                'title' => 'オープンチャット詳細・メンバー数推移',
+                'description' => '部屋IDを指定して、部屋の基本情報(名前・説明・カテゴリ・参加方法・現在のメンバー数)と'
+                    . '直近30日のメンバー数推移、LINE公式ランキングでの直近順位を返す。',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'openchat_id' => ['type' => 'integer', 'description' => 'オプチャグラフの部屋ID (search_openchat の id)'],
+                    ],
+                    'required' => ['openchat_id'],
+                ],
+            ],
+            [
+                'name' => 'query_database',
+                'title' => '統計DBへの読み取り専用SQL',
+                'description' => 'オプチャグラフの統計SQLiteデータベースに読み取り専用SQLを実行する。SELECT/WITHのみ・'
+                    . 'LIMIT 20まで(未指定なら自動付与)。20件を超えるデータはOFFSETでページングする。'
+                    . '先に get_database_schema でテーブル定義を確認すること。',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'sql' => ['type' => 'string', 'description' => '実行するSQL (SQLite方言・SELECT/WITHのみ)'],
+                    ],
+                    'required' => ['sql'],
+                ],
+            ],
+            [
+                'name' => 'get_database_schema',
+                'title' => '統計DBのスキーマ取得',
+                'description' => 'query_database で使えるテーブルの定義(DDL・日本語コメント付き)を返す。',
+                'inputSchema' => ['type' => 'object', 'properties' => new \stdClass()],
+            ],
+        ];
+    }
+
+    private function callTool(array $params): array
+    {
+        $name = $params['name'] ?? '';
+        $args = $params['arguments'] ?? [];
+        if (!is_array($args)) {
+            $args = [];
+        }
+
+        $data = match ($name) {
+            'search_openchat' => $this->searchOpenChat($args),
+            'get_openchat_stats' => $this->getOpenChatStats($args),
+            'query_database' => $this->queryDatabase($args),
+            'get_database_schema' => $this->getSchema(),
+            default => throw new McpToolException("Unknown tool: {$name}"),
+        };
+
+        return [
+            'content' => [[
+                'type' => 'text',
+                'text' => json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT),
+            ]],
+            'isError' => false,
+        ];
+    }
+
+    // ---------------------------------------------------------------
+    // ツール実装
+    // ---------------------------------------------------------------
+
+    private function searchOpenChat(array $args): array
+    {
+        $keyword = trim((string)($args['keyword'] ?? ''));
+        if ($keyword === '') {
+            throw new McpToolException('keyword is required');
+        }
+        $limit = min(max((int)($args['limit'] ?? 10), 1), self::MAX_LIMIT);
+
+        $this->acquireGuards();
+
+        $pdo = $this->getPdo();
+        $stmt = $pdo->prepare(
+            "SELECT m.openchat_id AS id, m.display_name AS name, substr(m.description, 1, 200) AS description,
+                    m.current_member_count AS member_count, c.category_name AS category,
+                    m.join_method, m.established_at
+             FROM openchat_master m
+             JOIN openchat_existing e ON e.openchat_id = m.openchat_id
+             LEFT JOIN categories c ON c.category_id = m.category_id
+             WHERE m.display_name LIKE :kw OR m.description LIKE :kw
+             ORDER BY m.current_member_count DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute(['kw' => '%' . $keyword . '%']);
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        foreach ($rows as &$row) {
+            $row['url'] = 'https://openchat-review.me/oc/' . $row['id'];
+        }
+        unset($row);
+
+        $this->addQuotaUsage(count($rows));
+
+        return [
+            'result_count' => count($rows),
+            'rooms' => $rows,
+            'lastUpdate' => $this->getLastImportedAt($pdo),
+        ];
+    }
+
+    private function getOpenChatStats(array $args): array
+    {
+        $id = (int)($args['openchat_id'] ?? 0);
+        if ($id <= 0) {
+            throw new McpToolException('openchat_id is required');
+        }
+
+        $this->acquireGuards();
+
+        $pdo = $this->getPdo();
+
+        $stmt = $pdo->prepare(
+            "SELECT m.openchat_id AS id, m.display_name AS name, m.description,
+                    m.current_member_count AS member_count, c.category_name AS category,
+                    m.join_method, m.verification_badge, m.established_at, m.last_updated_at,
+                    (e.openchat_id IS NOT NULL) AS still_exists
+             FROM openchat_master m
+             LEFT JOIN openchat_existing e ON e.openchat_id = m.openchat_id
+             LEFT JOIN categories c ON c.category_id = m.category_id
+             WHERE m.openchat_id = :id"
+        );
+        $stmt->execute(['id' => $id]);
+        $room = $stmt->fetch(\PDO::FETCH_ASSOC);
+        if (!$room) {
+            throw new McpToolException("openchat_id {$id} not found");
+        }
+        $room['url'] = 'https://openchat-review.me/oc/' . $id;
+
+        $stmt = $pdo->prepare(
+            "SELECT statistics_date, member_count FROM daily_member_statistics
+             WHERE openchat_id = :id ORDER BY statistics_date DESC LIMIT 30"
+        );
+        $stmt->execute(['id' => $id]);
+        $stats = array_reverse($stmt->fetchAll(\PDO::FETCH_ASSOC));
+
+        $stmt = $pdo->prepare(
+            "SELECT r.record_date, r.activity_ranking_position, c.category_name AS category
+             FROM line_official_activity_ranking_history r
+             LEFT JOIN categories c ON c.category_id = r.category_id
+             WHERE r.openchat_id = :id ORDER BY r.record_date DESC LIMIT 10"
+        );
+        $stmt->execute(['id' => $id]);
+        $ranking = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        $this->addQuotaUsage(1 + count($stats) + count($ranking));
+
+        return [
+            'room' => $room,
+            'daily_member_stats_last_30_days' => $stats,
+            'line_official_ranking_recent' => $ranking,
+            'lastUpdate' => $this->getLastImportedAt($pdo),
+        ];
+    }
+
+    private function queryDatabase(array $args): array
+    {
+        $sql = (string)($args['sql'] ?? '');
+        if (trim($sql) === '') {
+            throw new McpToolException('sql is required');
+        }
+
+        $sql = $this->filterPublicQuery($sql);
+
+        $this->acquireGuards();
+
+        $pdo = $this->getPdo();
+        try {
+            $result = $pdo->query($sql);
+        } catch (\Exception $e) {
+            throw new McpToolException('SQL error: ' . $e->getMessage());
+        }
+
+        // LIMIT はバリデーション済みだが、サブクエリ内 LIMIT 等のすり抜けに備えて
+        // フェッチ行数自体も上限で打ち切る
+        $rows = [];
+        while (($row = $result->fetch(\PDO::FETCH_ASSOC)) !== false) {
+            $rows[] = $row;
+            if (count($rows) >= self::MAX_LIMIT) {
+                break;
+            }
+        }
+
+        $this->addQuotaUsage(count($rows));
+
+        return [
+            'row_count' => count($rows),
+            'rows' => $rows,
+            'note' => count($rows) >= self::MAX_LIMIT
+                ? 'Results are capped at ' . self::MAX_LIMIT . ' rows per query. Use OFFSET for pagination.'
+                : null,
+            'lastUpdate' => $this->getLastImportedAt($pdo),
+        ];
+    }
+
+    private function getSchema(): array
+    {
+        $schemaContent = file_get_contents(AppConfig::SQLITE_SCHEMA_SQLAPI);
+        if ($schemaContent === false) {
+            throw new McpToolException('Schema file not found');
+        }
+
+        return [
+            'database_type' => 'SQLite 3',
+            'note' => 'SELECT/WITH のみ・LIMIT 20 まで。テーブル ' . implode(', ', self::BLOCKED_TABLES)
+                . ' は公開MCPからはアクセス不可。',
+            'schema' => $this->filterSchemaForPublic($schemaContent),
+        ];
+    }
+
+    // ---------------------------------------------------------------
+    // ガード
+    // ---------------------------------------------------------------
+
+    /**
+     * 公開MCP用のSQLバリデーション。通過したSQL（必要ならLIMIT付与済み）を返す。
+     */
+    private function filterPublicQuery(string $sql): string
+    {
+        if (strlen($sql) > 10000) {
+            throw new McpToolException('Query too long (max 10000 chars)');
+        }
+
+        if (!preg_match('/^\s*(SELECT|WITH)\b/i', $sql)) {
+            throw new McpToolException('Only SELECT / WITH (read-only) statements are allowed');
+        }
+
+        // 危険キーワード（別DBファイル接続・内部設定・拡張ロード）
+        foreach (['attach', 'pragma', 'load_extension'] as $kw) {
+            if (preg_match('/\b' . $kw . '\b/i', $sql)) {
+                throw new McpToolException("'{$kw}' is not allowed");
+            }
+        }
+
+        // 非公開テーブル。SQLite の識別子はコメント・連結で分割表記できないため、
+        // 部分一致の拒否でテーブルへの全到達経路を塞げる（文字列リテラル内の偽陽性は許容）
+        foreach (self::BLOCKED_TABLES as $table) {
+            if (stripos($sql, $table) !== false) {
+                throw new McpToolException("Table '{$table}' is not accessible via the public MCP endpoint");
+            }
+        }
+
+        // LIMIT の強制（/database API と同じ方針）
+        if (preg_match('/LIMIT\s+(\d+)/i', $sql, $m)) {
+            if ((int)$m[1] > self::MAX_LIMIT) {
+                throw new McpToolException('LIMIT cannot exceed ' . self::MAX_LIMIT . '. Use OFFSET for pagination.');
+            }
+        } else {
+            $sql = rtrim(trim($sql), ';') . ' LIMIT ' . self::MAX_LIMIT;
+        }
+
+        return $sql;
+    }
+
+    /**
+     * グローバル同時実行スロット＋IPクォータをまとめて確認する。
+     * DB を読むツールの実行前に必ず呼ぶ。
+     */
+    private function acquireGuards(): void
+    {
+        $this->acquireGlobalSlot();
+
+        $limiter = $this->getLimiter();
+        if ($limiter->isQuotaExceeded()) {
+            $retryAfter = $limiter->getRetryAfterSeconds();
+            throw new McpToolException(sprintf(
+                'Rate limit exceeded: up to %d records can be fetched per %d minutes per IP. Retry after %d seconds.',
+                AppConfig::API_RATE_LIMIT_MAX_RECORDS,
+                AppConfig::API_RATE_LIMIT_WINDOW_SECONDS / 60,
+                $retryAfter,
+            ));
+        }
+    }
+
+    private function addQuotaUsage(int $rowCount): void
+    {
+        if ($rowCount > 0) {
+            $this->getLimiter()->addRecordCount($rowCount);
+        }
+    }
+
+    private ?DatabaseApiRateLimiter $limiter = null;
+
+    private function getLimiter(): DatabaseApiRateLimiter
+    {
+        // IP単位のクォータ（/database API とはキー空間を分ける）
+        return $this->limiter ??= new DatabaseApiRateLimiter('mcp_' . getIP(), $this->fileStorage);
+    }
+
+    /**
+     * サイト全体での同時実行を MAX_GLOBAL_SLOTS 件に制限する（サーバ保護）。
+     * ロックはスクリプト終了時に自動解放される。
+     */
+    private function acquireGlobalSlot(): void
+    {
+        if ($this->globalLockHandles !== []) {
+            return; // 同一リクエスト内で取得済み
+        }
+
+        $dir = $this->fileStorage->getStorageFilePath('apiRateLimitDir');
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        for ($i = 0; $i < self::MAX_GLOBAL_SLOTS; $i++) {
+            $fp = fopen($dir . '/mcp_global_slot_' . $i . '.lock', 'c');
+            if ($fp === false) {
+                return; // ロックファイルが作れない場合は止めない（フェイルオープン）
+            }
+            if (flock($fp, LOCK_EX | LOCK_NB)) {
+                $this->globalLockHandles[] = $fp;
+                return;
+            }
+            fclose($fp);
+        }
+
+        throw new McpToolException('Server is busy: too many concurrent MCP requests. Please retry in a few seconds.');
+    }
+
+    /**
+     * スキーマDDLから非公開テーブルのセクションを取り除く。
+     * sqlapi.sql は `-- ====` 区切りのセクション構造なので、セクション単位で除外する。
+     */
+    private function filterSchemaForPublic(string $schemaContent): string
+    {
+        $sections = preg_split('/(?=^-- ={10,})/m', $schemaContent);
+        $filtered = [];
+        foreach ($sections as $section) {
+            $blocked = false;
+            foreach (self::BLOCKED_TABLES as $table) {
+                if (stripos($section, $table) !== false) {
+                    $blocked = true;
+                    break;
+                }
+            }
+            if (!$blocked) {
+                $filtered[] = $section;
+            }
+        }
+        return implode('', $filtered);
+    }
+
+    private function getPdo(): \PDO
+    {
+        return SQLiteOcgraphSqlapi::connect(['mode' => '?mode=ro']);
+    }
+
+    private function getLastImportedAt(\PDO $pdo): ?string
+    {
+        try {
+            $value = $pdo
+                ->query("SELECT meta_value FROM import_meta WHERE meta_key = 'last_imported_at'")
+                ->fetchColumn();
+
+            return $value === false ? null : $value;
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    private function resultResponse(mixed $id, mixed $result): array
+    {
+        return ['jsonrpc' => '2.0', 'id' => $id, 'result' => $result];
+    }
+
+    private function errorResponse(mixed $id, int $code, string $message): array
+    {
+        return ['jsonrpc' => '2.0', 'id' => $id, 'error' => ['code' => $code, 'message' => $message]];
+    }
+}

--- a/app/Services/Api/McpToolException.php
+++ b/app/Services/Api/McpToolException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Api;
+
+/**
+ * MCP ツール実行エラー。
+ * JSON-RPC のプロトコルエラーではなく、MCP 仕様に従い result.isError=true で
+ * クライアント（AIモデル）に返す（McpServerService::handleSingle が捕捉する）。
+ */
+class McpToolException extends \RuntimeException {}

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -18,6 +18,7 @@ class GoogleAdsense
      */
     public static function output(string $slotKey, bool $fullWidthResponsive = true)
     {
+        if (!GoogleAdsenseConfig::$enableAds) return;
         if (AppConfig::$isStaging) return;
 
         // 設定を取得
@@ -72,6 +73,7 @@ class GoogleAdsense
 
     public static function loadAdsTag()
     {
+        if (!GoogleAdsenseConfig::$enableAds) return;
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
 
         // 遅延読み込み(IntersectionObserver)はしない。広告ブロック検出(ad_guard)
@@ -95,6 +97,7 @@ class GoogleAdsense
      */
     public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false)
     {
+        if (!GoogleAdsenseConfig::$enableAds) return;
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
 
         if ($suppressOfferwall) {

--- a/app/Views/components/oc_head.php
+++ b/app/Views/components/oc_head.php
@@ -27,6 +27,8 @@
     <?php endforeach ?>
     <link rel="icon" type="image/png" href="<?php echo fileUrl(\App\Config\AppConfig::SITE_ICON_FILE_PATH, urlRoot: '') ?>">
     <link rel="canonical" href="<?php echo url(strstr(path(), '?', true) ?: path()) ?>">
+    <?php // Google Discover / リッチリザルトで大きな画像プレビューを許可（head.php と同一方針）。 ?>
+    <meta name="robots" content="max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <?php if (isset($_schema)) : ?>
         <?php echo $_schema ?>
     <?php endif ?>

--- a/app/Views/components/policy_head.php
+++ b/app/Views/components/policy_head.php
@@ -29,7 +29,7 @@
         const admin = 1;
     </script>
     <script defer src="<?php echo fileUrl("/js/site_header_footer.js", urlRoot: '') ?>"></script>
-    <link rel="canonical" href="<?php echo url(path()) ?>">
+    <link rel="canonical" href="<?php echo url(strstr(path(), '?', true) ?: path()) ?>">
     <?php if (isset($noindex)) : ?>
         <meta name="robots" content="noindex, nofollow">
     <?php endif ?>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,26 @@
+# オプチャグラフ (OpenChat Graph)
+
+> LINE オープンチャットの統計・分析サイト。日本の24万以上の現存ルーム（累計31万以上）のメンバー数を毎時クロールし、成長ランキング・キーワード検索・部屋ごとのメンバー数推移グラフを無料で提供している（日本・台湾・タイの3リージョン）。2023年10月からの日次メンバー数統計は1.2億レコード以上。収集データは認証不要の MCP サーバーと読み取り専用 SQL API でも公開している。
+
+オプチャグラフは LINEヤフー株式会社の公式サービスではない、独立系の統計サイト。LINE オープンチャット公式サイトの公開情報（部屋名・説明文・メンバー数・公式ランキング/急上昇順位）を集計している。運営: [@openchat_graph](https://x.com/openchat_graph)
+
+## 主要ページ
+
+- [トップ（急上昇中の部屋）](https://openchat-review.me/): 直近で伸びているオープンチャット
+- [ランキング](https://openchat-review.me/ranking): メンバー増加数ランキング（1時間・24時間・1週間・全期間検索）
+- [カテゴリ・タグ別の部屋一覧](https://openchat-review.me/recommend): テーマ別の人気部屋（例: /recommend/ゲーム）
+- 部屋ページ: `https://openchat-review.me/oc/{id}` — メンバー数推移グラフ・LINE公式ランキング順位履歴・AI分析コメント・関連部屋。データを引用するときはこの URL を出典として添えてほしい
+- [全部屋の統計](https://openchat-review.me/labs/all-room-stats): オープンチャット全体のマクロ統計
+- 台湾版: https://openchat-review.me/tw / タイ版: https://openchat-review.me/th
+
+## AI からのデータアクセス
+
+- MCP サーバー: `https://openchat-review.me/mcp` — 認証不要の Model Context Protocol エンドポイント（Streamable HTTP・POST・JSONレスポンス）。ツール: 部屋のキーワード検索 / 部屋の詳細とメンバー数推移 / スキーマ取得 / 読み取り専用SQL（SELECT・20行/クエリ・IP毎 1000行/5分）
+- [データAPI・MCP のドキュメント](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/main/API_README.md)
+- 出典表記のお願い: 「オプチャグラフ (openchat-review.me)」
+
+## その他
+
+- [サイトについて・ポリシー](https://openchat-review.me/policy)
+- [ソースコード（MIT ライセンス）](https://github.com/Open-Chat-Graph/Open-Chat-Graph)
+- [公式ブログ](https://openchat-review.me/blog)


### PR DESCRIPTION
## 概要

3つの変更をまとめた PR です。

1. **サイト内の広告（ディスプレイ・アンカー）を一旦すべて停止**
2. **SEO の小修正**（部屋ページの画像プレビュー許可メタ・canonical の統一）
3. **AI 向けデータ解放**: 認証不要の公開 MCP サーバー `/mcp` と `llms.txt` を追加

## 1. 広告の全停止（1フラグで復活可能）

運用方針の転換により、サイト内の Google AdSense 広告（広告ユニット・adsbygoogle.js・アンカー広告）をすべて停止します。

- [`GoogleAdsenseConfig::$enableAds`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/production-ads-seo-fixes-6hzwdv/app/Config/GoogleAdsenseConfig.php) に `false` を設定し、[`GoogleAdsense`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/production-ads-seo-fixes-6hzwdv/app/Views/Classes/Ads/GoogleAdsense.php) クラスの `output()` / `gTag()` / `loadAdsTag()` の冒頭で一括ガード
- 各ページの呼び出しコードはそのまま残っているため、**フラグを `true` に戻すだけで全広告が復活**します
- 広告が出力されなければ枠の親 div ごと出力されないため、空白スペースは残りません
- `ads.txt` は AdSense アカウント維持のため出力を継続
- 未配線で効いていなかった旧フラグ（`AppConfig::$disableAds` / `$disableAdTags`）は削除

※ 見た目の変化は「各ページから広告枠が消える」のみです（この環境からスクリーンショットの添付ができないため、文章での説明にしています）

## 2. SEO の小修正（GSC データを確認した上での対応）

Search Console のデータを直近6ヶ月分確認しました。明確に害になっている設定（インデックス汚染・soft 404・canonical 欠落など）は見つからず、削除済み部屋の 410 応答・`?limit=hour` 付き URL の canonical も正常に機能していました。そのうえで、簡単にできる改善のみ入れています。

- **部屋ページ（約31万URL・サイト最大のページ群）に `max-image-preview:large` の robots メタを追加**: 他のページ（`head.php`）には設定済みだった Google Discover / リッチリザルト向けの大きな画像プレビュー許可が、部屋ページ（`oc_head.php`）にだけ無かったのを統一
- **policy 系ページの canonical からクエリ文字列を除去**: 他の head と同じ実装に統一

（参考: 6月以降タグページの検索表示回数が減っていますが、掲載順位は維持されておりサイト側の欠陥ではなく Google 側の表示変動と判断しました）

## 3. AI 向けデータ解放: 公開 MCP サーバー `/mcp` + `llms.txt`

AI アシスタント（Claude・ChatGPT 等）が申請なしでオプチャグラフの統計データを使えるようになります。AI 経由での認知・流入を増やすための布石です。

- エンドポイント: `POST https://openchat-review.me/mcp`（MCP Streamable HTTP・認証不要・JSON レスポンスのみのステートレス実装）
- ツール: 部屋のキーワード検索 / 部屋詳細＋メンバー数推移30日 / スキーマ取得 / 読み取り専用 SQL
- 実装: [`McpApiController`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/production-ads-seo-fixes-6hzwdv/app/Controllers/Api/McpApiController.php) / [`McpServerService`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/production-ads-seo-fixes-6hzwdv/app/Services/Api/McpServerService.php)

**非力なサーバーを守るためのガード**（既存の `/database` API より厳しめ）:

| ガード | 内容 |
| --- | --- |
| SQL 制限 | SELECT / WITH のみ・LIMIT 20 強制＋フェッチ行数もサーバ側で20行打ち切り |
| 個人情報保護 | `ban_user`・`comment_log`（IPアドレス等を含む）と運営用 `ban_room` はアクセス不可。スキーマ出力からも除外 |
| 危険構文 | ATTACH / PRAGMA / load_extension を拒否 |
| クォータ | IP ごとに5分間1000行まで（既存 `DatabaseApiRateLimiter` を再利用） |
| 同時実行 | サイト全体で2件まで（ファイルロック。超過は「retry してください」を返す） |

テーブル名の遮断は部分一致方式です。SQLite の識別子はコメントや文字列連結で分割表記できないため、この方式で全到達経路を塞げます（20項目の動作テストで、クォート・ブラケット・大文字などのバイパス試行がすべて拒否されることを確認済み）。

あわせて:

- `https://openchat-review.me/llms.txt`（サイト概要とデータアクセス方法の機械可読版）を追加し、robots.txt と [API_README.md](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/production-ads-seo-fixes-6hzwdv/API_README.md) から案内
- **Cloudflare 側は適用済み**（oc-infra 参照）: bot チャレンジルールに `/mcp` パス除外と AI アシスタント系 UA の例外を追加。API 系パスは据え置き block のままなことを本番で実証済み。一般の curl / 無価値 bot へのチャレンジは従来どおり

## 動作確認

- 変更・新規の全 PHP ファイルの構文チェック済み
- MCP サーバーはフィクスチャ DB を使った 20 項目の動作テストで、initialize / tools/list / 各ツールの正常系と、書き込み・機微テーブル・ATTACH/PRAGMA・LIMIT 超過などの拒否系をすべて確認
- 本番 Cloudflare 経由で `/mcp` がチャレンジなしでオリジンに到達すること、GPTBot / ClaudeBot UA でページが 200 になること、API 系パスが 403 block のままなことを確認済み

---
🤖 Generated with Claude Code (claude-fable-5)
Posted from: `vm:~/Open-Chat-Graph`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Li9rTjva7zvSCgDfzVS4L1)_