### PR TITLE
[STG] iPhoneから合言葉を入力できない問題を修正

### DIFF
--- a/.claude/skills/pr-guide/SKILL.md
+++ b/.claude/skills/pr-guide/SKILL.md
@@ -1,53 +1,57 @@
 ---
 name: pr-guide
-description: PR・コミット作法の詳細。タイトル/本文の書き方（一般人向け・用語の言い換え）、UI スクリーンショットの撮り方と添付、skip-ci/skip-post の挙動と例外、本番デプロイの確認手順、環境署名フォーマット。PR 作成・コミット・マージ・デプロイ確認の前に読む。
+description: PR・コミット作法の詳細。タイトル/本文の書き方（一般人向け・用語の言い換え）、stg 確認から本番昇格までの進め方、skip-ci/skip-post の挙動と例外、本番デプロイの確認手順、環境署名フォーマット。PR 作成・コミット・マージ・デプロイ確認の前に読む。
 ---
 
 # PR・コミットガイド
 
-> 前提: CLAUDE.md の必守ルール（スクショ添付・デプロイ見届け・署名・skip-ci デフォルト方針）に従う。本ガイドはその具体的な手順と書き方。
+> 前提: CLAUDE.md の必守ルール（本番リリースまで通しで進める・署名・skip-ci デフォルト方針）に従う。本ガイドはその具体的な手順と書き方。
 
-## 画面(UI)を変えた PR はスクリーンショットを本文に必ず添付する
+## UI を変えた PR にスクリーンショットは貼らない
 
-画面に機能を追加・改修した PR は、**実装後の各画面のスクリーンショットを PR 本文に貼る**。文章だけだと
-レビュー側がどんな見た目になるか判断できないため。
+CLI から GitHub の画像 CDN へ直接アップロードできず、人手のドラッグ&ドロップが必要になって手が止まるため、
+**PR 本文へのスクショ添付は求めない**（2026-07-26 ユーザー指示）。見た目の確認は stg の URL を提示して
+ブラウザで見てもらう形に一本化する。スクショホスティング用のブランチも作らない。
 
-- 撮り方: 実環境（`.env` の `HTTPS_PORT`）を headless Chrome（`google-chrome --headless=new
-  --ignore-certificate-errors --screenshot=...`）かブラウザで開いて撮る。エラー画面・5xx・空状態など特殊な
-  状態は、対象エンドポイントに一時的に例外を throw する等で再現してから撮り、**撮影後に必ず元へ戻す**。
-- 添付方法: GitHub web UI へのドラッグ&ドロップで添付する（CLI から GitHub の画像 CDN へ直接アップロードは
-  できない）。**スクショホスティング用のブランチ（`assets/pr-screenshots` 等）は作らない**（2026-06-27 ユーザー指示）。
+見た目を自分で確認したいときは headless Chrome で実環境（`.env` の `HTTPS_PORT`）を開いて撮ればよいが、
+それは自分の検証用であって PR に貼るものではない。
 
-## 報告は本番デプロイ完了まで待つ
+## stg で確認をもらってから本番へ
 
-PR をマージして終わりにしない。**本番デプロイ（`deploy.yml` の Deploy job）が success になるまで見届けてから「完了」と報告する**。マージ＝デプロイ成功ではない（別 PR が `deploy.yml` 等に残した不整合で本番デプロイだけが落ちることがある）。
+1. 作業ブランチ → **base=stg** で PR を出し、CI(test) が pass したらマージする
+2. stg の Deploy job が success になったら、**確認用 URL をユーザーに提示して OK をもらう**
+   （stg は Basic 認証あり。`SecretsConfig::$stagingBasicAuthUser` / `$stagingBasicAuthPassword`）
+3. OK が出たら stg→main の昇格 PR を作り、**test が success になってからマージ**する
+   （待たずにマージすると本番デプロイの CI ゲートが落ちる）
+4. 本番 Deploy job が success になるまで見届けてから「完了」と報告する
+
+マージ＝デプロイ成功ではない（別 PR が `deploy.yml` 等に残した不整合で本番デプロイだけが落ちることがある）。
 
 - main マージ後、`gh run list --workflow=deploy.yml --limit 4` で該当 Deploy run を特定し、`gh run view <id> --json status,conclusion` を completed/success までポーリングする。本番かどうかの確実な見分け方は env `IS_STG: false`（run タイトルの `[PROD]` は `pr-title-prefix.yml` が main 向け PR タイトルに自動付与したもの）。
 - 失敗したら原因を直して再デプロイし、success を確認してから報告する。
-- 本番 SSH はしない（確認は Actions の結果まで）。
 
 ## 環境署名（全コミット・全 GitHub 投稿）
 
-GitHub に投稿する本文（PR 本文・issue・PR/issue コメント等）の**末尾**に、区切り線を入れて以下の署名ブロックを付ける。どのマシン・ディレクトリから、どのモデル・ツールで投稿されたかを残すため。
+GitHub に投稿する本文（PR 本文・issue・PR/issue コメント等）の**末尾**に、区切り線を入れて以下の署名ブロックを付ける。どのマシン・ディレクトリから投稿されたかを残すため。
 
 ```markdown
 ---
-🤖 Generated with Claude Code (<モデルID>)
+🤖 Generated with Claude Code
 Posted from: `<hostname>:<作業ディレクトリ>`
 ```
 
-- モデルはその時のセッションの実際のモデル ID を書く（表示名は省く。例: Opus 4.8 → `claude-opus-4-8[1m]`）
 - `<hostname>` は `hostname`、`<作業ディレクトリ>` は `pwd` の値だが**ホームディレクトリは `~` に短縮**する（例: `/home/user/repos/Open-Chat-Graph` → `user-B550M-Pro4:~/repos/Open-Chat-Graph`）
-- **コミットメッセージにも毎回 環境署名を入れる**（PR/issue/コメント本文だけでなく、全コミット）。末尾に署名2行を付ける。`Co-Authored-By: Claude ...` は 🤖 行とモデル情報が重複するので**付けない**（全廃）:
+- モデル ID は書かない（Claude Code 側の方針でリポジトリへ残す成果物にモデル識別子を入れられないため。以前の署名には入っていたが現在は不可）
+- **コミットメッセージにも毎回 環境署名を入れる**（PR/issue/コメント本文だけでなく、全コミット）。末尾に署名2行を付ける。`Co-Authored-By: Claude ...` は 🤖 行と重複するので**付けない**（全廃）:
 
   ```
   <コミット本文>
 
-  🤖 Generated with Claude Code (claude-opus-4-8[1m])
+  🤖 Generated with Claude Code
   Committed from: user-B550M-Pro4:~/repos/Open-Chat-Graph
   ```
 
-  - モデル・hostname・ディレクトリの書き方は上記と同じ（ホームは `~` 短縮、リポごとに実ディレクトリを書く）。
+  - hostname・ディレクトリの書き方は上記と同じ（ホームは `~` 短縮、リポごとに実ディレクトリを書く）。
   - **このルールは infra リポ(oc-infra)など他リポのコミットにも全て適用する**。
 
 ## タイトルの書き方
@@ -151,7 +155,8 @@ CI(`ci.yml`)は Mock 環境のクローリング＋URLテストなので、そ�
 - PR に `skip-post` ラベルを付ける
 - または PR タイトルを `skip-post:` 始まりにする（例: `skip-post: Internal configuration update`）
 
-X 自動投稿はリリース履歴を兼ねるため、**skip-post を自己判断で付けない**（ユーザー指示があるときだけ）。
+X 自動投稿はリリース履歴を兼ねるため、**付けるかどうかは自己判断せず毎回ユーザーに聞く**（CLAUDE.md の
+「聞くのは X 投稿の可否だけ」がこれにあたる）。
 
 ### 任意テキストのX投稿（PRマージ形式ではない普通の投稿）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **dev-env** — 環境の起動・操作（Docker/Makefile・Mock・Shared mode・Codespaces・CI・ポート一覧）
 - **coding-guide** — 実装（ページ追加MVC・DBアクセス・スキーマ変更・DI/ServiceProvider・クローラ設定・フロントビルド・キャッシュ生成/genetop の詳細）
-- **pr-guide** — PR・コミット（タイトル/本文の書き方・スクショの撮り方/添付・skip-ci/skip-post・デプロイ確認手順・署名の詳細）
+- **pr-guide** — PR・コミット（タイトル/本文の書き方・skip-ci/skip-post・デプロイ確認手順・署名の詳細）
 
 ## インフラ操作（oc-infra スキル・本人のみ）
 
@@ -34,9 +34,11 @@ ln -sfn ~/repos/oc-infra ~/.claude/skills/oc-infra   # /oc-infra スキルとし
 
 ### 環境保護（最重要）
 
-- `.env` の `DATA_PROTECTION=true` のときは本番データを使用した環境。**`make up-mock` / `make ci-test` 等の mock環境操作はユーザーの明示的な指示なしに実行してはいけない**（本番DBが破壊される）
-- ただし禁止対象は「本番DBを壊す mock環境操作」だけ。phpunit（`docker compose exec app vendor/bin/phpunit <path>`）や curl でローカル環境を叩く類のテストは普通に実行してよい（「テスト全般がNG」ではない）
-- `DATA_PROTECTION=false` のときはテスト実行も mock環境の操作も自己判断で自由に行ってよい
+`.env` の `DATA_PROTECTION=true` は本番データを載せた環境。このとき **`make up-mock` / `make ci-test` など
+mock環境を作り直す操作だけ**は、明示の指示なしに実行してはいけない（本番DBが飛ぶ）。
+
+禁止はそれだけで、phpunit（`docker compose exec app vendor/bin/phpunit <path>`）や curl でローカルを叩く
+検証は普通にやってよい。`DATA_PROTECTION=false` なら mock環境の操作も含め自由。
 
 ### MimimalCMS フレームワーク本体は改造しない
 
@@ -77,17 +79,26 @@ CI/デプロイの挙動など実態を変えたら、対応する記述も同�
 
 対象クラス・具体例は coding-guide。
 
+### 依頼されたら本番リリースまで一気にやる
+
+「やって」と言われたら、実装・PR・stg デプロイ・本番デプロイまで通しで進める。途中で止めて指示を待たない。
+例外は次の2つだけ:
+
+1. **stg に出た時点で、確認用の URL を提示して OK をもらう**。OK が出てから本番（stg→main 昇格 PR）へ進む
+2. **X（SNS）へ自動投稿するかどうかは毎回聞く**。それ以外は聞かずに進める
+
+本番デプロイは Deploy job（`deploy.yml`）が success になるまで見届けてから完了と報告する。
+本番・stg への SSH は、依頼された作業に必要なら行ってよい（自発的な調査目的では入らない）。
+
 ### PR・コミット
 
 - `docker compose`（スペース区切り）を使う。`docker-compose` は不可
-- UI を変えた PR は実装後のスクショを本文に必ず添付する
 - PR タイトルは一般人に伝わる書き方（コード用語を避け、具体数値と業務影響。SNS に自動投稿される）
 - PHP 非変更の PR はデフォルトで skip-ci（確実に効かせるため PR タイトルを `skip-ci:` 始まりに。例外条件あり）
-- マージで終わりにしない。本番 Deploy job（`deploy.yml`）が success になるまで見届けてから完了報告する。本番 SSH はしない
 - 全コミット・全 GitHub 投稿（PR本文・issue・コメント）の末尾に環境署名を付ける（`Co-Authored-By` は付けない。他リポにも適用）:
 
   ```
-  🤖 Generated with Claude Code (<モデルID>)
+  🤖 Generated with Claude Code
   Committed from: <hostname>:<作業ディレクトリ(~短縮)>
   ```
 

--- a/app/Views/ad_opt_out.php
+++ b/app/Views/ad_opt_out.php
@@ -120,7 +120,10 @@ $topUrl = url();
             color: var(--mist);
         }
 
-        input[type="password"] {
+        /* 合言葉は日本語なので type="password" は使わない。iOS は安全入力欄(secure text entry)で
+           日本語IMEを無効にして英数キーボードに固定するため、日本語の合言葉が打てなくなる。
+           伏せ字にもしない（滅多に開かない隠しページで、打った文字が見えないほうが不便）。 */
+        input.secret {
             width: 100%;
             padding: 15px 16px;
             font-family: var(--mono);
@@ -134,7 +137,7 @@ $topUrl = url();
             transition: border-color .18s, box-shadow .18s;
         }
 
-        input[type="password"]:focus-visible {
+        input.secret:focus-visible {
             border-color: var(--ember);
             box-shadow: 0 0 0 3px rgba(232, 93, 4, .22);
         }
@@ -387,7 +390,7 @@ $topUrl = url();
             <form method="post" action="">
                 <div class="field">
                     <label for="passphrase">合言葉</label>
-                    <input type="password" id="passphrase" name="passphrase" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" required autofocus>
+                    <input type="text" class="secret" id="passphrase" name="passphrase" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" required autofocus>
                 </div>
                 <button type="submit">通る</button>
             </form>


### PR DESCRIPTION
iPhone から合言葉を入力できなかったのを直した。

入力欄を伏せ字（`type="password"`）にしていたため、iOS がこれを安全入力欄として扱い、日本語IMEを無効にして英数キーボードに固定していた。合言葉は日本語なので、そもそも打てない状態だった。伏せ字をやめて通常のテキスト欄にした（滅多に開かないページなので、打った文字が見えるほうが実用的）。

## ドキュメントも実態に合わせた

- **PR本文へのスクリーンショット添付をやめる**。CLI から GitHub の画像CDNへ上げられず、人手のドラッグ&ドロップ待ちで作業が止まるため。見た目の確認は stg のURLを提示する形に一本化した
- **依頼されたら本番リリースまで通しで進める**と明記。途中で止まるのは「stg のURLを見せてOKをもらう」「X投稿の可否を聞く」の2点だけ
- 「本番SSHはしない」→「依頼された作業に必要なら入ってよい（自発的な調査目的では入らない）」に修正。実際には secrets 追加などで入る必要があり、記述と運用が食い違っていた
- 環境署名からモデルIDを外した。Claude Code 側の方針でリポジトリに残す成果物にモデル識別子を書けなくなったため、記述だけが残って守れない状態になっていた
- 環境保護の項が「テスト全般が禁止」と読めたので整理（禁止は mock環境を作り直す操作だけ）

---
🤖 Generated with Claude Code
Posted from: `user-B550M-Pro4:~/repos/Open-Chat-Graph`
