### PR TITLE
[PROD] 指定したオープンチャットの部屋だけ広告を一切表示しない設定を追加（4部屋を設定・以降はID追加のみで運用可）

### DIFF
--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -36,6 +36,34 @@ class GoogleAdsenseConfig
     static bool $enableAdBlockGuard = false;
 
     /**
+     * 広告を一切出さないオープンチャット（open_chat.id のリスト）
+     *
+     * ここに ID を書いた部屋では、その部屋のページ（`/oc/{id}` と `/oc/{id}/jump`）から
+     * AdSense 関連の出力が全て消える:
+     *   - adsbygoogle.js の読み込み（GoogleAdsense::gTag）→ 自動広告・オファーウォールも出ない
+     *   - 広告枠 <ins>（GoogleAdsense::output）と push スクリプト（loadAdsTag）
+     *   - アンチアドブロックのオーバーレイ（ad_guard）
+     *
+     * 後から増やすときはこの配列に ID を1行足すだけ（他のファイルは触らなくてよい）:
+     *   123456, // 追加理由をコメントで残す
+     *
+     * ※ ここに書くのは URL の `/oc/` に続く数値 ID（open_chat.id）。LINE の emid ではない。
+     */
+    static array $adDisabledOpenChatIds = [
+        137181,
+        149382,
+        473106,
+    ];
+
+    /**
+     * 指定の部屋が「広告を一切出さない部屋」かどうか
+     */
+    public static function isAdDisabledOpenChat(int $openChatId): bool
+    {
+        return in_array($openChatId, self::$adDisabledOpenChatIds, true);
+    }
+
+    /**
      * Google AdSense広告スロット設定
      *
      * キー: スロット識別子（文字列）

--- a/app/Config/GoogleAdsenseConfig.php
+++ b/app/Config/GoogleAdsenseConfig.php
@@ -53,6 +53,7 @@ class GoogleAdsenseConfig
         137181,
         149382,
         473106,
+        453823,
     ];
 
     /**

--- a/app/Controllers/Pages/JumpOpenChatPageController.php
+++ b/app/Controllers/Pages/JumpOpenChatPageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controllers\Pages;;
 
 use App\Models\Repositories\OpenChatPageRepositoryInterface;
+use App\Views\Ads\GoogleAdsense;
 use Shared\MimimalCmsConfig;
 
 class JumpOpenChatPageController
@@ -15,6 +16,10 @@ class JumpOpenChatPageController
     ) {
         $oc = $ocRepo->getOpenChatById($open_chat_id);
         if (!$oc) return false;
+
+        // 広告非表示に指定された部屋なら、このリクエストの広告出力を全て止める
+        // （GoogleAdsenseConfig::$adDisabledOpenChatIds に ID を足すだけで増やせる）
+        GoogleAdsense::suppressForOpenChat($open_chat_id);
 
         $_meta = meta()->setTitle(t('【参加確認】') . $oc['name'])
             ->setDescription(t('【参加確認】') . $oc['description'])

--- a/app/Controllers/Pages/OpenChatPageController.php
+++ b/app/Controllers/Pages/OpenChatPageController.php
@@ -14,6 +14,7 @@ use App\Services\Recommend\RecommendGenarator;
 use App\Services\Recommend\SimilarSizeRoomService;
 use App\Services\StaticData\Dto\StaticTopPageDto;
 use App\Services\StaticData\StaticDataFile;
+use App\Views\Ads\GoogleAdsense;
 use App\Views\Meta\OcPageMeta;
 use App\Views\Schema\OcPageSchema;
 use App\Views\Schema\PageBreadcrumbsListSchema;
@@ -43,6 +44,10 @@ class OpenChatPageController
     ) {
         $this->fileStorage = $fileStorage;
         AppConfig::$listLimitTopRanking = 5;
+
+        // 広告非表示に指定された部屋なら、このリクエストの広告出力を全て止める
+        // （GoogleAdsenseConfig::$adDisabledOpenChatIds に ID を足すだけで増やせる）
+        GoogleAdsense::suppressForOpenChat($open_chat_id);
 
         $_adminDto = isset($isAdminPage) ? $this->getAdminDto($open_chat_id) : null;
 

--- a/app/Views/Classes/Ads/GoogleAdsense.php
+++ b/app/Views/Classes/Ads/GoogleAdsense.php
@@ -8,6 +8,36 @@ use App\Config\GoogleAdsenseConfig;
 class GoogleAdsense
 {
     /**
+     * このリクエストで広告出力を全面停止するか（部屋単位の広告非表示）
+     *
+     * View の呼び出し側（oc_content / oc_jump_page など）を書き換えるのではなく、
+     * このクラスの出口（output / loadAdsTag / gTag）と ad_guard で一括して止める。
+     * こうしておけば新しい広告枠や新しいページを足しても、対象の部屋では自動的に
+     * 「広告タグを一切読み込まない」状態が保たれる（消し忘れが起きない）。
+     */
+    private static bool $suppressed = false;
+
+    /**
+     * 部屋ページのコントローラから呼ぶ。対象の部屋なら以降このリクエストの広告出力を全て止める。
+     *
+     * 対象の判定は GoogleAdsenseConfig::$adDisabledOpenChatIds（ID を足すだけで増やせる）。
+     */
+    public static function suppressForOpenChat(int $openChatId): void
+    {
+        if (GoogleAdsenseConfig::isAdDisabledOpenChat($openChatId)) {
+            self::$suppressed = true;
+        }
+    }
+
+    /**
+     * このリクエストが広告全面停止かどうか（ad_guard など View 側の分岐用）
+     */
+    public static function isSuppressed(): bool
+    {
+        return self::$suppressed;
+    }
+
+    /**
      * 広告を出力
      *
      * @param string $slotKey スロット識別子（例: 'ocTopRectangle'）
@@ -18,6 +48,7 @@ class GoogleAdsense
      */
     public static function output(string $slotKey, bool $fullWidthResponsive = true)
     {
+        if (self::$suppressed) return;
         if (!GoogleAdsenseConfig::$enableAds) return;
         if (AppConfig::$isStaging) return;
 
@@ -73,6 +104,7 @@ class GoogleAdsense
 
     public static function loadAdsTag()
     {
+        if (self::$suppressed) return;
         if (!GoogleAdsenseConfig::$enableAds) return;
         if (AppConfig::$isStaging || AppConfig::$isDevlopment) return;
 
@@ -97,6 +129,10 @@ class GoogleAdsense
      */
     public static function gTag(?string $dataOverlays = null, bool $suppressOfferwall = false)
     {
+        // 広告非表示の部屋では adsbygoogle.js 自体を読み込まない
+        // （自動広告・オファーウォールも含めて一切出さないため）
+        if (self::$suppressed) return;
+
         // display広告停止中もオファーウォール（全画面メッセージ）は継続するため、
         // タグ自体は $enableOfferwallTag が有効なら出力する
         if (!GoogleAdsenseConfig::$enableAds && !GoogleAdsenseConfig::$enableOfferwallTag) return;

--- a/app/Views/components/ad_guard.php
+++ b/app/Views/components/ad_guard.php
@@ -35,6 +35,12 @@ if (!\App\Config\GoogleAdsenseConfig::$enableAdBlockGuard) {
     return;
 }
 
+// 広告非表示の部屋（GoogleAdsenseConfig::$adDisabledOpenChatIds）でも何も出力しない。
+// そもそも広告枠が無いので検出は成立しないが、広告関連のスクリプトを一切出さないため。
+if (\App\Views\Ads\GoogleAdsense::isSuppressed()) {
+    return;
+}
+
 // --- 乱数識別子（毎リクエスト） ---
 $rid = static function (): string {
     return 'o' . substr(bin2hex(random_bytes(8)), 0, 10);


### PR DESCRIPTION
## 概要

特定のオープンチャットの部屋のページでだけ、広告を**一切表示しない**ようにした。

対象の部屋では、広告に関わる HTML・スクリプトが1つも出力されなくなる（「表示だけ消す」ではなく、そもそも広告のタグを読み込まない）。

今回の設定対象は 4 部屋:

- ID `137181`
- ID `149382`
- ID `473106`
- ID `453823`

**後から対象を増やす方法**: [`GoogleAdsenseConfig::$adDisabledOpenChatIds`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/openchat-hide-ads-45u86x/app/Config/GoogleAdsenseConfig.php) の配列に部屋の ID を1行足すだけ。他のファイルは触らなくてよい（広告スロットの追加と同じ運用）。書くのは URL の `/oc/` に続く数値 ID。

## 対象の部屋で消えるもの

| 出力 | 内容 |
| --- | --- |
| `adsbygoogle.js` の読み込み（`gTag`） | Google の広告スクリプト本体。自動広告・オファーウォール（全画面メッセージ）もこれが無いと出ない |
| 広告枠の ins タグ（`output`） | 手動配置の広告枠 |
| 広告表示のスクリプト（`loadAdsTag`） | 枠に広告を流し込む処理 |
| アンチアドブロック（`ad_guard`） | 広告未表示の検出と案内オーバーレイ |

対象ページは `/oc/{id}`（部屋ページ）と `/oc/{id}/jump`（参加確認ページ）。他の部屋・他のページには一切影響しない。

## 実装

各テンプレートから広告の呼び出しを個別に削るのではなく、**広告出力の出口でまとめて止める**設計にした。

- [`GoogleAdsense`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/openchat-hide-ads-45u86x/app/Views/Classes/Ads/GoogleAdsense.php) にリクエスト単位のフラグを持たせ、`output()` / `loadAdsTag()` / `gTag()` の冒頭で停止する
- [`ad_guard`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/openchat-hide-ads-45u86x/app/Views/components/ad_guard.php) も同じフラグを見て何も出力しない
- 有効化は部屋ページのコントローラ（[`OpenChatPageController`](https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/openchat-hide-ads-45u86x/app/Controllers/Pages/OpenChatPageController.php) / [`JumpOpenChatPageController`](``https://github.com/Open-Chat-Graph/Open-Chat-Graph/blob/claude/openchat-hide-ads-45u86x/app/Controllers/Pages/JumpOpenChatPageController.php)）から`` `GoogleAdsense::suppressForOpenChat($open_chat_id)` を1行呼ぶだけ

こうしておくと、**今後新しい広告枠やページを足しても、対象の部屋では自動的に「広告タグを一切出さない」状態が保たれる**（テンプレートごとの消し忘れが起きない）。

キャッシュとの相性: 判定は URL に含まれる部屋 ID だけで決まり、同じ URL なら全訪問者に同じ HTML を返すため、Cloudflare のエッジキャッシュと衝突しない。

## 確認

- 変更した5ファイルの構文チェック（`php -l`）: エラーなし
- 広告出力の挙動をスタンドアロンで検証:
  - 対象外の部屋 → `adsbygoogle.js`・広告枠・表示スクリプトが従来どおり出力される（display 広告が復活した状態も含めて確認）
  - 対象の部屋 → 広告関連の出力は**0バイト**

スクリーンショットは省略。現在 display 広告は全体停止中（`$enableAds = false`）で、この変更で消えるのは広告スクリプトの読み込みのみのため、見た目の変化がない。

X への自動投稿はしない（`skip-post` ラベル）。

---
🤖 Generated with Claude Code
Posted from: `vm:~/Open-Chat-Graph`
