### PR TITLE
[PROD] データ更新の負荷を軽減: 掲載制限記録の毎時同期を270万件の全件入れ直しから差分方式（数百件）に変更

### DIFF
--- a/app/Services/Cron/OcreviewApiDataImporter.php
+++ b/app/Services/Cron/OcreviewApiDataImporter.php
@@ -959,11 +959,18 @@ class OcreviewApiDataImporter
      * このため、openchat_master.openchat_id = open_chat_deleted.id でJOINできます。
      */
     /**
-     * 公式ランキング未掲載（掲載制限）記録のインポート
+     * 公式ランキング未掲載（掲載制限）記録のインポート（差分同期）
      *
-     * 【全件リフレッシュの仕組み】
-     * ranking_ban は既存行が更新される（復活時に end_datetime が入る・update_items が追記される）ため、
-     * 差分同期ではなく成長ランキングと同じ全削除→全件入れ直しで同期する（レコード数は少ない）。
+     * 【差分同期の仕組み】
+     * ranking_ban の行は「未掲載検知で INSERT（flag=0・end_datetime NULL）→ 復活時に一度だけ
+     * UPDATE（flag=1・end_datetime 設定・update_items）→ 以後不変」というライフサイクル
+     * （RankingBanTableUpdater::updateTable は flag=0 の行しか更新しない）。そのため
+     *   1. 新規行: id がターゲットの最大 id より大きい行
+     *   2. 変更行: 復活で閉じられた行だけ ＝ end_datetime がターゲットの最終クローズ時刻以降の行
+     * の2種類を UPSERT すれば完全に追随でき、全件リフレッシュは不要（約270万行を毎時
+     * 入れ直すとサーバ負荷と Discord 進捗通知の連打になるため差分化した経緯がある）。
+     * 境界の重複取得は INSERT OR REPLACE で冪等。ターゲットが空のときだけ初回全件ロード。
+     * 進捗メッセージは渡さない（Discord 通知を出さない）。
      * sort_datetime は MariaDB の VIRTUAL 生成列のためインポート対象外。
      */
     private function importRankingBan(): void
@@ -985,58 +992,98 @@ class OcreviewApiDataImporter
         $this->targetPdo->exec("CREATE INDEX IF NOT EXISTS idx_ranking_ban_open_chat ON ranking_ban(open_chat_id)");
         $this->targetPdo->exec("CREATE INDEX IF NOT EXISTS idx_ranking_ban_datetime ON ranking_ban(datetime)");
 
-        // ソーステーブルのレコード数を取得
-        $totalCount = $this->sourcePdo->query("SELECT COUNT(*) FROM ranking_ban")->fetchColumn();
+        $columnList = 'id, open_chat_id, datetime, percentage, member, flag, updated_at, update_items, end_datetime';
 
-        // ターゲットテーブルを全削除（SQLiteはTRUNCATEをサポートしていないため DELETE を使用）
-        $this->targetPdo->exec("DELETE FROM ranking_ban");
+        $targetCount = (int)$this->targetPdo->query("SELECT COUNT(*) FROM ranking_ban")->fetchColumn();
+
+        if ($targetCount === 0) {
+            // 初回のみ全件ロード
+            $totalCount = (int)$this->sourcePdo->query("SELECT COUNT(*) FROM ranking_ban")->fetchColumn();
+            if ($totalCount === 0) {
+                return;
+            }
+
+            $stmt = $this->sourcePdo->prepare(
+                "SELECT {$columnList} FROM ranking_ban ORDER BY id LIMIT ? OFFSET ?"
+            );
+
+            $this->processInChunks(
+                $stmt,
+                [],
+                $totalCount,
+                self::CHUNK_SIZE,
+                function (array $data) {
+                    $this->upsertRankingBanRows($data);
+                },
+            );
+            return;
+        }
+
+        // 差分同期: 新規行（id 超過分）＋ 復活で閉じられた行（end_datetime が境界以降）
+        $maxId = (int)$this->targetPdo->query("SELECT MAX(id) FROM ranking_ban")->fetchColumn();
+        $since = $this->targetPdo->query("SELECT MAX(end_datetime) FROM ranking_ban")->fetchColumn()
+            ?: '1970-01-01 00:00:00';
+
+        $countStmt = $this->sourcePdo->prepare(
+            "SELECT COUNT(*) FROM ranking_ban WHERE id > ? OR end_datetime >= ?"
+        );
+        $countStmt->execute([$maxId, $since]);
+        $totalCount = (int)$countStmt->fetchColumn();
 
         if ($totalCount === 0) {
             return;
         }
 
-        $query = "
-            SELECT
-                id,
-                open_chat_id,
-                datetime,
-                percentage,
-                member,
-                flag,
-                updated_at,
-                update_items,
-                end_datetime
-            FROM
-                ranking_ban
-            ORDER BY id
-            LIMIT ? OFFSET ?
-        ";
-
-        $stmt = $this->sourcePdo->prepare($query);
+        $stmt = $this->sourcePdo->prepare(
+            "SELECT {$columnList} FROM ranking_ban
+             WHERE id > ? OR end_datetime >= ?
+             ORDER BY id LIMIT ? OFFSET ?"
+        );
 
         $this->processInChunks(
             $stmt,
-            [],
+            [
+                1 => [$maxId, PDO::PARAM_INT],
+                2 => [$since, PDO::PARAM_STR],
+            ],
             $totalCount,
             self::CHUNK_SIZE,
             function (array $data) {
-                if (!empty($data)) {
-                    $this->sqlImporter->import($this->targetPdo, 'ranking_ban', $data, self::CHUNK_SIZE);
-                }
+                $this->upsertRankingBanRows($data);
             },
-            'ranking_ban: %d / %d 件処理完了'
         );
+    }
 
-        // レコード数の整合性を検証し、不一致があれば修正
-        $this->verifyAndFixRecordCount(
-            'ranking_ban',
-            'ranking_ban',
-            'id',
-            'id',
-            null,
-            $this->sourcePdo,
-            $this->targetPdo
-        );
+    /**
+     * ranking_ban 行の一括 UPSERT（主キー id・全カラム置き換え）。
+     * 共通の sqliteUpsert は主キーが openchat_id 前提のためここでは使わない。
+     */
+    private function upsertRankingBanRows(array $rows): void
+    {
+        if (empty($rows)) {
+            return;
+        }
+
+        $columns = array_keys($rows[0]);
+        $columnCount = count($columns);
+        // SQLiteのパラメータ数制限（999）内に収める
+        $recordsPerBatch = (int)floor(999 / $columnCount) - 20;
+
+        foreach (array_chunk($rows, $recordsPerBatch) as $chunk) {
+            $placeholders = '(' . implode(', ', array_fill(0, $columnCount, '?')) . ')';
+            $sql = "INSERT OR REPLACE INTO ranking_ban (" . implode(', ', $columns) . ") VALUES "
+                . implode(', ', array_fill(0, count($chunk), $placeholders));
+
+            $params = [];
+            foreach ($chunk as $row) {
+                foreach ($columns as $column) {
+                    $params[] = $row[$column];
+                }
+            }
+
+            $stmt = $this->targetPdo->prepare($sql);
+            $stmt->execute($params);
+        }
     }
 
     private function importOpenChatDeleted(): void

--- a/app/Views/top_content.php
+++ b/app/Views/top_content.php
@@ -42,11 +42,15 @@ viewComponent('head', compact('_css', '_meta', '_schema')) ?>
             <p class="oc-home-hero__tagline"><?php echo t('LINEオープンチャットの人数推移とランキングを毎時間記録') ?></p>
             <div class="oc-home-hero__metarow">
                 <div class="oc-home-hero__meta"><span class="oc-home-hero__dot" aria-hidden="true"></span><?php echo t('1時間ごとに更新') ?><span class="oc-home-hero__time">・<?php echo $_updatedAt->format('G:i') ?></span></div>
-                <?php // 上級者向けの分析ツール（分析Labs）への控えめな導線。悪目立ちさせない小さなテキストリンク。ja のみ。 ?>
+                <?php // 上級者向けの分析ツール（分析Labs）とAI連携(MCP)への控えめな導線。悪目立ちさせない小さなテキストリンク。ja のみ。 ?>
                 <?php if (MimimalCmsConfig::$urlRoot === ''): ?>
                     <a class="oc-home-hero__labs unset" href="<?php echo url('labs') ?>" aria-label="分析Labs（上級者向けの分析ツール）を開く">
                         <svg viewBox="0 -960 960 960" aria-hidden="true"><path d="M209-120q-42 0-70.5-28.5T110-217q0-14 3-25.5t9-21.5l228-341q10-14 15-31t5-34v-110h-20q-13 0-21.5-8.5T320-810q0-13 8.5-21.5T350-840h260q13 0 21.5 8.5T640-810q0 13-8.5 21.5T610-780h-20v110q0 17 5 34t15 31l227 341q6 9 9.5 20.5T850-217q0 41-28 69t-69 28H209Zm271-340Z"/></svg>
                         <span>分析Labs</span>
+                    </a>
+                    <a class="oc-home-hero__labs unset" href="<?php echo url('mcp') ?>" aria-label="AI連携・データAPI（MCP）の案内ページを開く">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2l1.9 6.1L20 10l-6.1 1.9L12 18l-1.9-6.1L4 10l6.1-1.9L12 2zm7 11l1 3.2 3.2 1-3.2 1-1 3.2-1-3.2-3.2-1 3.2-1 1-3.2z"/></svg>
+                        <span>AI連携 (MCP)</span>
                     </a>
                 <?php endif ?>
             </div>

--- a/public/style/pages/top_page.css
+++ b/public/style/pages/top_page.css
@@ -66,7 +66,7 @@
   color: var(--c-text-3);
 }
 
-/* 更新インジケータ＋分析Labs導線を同じ行に並べる */
+/* 更新インジケータ＋分析Labs・AI連携(MCP)導線を同じ行に並べる */
 .oc-home-hero__metarow {
   display: flex;
   align-items: center;
@@ -89,7 +89,7 @@
   border-radius: 999px;
 }
 
-/* 上級者向け分析ツール（分析Labs）への導線。サイズは控えめのまま、色＋下線でリンクと分かるように */
+/* 上級者向け導線（分析Labs・AI連携MCP 共用）。サイズは控えめのまま、色＋下線でリンクと分かるように */
 .oc-home-hero__labs {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## 問題

AI連携用の統計DBに追加した掲載制限記録（`ranking_ban`・約270万件）の毎時同期を「全削除→全件入れ直し」で実装したため、毎時270万行の転送によるサーバ負荷と、Discord への進捗通知の連打（毎時十数件）が発生していた。

## 対処

`ranking_ban` の行は「未掲載検知で作成 → 復活時に一度だけ更新 → 以後不変」というライフサイクルのため、全件入れ直しは不要と判断し差分同期に変更:

1. 新規行: id が同期先の最大 id より大きい行
2. 変更行: 復活で閉じられた行（end_datetime が同期先の最終クローズ時刻以降）

この2種類だけを冪等な UPSERT で取り込む（毎時数百件規模）。同期先が空のときだけ初回全件ロード。進捗メッセージは出さず Discord 通知も発生しない。

[`OcreviewApiDataImporter::importRankingBan()`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/production-ads-seo-fixes-6hzwdv/app/Services/Cron/OcreviewApiDataImporter.php)

## 動作確認

- SQLite フィクスチャで「初回全件ロード → 復活行/新規行の差分反映 → 3回目実行で変化なし（冪等）」を検証済み
- ステージングで確認済み（CI・デプロイとも success）
- 既存の本番データ（投入済みの270万件）はそのまま差分同期に引き継がれる

---
🤖 Generated with Claude Code (claude-fable-5)
Posted from: `vm:~/Open-Chat-Graph`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Li9rTjva7zvSCgDfzVS4L1)_